### PR TITLE
chore: Move to dispatch conditions / NIOLock instead of raw pthread mutex/conditions

### DIFF
--- a/Documentation/TODO.md
+++ b/Documentation/TODO.md
@@ -24,7 +24,6 @@ for tests that reports VSIZE/RSIZE to get comparable numbers by default)
 * Add support for printing the distribution graphs (linear and power-of-two) that we have instead of tables.
 * Add support to Linux for using perf\_events to capture context switches, cache hit rate, IPC, instructions, ... (need physical machine for most, only context switches are available from virtualized hosts)
 * Validate why some measurements provides 0 to Statistics (enable fatalError() and troubleshoot - likely malloc and time)
-* Consider moving from raw pthread locks/conditions to Dispatch primitives.
 
 ## Blocked waiting for Swift 5.7 migration
 * Move Instant & Duration for timestamps 

--- a/Sources/BenchmarkSupport/BenchmarkRunner+ReadWrite.swift
+++ b/Sources/BenchmarkSupport/BenchmarkRunner+ReadWrite.swift
@@ -8,7 +8,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 
-// swiftlint:disable cyclomatic_complexity 
+// swiftlint:disable cyclomatic_complexity
 // swiftlint disable: file_length type_body_length
 import ArgumentParser
 @_exported import Benchmark

--- a/Sources/BenchmarkSupport/MallocStats/MallocStatsProducer+jemalloc.swift
+++ b/Sources/BenchmarkSupport/MallocStats/MallocStatsProducer+jemalloc.swift
@@ -82,27 +82,27 @@ public class MallocStatsProducer {
                 print("mallctlnametomib epochMIB returned \(result)")
             }
         }
-/*
-        mibSize = smallNMallocMIB.count
-        smallNMallocMIB.withUnsafeMutableBufferPointer { pointer in
-            let result = mallctlnametomib("stats.arenas.\(MALLCTL_ARENAS_ALL).small.nmalloc",
-                                          pointer.baseAddress,
-                                          &mibSize)
-            if result != 0 {
-                print("mallctlnametomib smallNMallocMIB returned \(result)")
-            }
-        }
+        /*
+         mibSize = smallNMallocMIB.count
+         smallNMallocMIB.withUnsafeMutableBufferPointer { pointer in
+             let result = mallctlnametomib("stats.arenas.\(MALLCTL_ARENAS_ALL).small.nmalloc",
+                                           pointer.baseAddress,
+                                           &mibSize)
+             if result != 0 {
+                 print("mallctlnametomib smallNMallocMIB returned \(result)")
+             }
+         }
 
-        mibSize = largeNMallocMIB.count
-        largeNMallocMIB.withUnsafeMutableBufferPointer { pointer in
-            let result = mallctlnametomib("stats.arenas.\(MALLCTL_ARENAS_ALL).large.nmalloc",
-                                          pointer.baseAddress,
-                                          &mibSize)
-            if result != 0 {
-                print("mallctlnametomib largeNMallocMIB returned \(result)")
-            }
-        }
-*/
+         mibSize = largeNMallocMIB.count
+         largeNMallocMIB.withUnsafeMutableBufferPointer { pointer in
+             let result = mallctlnametomib("stats.arenas.\(MALLCTL_ARENAS_ALL).large.nmalloc",
+                                           pointer.baseAddress,
+                                           &mibSize)
+             if result != 0 {
+                 print("mallctlnametomib largeNMallocMIB returned \(result)")
+             }
+         }
+         */
         // tcaches
         mibSize = smallTMallocMIB.count
         smallTMallocMIB.withUnsafeMutableBufferPointer { pointer in
@@ -123,47 +123,47 @@ public class MallocStatsProducer {
                 print("mallctlnametomib largeTMallocMIB returned \(result)")
             }
         }
-/*
-        mibSize = smallNDallocMIB.count
-        smallNDallocMIB.withUnsafeMutableBufferPointer { pointer in
-            let result = mallctlnametomib("stats.arenas.\(MALLCTL_ARENAS_ALL).small.ndalloc",
-                                          pointer.baseAddress,
-                                          &mibSize)
-            if result != 0 {
-                print("mallctlnametomib smallNDallocMIB returned \(result)")
-            }
-        }
+        /*
+                mibSize = smallNDallocMIB.count
+                smallNDallocMIB.withUnsafeMutableBufferPointer { pointer in
+                    let result = mallctlnametomib("stats.arenas.\(MALLCTL_ARENAS_ALL).small.ndalloc",
+                                                  pointer.baseAddress,
+                                                  &mibSize)
+                    if result != 0 {
+                        print("mallctlnametomib smallNDallocMIB returned \(result)")
+                    }
+                }
 
-        mibSize = largeNDallocMIB.count
-        largeNDallocMIB.withUnsafeMutableBufferPointer { pointer in
-            let result = mallctlnametomib("stats.arenas.\(MALLCTL_ARENAS_ALL).large.ndalloc",
-                                          pointer.baseAddress,
-                                          &mibSize)
-            if result != 0 {
-                print("mallctlnametomib largeNDallocMIB returned \(result)")
-            }
-        }
+                mibSize = largeNDallocMIB.count
+                largeNDallocMIB.withUnsafeMutableBufferPointer { pointer in
+                    let result = mallctlnametomib("stats.arenas.\(MALLCTL_ARENAS_ALL).large.ndalloc",
+                                                  pointer.baseAddress,
+                                                  &mibSize)
+                    if result != 0 {
+                        print("mallctlnametomib largeNDallocMIB returned \(result)")
+                    }
+                }
 
-        mibSize = smallAlloctedMIB.count
-        smallAlloctedMIB.withUnsafeMutableBufferPointer { pointer in
-            let result = mallctlnametomib("stats.arenas.\(MALLCTL_ARENAS_ALL).small.allocated",
-                                          pointer.baseAddress,
-                                          &mibSize)
-            if result != 0 {
-                print("mallctlnametomib rsmallAlloctedMIB eturned \(result)")
-            }
-        }
+                mibSize = smallAlloctedMIB.count
+                smallAlloctedMIB.withUnsafeMutableBufferPointer { pointer in
+                    let result = mallctlnametomib("stats.arenas.\(MALLCTL_ARENAS_ALL).small.allocated",
+                                                  pointer.baseAddress,
+                                                  &mibSize)
+                    if result != 0 {
+                        print("mallctlnametomib rsmallAlloctedMIB eturned \(result)")
+                    }
+                }
 
-        mibSize = largeAllocatedMIB.count
-        largeAllocatedMIB.withUnsafeMutableBufferPointer { pointer in
-            let result = mallctlnametomib("stats.arenas.\(MALLCTL_ARENAS_ALL).large.allocated",
-                                          pointer.baseAddress,
-                                          &mibSize)
-            if result != 0 {
-                print("mallctlnametomib largeAllocatedMIB returned \(result)")
-            }
-        }
- */
+                mibSize = largeAllocatedMIB.count
+                largeAllocatedMIB.withUnsafeMutableBufferPointer { pointer in
+                    let result = mallctlnametomib("stats.arenas.\(MALLCTL_ARENAS_ALL).large.allocated",
+                                                  pointer.baseAddress,
+                                                  &mibSize)
+                    if result != 0 {
+                        print("mallctlnametomib largeAllocatedMIB returned \(result)")
+                    }
+                }
+         */
         mibSize = totalAllocatedMIB.count
         totalAllocatedMIB.withUnsafeMutableBufferPointer { pointer in
             let result = mallctlnametomib("stats.resident", pointer.baseAddress, &mibSize)

--- a/Sources/BenchmarkSupport/NIOLock.swift
+++ b/Sources/BenchmarkSupport/NIOLock.swift
@@ -1,4 +1,4 @@
-// swiftlint: disable all
+// swiftlint:disable all
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project

--- a/Sources/BenchmarkSupport/NIOLock.swift
+++ b/Sources/BenchmarkSupport/NIOLock.swift
@@ -1,0 +1,150 @@
+// swiftlint: disable all
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// Thanks to SwiftNIO for the lock wrapper, just adopted to not be public and reexported.
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    import Darwin
+#elseif os(Windows)
+    import ucrt
+    import WinSDK
+#else
+    import Glibc
+#endif
+
+/// A threading lock based on `libpthread` instead of `libdispatch`.
+///
+/// - note: ``NIOLock`` has reference semantics.
+///
+/// This object provides a lock on top of a single `pthread_mutex_t`. This kind
+/// of lock is safe to use with `libpthread`-based threading models, such as the
+/// one used by NIO. On Windows, the lock is based on the substantially similar
+/// `SRWLOCK` type.
+struct NIOLock {
+    @usableFromInline
+    internal let _storage: _Storage
+
+    #if os(Windows)
+        @usableFromInline
+        internal typealias LockPrimitive = SRWLOCK
+    #else
+        @usableFromInline
+        internal typealias LockPrimitive = pthread_mutex_t
+    #endif
+
+    @usableFromInline
+    internal final class _Storage {
+        // TODO: We should tail-allocate the pthread_t/SRWLock.
+        @usableFromInline
+        internal let mutex: UnsafeMutablePointer<LockPrimitive> =
+            UnsafeMutablePointer.allocate(capacity: 1)
+
+        /// Create a new lock.
+        internal init() {
+            #if os(Windows)
+                InitializeSRWLock(mutex)
+            #else
+                var attr = pthread_mutexattr_t()
+                pthread_mutexattr_init(&attr)
+
+                let err = pthread_mutex_init(mutex, &attr)
+                precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+            #endif
+        }
+
+        internal func lock() {
+            #if os(Windows)
+                AcquireSRWLockExclusive(mutex)
+            #else
+                let err = pthread_mutex_lock(mutex)
+                precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+            #endif
+        }
+
+        internal func unlock() {
+            #if os(Windows)
+                ReleaseSRWLockExclusive(mutex)
+            #else
+                let err = pthread_mutex_unlock(mutex)
+                precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+            #endif
+        }
+
+        internal func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
+            try body(mutex)
+        }
+
+        deinit {
+            #if os(Windows)
+            // SRWLOCK does not need to be free'd
+            #else
+                let err = pthread_mutex_destroy(self.mutex)
+                precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+            #endif
+            mutex.deallocate()
+        }
+    }
+
+    /// Create a new lock.
+    init() {
+        _storage = _Storage()
+    }
+
+    /// Acquire the lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `unlock`, to simplify lock handling.
+    func lock() {
+        _storage.lock()
+    }
+
+    /// Release the lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `lock`, to simplify lock handling.
+    func unlock() {
+        _storage.unlock()
+    }
+
+    internal func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
+        try _storage.withLockPrimitive(body)
+    }
+}
+
+extension NIOLock {
+    /// Acquire the lock for the duration of the given block.
+    ///
+    /// This convenience method should be preferred to `lock` and `unlock` in
+    /// most situations, as it ensures that the lock will be released regardless
+    /// of how `body` exits.
+    ///
+    /// - Parameter body: The block to execute while holding the lock.
+    /// - Returns: The value returned by the block.
+    @inlinable
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        lock()
+        defer {
+            self.unlock()
+        }
+        return try body()
+    }
+
+    @inlinable
+    func withLockVoid(_ body: () throws -> Void) rethrows {
+        try withLock(body)
+    }
+}
+
+extension NIOLock: Sendable {}
+extension NIOLock._Storage: Sendable {}

--- a/Sources/BenchmarkSupport/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
+++ b/Sources/BenchmarkSupport/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
@@ -146,7 +146,7 @@
 
                     if self.runState == .shuttingDown {
                         self.runState = .done
-                        semaphore.signal()
+                        self.semaphore.signal()
                     }
 
                     let quit = self.runState

--- a/Sources/BenchmarkSupport/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
+++ b/Sources/BenchmarkSupport/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
@@ -18,9 +18,8 @@
         var nsPerSchedulerTick: Int
         var pageSize: Int
 
-        var thread: pthread_t = .init()
-        var lock: pthread_mutex_t = .init()
-        var condition: pthread_cond_t = .init()
+        let lock = NIOLock()
+        let semaphore = DispatchSemaphore(value: 0)
         var peakThreads: Int = 0
         var sampleRate: Int = 10_000
         var runState: RunState = .running
@@ -36,9 +35,6 @@
 
             nsPerSchedulerTick = 1_000_000_000 / schedulerTicksPerSecond
             pageSize = sysconf(Int32(_SC_PAGESIZE))
-
-            pthread_mutex_init(&lock, nil)
-            pthread_cond_init(&condition, nil)
         }
 
         deinit {}
@@ -131,16 +127,18 @@
 
         func startSampling(_: Int = 10_000) { // sample rate in microseconds
             DispatchQueue.global(qos: .userInitiated).async {
-                pthread_mutex_lock(&self.lock)
+                self.lock.lock()
+
                 let rate = self.sampleRate
                 self.peakThreads = 0
                 self.runState = .running
-                pthread_mutex_unlock(&self.lock)
+
+                self.lock.unlock()
 
                 while true {
                     let processStats = self.readProcessStats()
 
-                    pthread_mutex_lock(&self.lock)
+                    self.lock.lock()
 
                     if processStats.threads > self.peakThreads {
                         self.peakThreads = processStats.threads
@@ -148,12 +146,12 @@
 
                     if self.runState == .shuttingDown {
                         self.runState = .done
-                        pthread_cond_signal(&self.condition)
+                        semaphore.signal()
                     }
 
                     let quit = self.runState
 
-                    pthread_mutex_unlock(&self.lock)
+                    self.lock.unlock()
 
                     if quit == .done {
                         return
@@ -167,15 +165,11 @@
         }
 
         func stopSampling() {
-            pthread_mutex_lock(&lock)
+            lock.lock()
             runState = .shuttingDown
+            lock.unlock()
 
-            while pthread_cond_wait(&condition, &lock) == 0 {
-                if runState == .done {
-                    pthread_mutex_unlock(&lock)
-                    return
-                }
-            }
+            semaphore.wait()
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/ordo-one/package-benchmark/issues/21

Basically borrowed NIOLock for the time being until we have some other native swift concurrency primitive for synchronisation, using dispatch semaphores instead of pthread ones.