### PR TITLE
feat: Run all benchmarks in isolation

### DIFF
--- a/Benchmarks/Histogram/HistogramBenchmark.swift
+++ b/Benchmarks/Histogram/HistogramBenchmark.swift
@@ -27,8 +27,8 @@ func benchmarks() {
 
         var histogram = Histogram<UInt64>(highestTrackableValue: maxValue, numberOfSignificantValueDigits: .three)
 
-        let numValues = 1024 // so compiler can optimize modulo below
-        let values = [UInt64]((0..<numValues).map { _ in UInt64.random(in: 100...1000) })
+        let numValues = 1_024 // so compiler can optimize modulo below
+        let values = [UInt64]((0 ..< numValues).map { _ in UInt64.random(in: 100 ... 1_000) })
 
         benchmark.startMeasurement()
 
@@ -42,8 +42,8 @@ func benchmarks() {
               skip: false) { benchmark in
         var histogram = Histogram<UInt64>(numberOfSignificantValueDigits: .three)
 
-        let numValues = 1024 // so compiler can optimize modulo below
-        let values = [UInt64]((0..<numValues).map { _ in UInt64.random(in: 100...10_000) })
+        let numValues = 1_024 // so compiler can optimize modulo below
+        let values = [UInt64]((0 ..< numValues).map { _ in UInt64.random(in: 100 ... 10_000) })
 
         benchmark.startMeasurement()
 
@@ -62,10 +62,10 @@ func benchmarks() {
 
         // fill histogram with some data
         for _ in 0 ..< 10_000 {
-            blackHole(histogram.record(UInt64.random(in: 10...1000)))
+            blackHole(histogram.record(UInt64.random(in: 10 ... 1_000)))
         }
 
-        let percentiles = [ 0.0, 25.0, 50.0, 75.0, 80.0, 90.0, 99.0, 100.0 ]
+        let percentiles = [0.0, 25.0, 50.0, 75.0, 80.0, 90.0, 99.0, 100.0]
 
         benchmark.startMeasurement()
 
@@ -84,7 +84,7 @@ func benchmarks() {
 
         // fill histogram with some data
         for _ in 0 ..< 10_000 {
-            blackHole(histogram.record(UInt64.random(in: 10...1000)))
+            blackHole(histogram.record(UInt64.random(in: 10 ... 1_000)))
         }
 
         benchmark.startMeasurement()

--- a/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
@@ -31,7 +31,9 @@ extension BenchmarkTool {
         }
     }
 
-    mutating func runBenchmark(_ benchmark: Benchmark, _ benchmarkResults: inout BenchmarkResults) throws {
+    mutating func runBenchmark(_ benchmark: Benchmark) throws -> BenchmarkResults {
+        var benchmarkResults: BenchmarkResults = [:]
+
         try write(.run(benchmark: benchmark))
 
         outerloop: while true {
@@ -55,9 +57,11 @@ extension BenchmarkTool {
                 print("Unexpected reply \(benchmarkReply)")
             }
         }
+
+        return benchmarkResults
     }
 
-    mutating func postProcessBenchmarks(_ benchmarkResults: BenchmarkResults) throws {
+    mutating func postProcessBenchmarkResults(_ benchmarkResults: BenchmarkResults) throws {
         let benchmarkMachine = benchmarkMachine()
 
         switch command {

--- a/Sources/Statistics/Statistics.swift
+++ b/Sources/Statistics/Statistics.swift
@@ -75,8 +75,6 @@ public struct Statistics {
             return .count
         }
 
-        // print("deducing time units from mean: \(histogram.mean)")
-
         return StatisticsUnits(fromMagnitudeOf: histogram.mean)
     }
 

--- a/Sources/Statistics/Statistics.swift
+++ b/Sources/Statistics/Statistics.swift
@@ -9,8 +9,8 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 
-import Numerics
 import Histogram
+import Numerics
 
 public let defaultPercentilesToCalculate = [0.000001, 25.0, 50.0, 75.0, 90.0, 99.0, 100.0]
 private let numberPadding = 10
@@ -75,7 +75,7 @@ public struct Statistics {
             return .count
         }
 
-        //print("deducing time units from mean: \(histogram.mean)")
+        // print("deducing time units from mean: \(histogram.mean)")
 
         return StatisticsUnits(fromMagnitudeOf: histogram.mean)
     }
@@ -85,11 +85,11 @@ public struct Statistics {
     public var onlyZeroMeasurements = true
 
     public var measurementCount: Int {
-        return Int(histogram.totalCount)
+        Int(histogram.totalCount)
     }
 
     public var averageMeasurement: Double {
-        return histogram.mean
+        histogram.mean
     }
 
     public init(maximumMeasurement: Int = defaultMaximumMeasurement,
@@ -100,7 +100,7 @@ public struct Statistics {
         self.numberOfSignificantDigits = numberOfSignificantDigits
         self.prefersLarger = prefersLarger
         percentilesToCalculate = percentiles
-        self._timeUnits = timeUnits
+        _timeUnits = timeUnits
 
         histogram = Histogram(highestTrackableValue: UInt64(maximumMeasurement), numberOfSignificantValueDigits: numberOfSignificantDigits)
         histogram.autoResize = true
@@ -118,7 +118,7 @@ public struct Statistics {
 //            fatalError()
         }
 
-        if measurement != 0 && onlyZeroMeasurements {
+        if measurement != 0, onlyZeroMeasurements {
             onlyZeroMeasurements = false
         }
 
@@ -156,7 +156,7 @@ public struct Statistics {
     /// A printable text-based histogram+percentiles suitable for display in a fixed-size font
     /// - Returns: All collected statistics
     public mutating func output() -> String {
-        var out: String = ""
+        var out = ""
         histogram.outputPercentileDistribution(to: &out, outputValueUnitScalingRatio: Double(timeUnits.rawValue))
         return out
     }


### PR DESCRIPTION
## Description

Run all benchmarks in isolated processes to get correct memory statistics, also some minor code cleanup (move to enum instead of strings for command, run swiftformat on all).

Fixes https://github.com/ordo-one/package-benchmark/issues/51
 
## How Has This Been Tested?

Performed basic manual testing.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
