### PR TITLE
feat: Add regex support for targets and benchmark for filter/skip

### DIFF
--- a/Documentation/RunningBenchmarks.md
+++ b/Documentation/RunningBenchmarks.md
@@ -17,11 +17,13 @@ swift package benchmark
 
 ## Options 
 
-* `--target` - specify which target we should run the benchmark plugin for, multiple may be specified, default all targets
-* `--skip` - specify that a given target should be skipped
+* `--target` - specify which target we should run the benchmark plugin for (regex), multiple may be specified, default all targets
+* `--skip-target` - specify that a given target should be skipped matching regex, multiple can be specified
 * `--grouping` - `metric` or `test` - specifies how results should be grouped in tables, default `test`
 * `--format` - `text` or `markdown` - specifes textual output format (markdown useful for e.g. GitHub CI), default `text`
 * `--quiet` - suppress output (e.g. tables)
+* `--filter` - Include benchmarks matching regex, multiple can be provided
+* `--skip` - Skip benchmarks matching regex, multiple can be provided
 
 ## Disk write permissions failures
 We've seen one instance of strange permissioning failures for disk writes for tests that use LMDB (where only the lock file can be created, but the actual data file fails - even when specifying `--allow-writing-to-package-directory`).
@@ -42,6 +44,10 @@ swift package benchmark
 ### Run all benchmark targets, but display by metric instead of by test:
 ```
 swift package benchmark --grouping metric
+```
+### Run targets / benchmarks with regex matching
+```
+swift package benchmark --target ".*Time" --filter ".*k\." --skip ".*UTC.*" --skip-target ".*Time"
 ```
 
 ### List available benchmark targets:

--- a/Documentation/TODO.md
+++ b/Documentation/TODO.md
@@ -5,10 +5,6 @@ These are a set of known missing features/functionality where help would be high
 ## Tests & Documentation
 * Explore moving to DocC for documentation
 
-## Benchmark plugin
-* `--filter` regexp filtering not implemented yet (we don't want to add Foundation dependency and can't yet
-use the Swift 5.7 RegEx, so parked it for now)
-
 ## JSON evolution support
 Needs to review baselines storage JSON format evolution (currently not considered), right now any format change 
 basically requires nuking of pre-existing baselines. We won't commit to a stable on-disk format until `1.0.0`.
@@ -22,7 +18,3 @@ unclear if we can get conditional import of module if its available somehow?
 * Add support for printing the distribution graphs (linear and power-of-two) that we have instead of tables.
 * Add support to Linux for using perf\_events to capture context switches, cache hit rate, IPC, instructions, ... (need physical machine for most, only context switches are available from virtualized hosts)
 * Validate why some measurements provides 0 to Statistics (enable fatalError() and troubleshoot - likely malloc and time)
-
-## Blocked waiting for Swift 5.7 migration
-* Move Instant & Duration for timestamps 
-* Adopt RegEx for `--filter`

--- a/Documentation/WritingBenchmarks.md
+++ b/Documentation/WritingBenchmarks.md
@@ -78,7 +78,7 @@ The `Benchmark` initializer has a wide range of options that allows tuning for h
                  timeUnits: BenchmarkTimeUnits = Benchmark.defaultTimeUnits,
                  warmupIterations: Int = Benchmark.defaultWarmupIterations,
                  throughputScalingFactor: StatisticsUnits = Benchmark.defaultThroughputScalingFactor,
-                 desiredDuration: TimeDuration = Benchmark.defaultDesiredDuration,
+                 desiredDuration: Duration = Benchmark.defaultDesiredDuration,
                  desiredIterations: Int = Benchmark.defaultDesiredIterations,
                  skip: Bool = Benchmark.defaultSkip,
                  thresholds: [BenchmarkMetric: BenchmarkResult.PercentileThresholds]? = Benchmark.defaultThresholds,

--- a/Plugins/Benchmark/ArgumentExtractor+Extensions.swift
+++ b/Plugins/Benchmark/ArgumentExtractor+Extensions.swift
@@ -1,68 +1,36 @@
-// This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
-// Licensed under Apache License v2.0 with Runtime Library Exception
+// Copyright (c) 2023 Ordo One AB.
 //
-// See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
 
-// Extracted and adopted/modified from Swift-DocC, thank you!
 import PackagePlugin
 
-enum ArgumentParsingError: Error, CustomStringConvertible {
-    case unknownTarget(_ targetName: String)
-    case productDoesNotContainSwiftSourceModuleTargets(String)
-    case packageDoesNotContainSwiftSourceModuleTargets
-    case targetIsNotSwiftSourceModule(String)
-    case testTarget(String)
-
-    var description: String {
-        switch self {
-        case let .unknownTarget(targetName):
-            return """
-            no target named '\(targetName)'
-
-            """
-        case let .productDoesNotContainSwiftSourceModuleTargets(string):
-            return "product '\(string)' does not contain any Swift source modules"
-        case let .targetIsNotSwiftSourceModule(string):
-            return "target '\(string)' is not a Swift source module"
-        case let .testTarget(string):
-            return "target '\(string)' is a test target; only library and executable targets are supported by Swift-DocC"
-        case .packageDoesNotContainSwiftSourceModuleTargets:
-            return "the current package does not contain any compatible Swift source modules"
-        }
-    }
-
-    var errorDescription: String? {
-        description
-    }
-}
-
+@available(macOS 13.0, *)
 extension ArgumentExtractor {
-    mutating func extractSpecifiedTargets(in package: Package, withOption option: String) throws -> [SwiftSourceModuleTarget] {
+    mutating func extractSpecifiedTargets(in package: Package,
+                                          withOption option: String) throws -> [SwiftSourceModuleTarget] {
         let specifiedTargets = extractOption(named: option)
+        var targets: [SwiftSourceModuleTarget] = []
 
-        let targets = try specifiedTargets.map { specifiedTarget -> SwiftSourceModuleTarget in
-            let target = package.targets.first { target in
-                target.name == specifiedTarget
+        try package.targets.forEach { target in
+            for specifiedTarget in specifiedTargets {
+                let regex = try Regex(specifiedTarget)
+                
+                if target.name.contains(regex) {
+                    if let swiftSourceModuleTarget = target as? SwiftSourceModuleTarget {
+                        if swiftSourceModuleTarget.kind != .test {
+                            targets.append(swiftSourceModuleTarget)
+                            break
+                        }
+                    }
+                }
             }
-
-            guard let target else {
-                throw ArgumentParsingError.unknownTarget(specifiedTarget)
-            }
-
-            guard let swiftSourceModuleTarget = target as? SwiftSourceModuleTarget else {
-                throw ArgumentParsingError.targetIsNotSwiftSourceModule(specifiedTarget)
-            }
-
-            guard swiftSourceModuleTarget.kind != .test else {
-                throw ArgumentParsingError.testTarget(specifiedTarget)
-            }
-
-            return swiftSourceModuleTarget
         }
-
         return targets
     }
 }

--- a/Plugins/Benchmark/ArgumentExtractor+Extensions.swift
+++ b/Plugins/Benchmark/ArgumentExtractor+Extensions.swift
@@ -20,7 +20,7 @@ extension ArgumentExtractor {
         try package.targets.forEach { target in
             for specifiedTarget in specifiedTargets {
                 let regex = try Regex(specifiedTarget)
-                
+
                 if target.name.contains(regex) {
                     if let swiftSourceModuleTarget = target as? SwiftSourceModuleTarget {
                         if swiftSourceModuleTarget.kind != .test {

--- a/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
@@ -64,6 +64,10 @@ extension BenchmarkTool {
     mutating func postProcessBenchmarkResults(_ benchmarkResults: BenchmarkResults) throws {
         let benchmarkMachine = benchmarkMachine()
 
+        if benchmarkResults.isEmpty {
+            return
+        }
+
         switch command {
         case .run:
             prettyPrint(BenchmarkBaseline(machine: benchmarkMachine, results: benchmarkResults))

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -87,6 +87,12 @@ struct BenchmarkTool: AsyncParsableCommand {
     @Option(name: .long, help: "The grouping to use, 'metric' or 'test'")
     var grouping: Grouping
 
+    @Option(name: .long, help: "Benchmarks matching the regexp filter that should be run")
+    var filter: [String] = []
+
+    @Option(name: .long, help: "Benchmarks matching the regexp filter that should be skipped")
+    var skip: [String] = []
+
     var inputFD: CInt = 0
     var outputFD: CInt = 0
 
@@ -106,6 +112,33 @@ struct BenchmarkTool: AsyncParsableCommand {
         print("Likely your benchmark crahed, try running the tool in the debugger, e.g.")
         print("lldb \(benchmarkExecutablePath)")
         print("Or check Console.app for a backtrace if on macOS.")
+    }
+
+    func shouldRunBenchmark(_ name: String) throws -> Bool {
+        for matchingString in skip {
+            let regex = try Regex(matchingString)
+
+            if name.contains(regex) {
+                return false
+            }
+        }
+
+        var anyMatching = false
+
+        if filter.isEmpty {
+            anyMatching = true
+        } else {
+            for matchingString in filter {
+                let regex = try Regex(matchingString)
+
+                if name.contains(regex) {
+                    anyMatching = true
+                    break
+                }
+            }
+        }
+
+        return anyMatching
     }
 
     mutating func run() async throws {
@@ -163,18 +196,19 @@ struct BenchmarkTool: AsyncParsableCommand {
 
             // run each benchmark for the target as a separate process
             try benchmarks.forEach { benchmark in
-                // Then perform actions
-                let results = try runChild(benchmarkPath: benchmarkExecutablePath,
-                                           benchmarkCommand: command,
-                                           benchmark: benchmark) { [self] result in
-                    if result != 0 {
-                        printChildRunError(result)
+                if try shouldRunBenchmark(benchmark.name) {
+                    // Then perform actions
+                    let results = try runChild(benchmarkPath: benchmarkExecutablePath,
+                                               benchmarkCommand: command,
+                                               benchmark: benchmark) { [self] result in
+                        if result != 0 {
+                            printChildRunError(result)
+                        }
                     }
+
+                    benchmarkResults = benchmarkResults.merging(results) { (_, new) in new }
                 }
-
-                benchmarkResults = benchmarkResults.merging(results) { (_, new) in new }
             }
-
             try postProcessBenchmarkResults(benchmarkResults)
         default:
             print("Unknown command \(command) in BenchmarkTool")

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -206,7 +206,7 @@ struct BenchmarkTool: AsyncParsableCommand {
                         }
                     }
 
-                    benchmarkResults = benchmarkResults.merging(results) { (_, new) in new }
+                    benchmarkResults = benchmarkResults.merging(results) { _, new in new }
                 }
             }
             try postProcessBenchmarkResults(benchmarkResults)

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -115,30 +115,10 @@ struct BenchmarkTool: AsyncParsableCommand {
     }
 
     func shouldRunBenchmark(_ name: String) throws -> Bool {
-        for matchingString in skip {
-            let regex = try Regex(matchingString)
-
-            if name.contains(regex) {
-                return false
-            }
+        if try skip.contains(where: { name.wholeMatch(of: try Regex($0)) != nil }) {
+            return false
         }
-
-        var anyMatching = false
-
-        if filter.isEmpty {
-            anyMatching = true
-        } else {
-            for matchingString in filter {
-                let regex = try Regex(matchingString)
-
-                if name.contains(regex) {
-                    anyMatching = true
-                    break
-                }
-            }
-        }
-
-        return anyMatching
+        return try filter.isEmpty || filter.contains(where: { name.wholeMatch(of: try Regex($0)) != nil })
     }
 
     mutating func run() async throws {

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -9,7 +9,7 @@
 //
 
 import Dispatch
-import Statistics // For TimeInstant/TimeDuration until we can migrate to 5.7 Instant/Duration
+import Statistics
 
 /// Defines a benchmark
 public final class Benchmark: Codable, Hashable {


### PR DESCRIPTION
Rename skip -> skip-target, add regexp support to target/skip-targ, add filter/skip options with regexp support, multiple of each can be provided

Fixes https://github.com/ordo-one/package-benchmark/issues/58

## Description

This adds support for Regex for target/skip-target options, add new options for filter/skip that allow for regex filtering for what benchmarks should be run. 

## How Has This Been Tested?

Manual testing only

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
