### PR TITLE
Use @_optimize(none) instead of @inline(never) for the blackHole()

### DIFF
--- a/Sources/Benchmark/Blackhole.swift
+++ b/Sources/Benchmark/Blackhole.swift
@@ -17,5 +17,5 @@
 /// get used, and this could potentially interfere with the accuracy of a
 /// benchmark. To defeat these optimizations, pass such unused results to
 /// this function so that the compiler considers them used.
-@inline(never)
+@_optimize(none)
 public func blackHole<T>(_: T) {}


### PR DESCRIPTION
## Description
Use @_optimize(none) instead of @inline(never) for the blackHole()

## How Has This Been Tested?
Disassembled generated code.

## Minimal checklist:

- [X ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
