### PR TITLE
feat: Support default thresholds for benchmark suite and rename defaultBenchmarkTimeUnits to defaultTimeUnits

### DIFF
--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -68,7 +68,11 @@ public class Benchmark: Codable, Hashable {
     // Hook for custom metrics capturing
     public var customMetricMeasurement: BenchmarkCustomMetricMeasurement?
 
-    public static var defaultBenchmarkTimeUnits: BenchmarkTimeUnits = .automatic
+    /// Hook for setting the time units to use for a whole benchmark suite
+    public static var defaultTimeUnits: BenchmarkTimeUnits = .automatic
+    /// Hook for setting thresholds for a whole benchmark suite
+    public static var defaultThresholds: [BenchmarkMetric: BenchmarkResult.PercentileThresholds]?
+
     internal static var testSkipBenchmarkRegistrations = false // true in test to avoid bench registration fail
 
     var lock: pthread_mutex_t = .init()
@@ -115,13 +119,13 @@ public class Benchmark: Codable, Hashable {
     @discardableResult
     public init?(_ name: String,
                  metrics: [BenchmarkMetric] = BenchmarkMetric.default,
-                 timeUnits: BenchmarkTimeUnits? = defaultBenchmarkTimeUnits,
+                 timeUnits: BenchmarkTimeUnits? = defaultTimeUnits,
                  warmup: Bool = true,
                  throughputScalingFactor: StatisticsUnits = .count,
                  desiredDuration: TimeDuration? = nil,
                  desiredIterations: Int? = nil,
                  skip: Bool = false,
-                 thresholds: [BenchmarkMetric: BenchmarkResult.PercentileThresholds]? = nil,
+                 thresholds: [BenchmarkMetric: BenchmarkResult.PercentileThresholds]? = defaultThresholds,
                  closure: @escaping BenchmarkClosure) {
         if skip {
             return nil
@@ -176,13 +180,13 @@ public class Benchmark: Codable, Hashable {
     @discardableResult
     public init?(_ name: String,
                  metrics: [BenchmarkMetric] = BenchmarkMetric.default,
-                 timeUnits: BenchmarkTimeUnits? = defaultBenchmarkTimeUnits,
+                 timeUnits: BenchmarkTimeUnits? = defaultTimeUnits,
                  warmup: Bool = true,
                  throughputScalingFactor: StatisticsUnits = .count,
                  desiredDuration: TimeDuration? = nil,
                  desiredIterations: Int? = nil,
                  skip: Bool = false,
-                 thresholds: [BenchmarkMetric: BenchmarkResult.PercentileThresholds]? = nil,
+                 thresholds: [BenchmarkMetric: BenchmarkResult.PercentileThresholds]? = defaultThresholds,
                  closure: @escaping BenchmarkAsyncClosure) {
         if skip {
             return nil


### PR DESCRIPTION
Fixes https://github.com/ordo-one/package-benchmark/issues/24

Supports setting the thresholds for all tests in a suite like:
```swift
@_dynamicReplacement(for: registerBenchmarks)
func benchmarks() {

    Benchmark.defaultTimeUnits = .microseconds

    let customThreshold = BenchmarkResult.PercentileThresholds(relative: [.p50 : 5.0, .p75 : 10.0],
                                                               absolute: [.p25 : 10, .p50 : 15])
    let customThreshold2 = BenchmarkResult.PercentileThresholds(relative: .strict)
    let customThreshold3 = BenchmarkResult.PercentileThresholds(absolute: .relaxed)

    Benchmark.defaultThresholds = [.wallClock : customThreshold,
                                   .throughput : customThreshold2,
                                   .cpuTotal: customThreshold3,
                                   .cpuUser: .strict]
...
```