### PR TITLE
fix: [sc-1033] Remove circular dependency on Benchmark

### DIFF
--- a/Benchmarks/DateTime/DateTime.swift
+++ b/Benchmarks/DateTime/DateTime.swift
@@ -19,19 +19,19 @@ func benchmarks() {
     Benchmark.defaultThroughputScalingFactor = .kilo
 
     Benchmark("InternalUTCClock.now") { benchmark in
-        for _ in 0 ..< benchmark.throughputScalingFactor.rawValue {
+        for _ in benchmark.throughputIterations {
             BenchmarkSupport.blackHole(InternalUTCClock.now)
         }
     }
 
     Benchmark("BenchmarkClock.now") { benchmark in
-        for _ in 0 ..< benchmark.throughputScalingFactor.rawValue {
+        for _ in benchmark.throughputIterations {
             BenchmarkSupport.blackHole(BenchmarkClock.now)
         }
     }
 
     Benchmark("Foundation.Date") { benchmark in
-        for _ in 0 ..< benchmark.throughputScalingFactor.rawValue {
+        for _ in benchmark.throughputIterations  {
             BenchmarkSupport.blackHole(Foundation.Date())
         }
     }

--- a/Benchmarks/DateTime/DateTime.swift
+++ b/Benchmarks/DateTime/DateTime.swift
@@ -1,0 +1,39 @@
+// Copyright 2023 Ordo One AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+import DateTime
+
+import BenchmarkSupport
+@main extension BenchmarkRunner {}
+
+@_dynamicReplacement(for: registerBenchmarks)
+func benchmarks() {
+
+    Benchmark.defaultDesiredDuration = .seconds(2)
+    Benchmark.defaultDesiredIterations = 10_000
+    Benchmark.defaultThroughputScalingFactor = .kilo
+
+    Benchmark("InternalUTCClock.now") { benchmark in
+        for _ in 0 ..< benchmark.throughputScalingFactor.rawValue {
+            BenchmarkSupport.blackHole(InternalUTCClock.now)
+        }
+    }
+
+    Benchmark("BenchmarkClock.now") { benchmark in
+        for _ in 0 ..< benchmark.throughputScalingFactor.rawValue {
+            BenchmarkSupport.blackHole(BenchmarkClock.now)
+        }
+    }
+
+    Benchmark("Foundation.Date") { benchmark in
+        for _ in 0 ..< benchmark.throughputScalingFactor.rawValue {
+            BenchmarkSupport.blackHole(Foundation.Date())
+        }
+    }
+
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ordo-one/package-datetime",
       "state" : {
-        "revision" : "cbfca20a5116683241ed4b3c555c6eef82c78ef6",
-        "version" : "0.0.3"
+        "revision" : "10efe0a2696c9c3cfbe1b1e76481777409b0b217",
+        "version" : "0.0.4"
       }
     },
     {
@@ -21,10 +21,10 @@
     {
       "identity" : "spimanifest",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SwiftPackageIndex/SPIManifest.git",
+      "location" : "https://github.com/SwiftPackageIndex/SPIManifest",
       "state" : {
-        "revision" : "2c8538d38f8d38e07e93ca957c13e0d313d6358d",
-        "version" : "0.13.0"
+        "revision" : "268fab2006be5c11411994bc76f429d9971a840a",
+        "version" : "0.15.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "fddd1c00396eed152c45a46bea9f47b98e59301d",
-        "version" : "1.2.0"
+        "revision" : "4ad606ba5d7673ea60679a61ff867cc1ff8c8e86",
+        "version" : "1.2.1"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "01835dc202670b5bb90d07f3eae41867e9ed29f6",
-        "version" : "5.0.1"
+        "revision" : "c7facc5ccb8c5a4577ea8c491aa875762cdee57a",
+        "version" : "5.0.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -93,6 +93,15 @@ let package = Package(
             path: "Benchmarks/Basic"
         ),
 
+        // Benchmark of the DateTime package (which can't depend on Benchmark as we'll get a circular dependency)
+        .executableTarget(
+            name: "BenchmarkDateTime",
+            dependencies: [
+                "BenchmarkSupport"
+            ],
+            path: "Benchmarks/DateTime"
+        ),
+
         // Scaffolding to support benchmarks under the hood
         .target(
             name: "BenchmarkSupport",


### PR DESCRIPTION
## Description

Moving DateTime benchmarks here to remove circular dependency.

Fixes sc-1033.