### PR TITLE
fix: Make benchmark plugin discover tests in Benchmarks directory regardless of target name

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -30,11 +30,12 @@ Add a dependency on the plugin:
         .package(url: "https://github.com/ordo-one/package-benchmark", .upToNextMajor(from: "0.2.0")),
 ```
 
-## Add exectuable targets with a `Benchmark` suffix
+## Add exectuable targets
 
 To add targets for benchmarking, you create an executable target for each benchmark suite that should be measured.
+The source must reside as a subdirectory to a `Benchmarks` directory.
 
-Each benchmark suite to be run *must have an executable target with the `Benchmark` suffix* that depends on `BenchmarkSupport`, e.g.
+Each benchmark suite to be run *must have its source path in the Benchmarks folder* and depend on `BenchmarkSupport`, e.g.
 ```
             .executableTarget(
                 name: "My-Benchmark",

--- a/Documentation/TODO.md
+++ b/Documentation/TODO.md
@@ -3,8 +3,7 @@
 These are a set of known missing features/functionality where help would be highly appreciated with PR:s.
 
 ## Tests & Documentation
-* Currently no tests and only minimal documentation are in place, should be added/expanded.
-(why we only have one measurement across the whole run...), benchmark.currentIteration, `--quiet`, etc.
+* Currently no tests and only partial documentation are in place, should be added/expanded.
 * Explore moving to DocC for documentation
 
 ## Benchmark plugin

--- a/Documentation/WritingBenchmarks.md
+++ b/Documentation/WritingBenchmarks.md
@@ -32,7 +32,7 @@ func benchmarks() {
               metrics: [.throughput, .wallClock],
               throughputScalingFactor: .mega,
               thresholds: [.throughput : customThreshold, .wallClock : customThreshold]) { benchmark in
-        for _ in 0..<benchmark.throughputScalingFactor.rawValue {
+        for _ in benchmark.throughputIterations {
             blackHole(Date())
         }
     }
@@ -93,7 +93,7 @@ An example would be:
     Benchmark("Foundation Date()",
               metrics: [.throughput],
               throughputScalingFactor: .mega) { benchmark in
-        for _ in 0..<benchmark.throughputScalingFactor.rawValue { // will loop 1_000_000 times
+        for _ in benchmark.throughputIterations { // will loop 1_000_000 times
             blackHole(Date())
         }
     }
@@ -114,7 +114,7 @@ Metrics can be specified both explicitly, e.g. `[.throughput, .wallClock]` but a
               metrics: [.throughput, .wallClock],
               throughputScalingFactor: .mega,
               thresholds: [.throughput : customThreshold, .wallClock : customThreshold]) { benchmark in
-        for _ in 0..<benchmark.throughputScalingFactor.rawValue {
+        for _ in benchmark.throughputIterations {
             blackHole(Date())
         }
     }

--- a/Plugins/Benchmark/BenchmarkPlugin.swift
+++ b/Plugins/Benchmark/BenchmarkPlugin.swift
@@ -104,17 +104,24 @@ import PackagePlugin
             swiftSourceModuleTargets = specifiedTargets
         }
 
+        let filteredTargets = swiftSourceModuleTargets
+            .filter { $0.kind == .executable }
+            .filter { benchmark in
+                let path = benchmark.directory.removingLastComponent()
+                return path.lastComponent == "Benchmarks" ? true : false
+            }
+            .filter { benchmark in
+                swiftSourceModuleTargets.first(where: { $0.name == benchmark.name }) != nil ? true : false
+            }
+            .filter { benchmark in
+                skipTargets.first(where: { $0.name == benchmark.name }) == nil ? true : false
+            }
+
         // Filter out all executable products which are Benchmarks we should run
         let benchmarks = buildResult.builtArtifacts
-            .filter { $0.kind == .executable }
-            .filter { $0.path.lastComponent.hasSuffix("Benchmark") }
             .filter { benchmark in
-                swiftSourceModuleTargets.first(where: { $0.name == benchmark.path.lastComponent }) != nil ? true : false
+                filteredTargets.first(where: { $0.name == benchmark.path.lastComponent }) != nil ? true : false
             }
-            .filter { benchmark in
-                skipTargets.first(where: { $0.name == benchmark.path.lastComponent }) == nil ? true : false
-            }
-            .sorted(by: { $0.path.lastComponent <= $1.path.lastComponent })
 
         // Remaining positional arguments are various action verbs for the plugin
         var positionalArguments = argumentExtractor.remainingArguments


### PR DESCRIPTION
Fixes https://github.com/ordo-one/package-benchmark/issues/9