### PR TITLE
feat: Add Configuration type to allow sharing of common configurations between benchmarks

### DIFF
--- a/Benchmarks/Basic/BenchmarkRunner.swift
+++ b/Benchmarks/Basic/BenchmarkRunner.swift
@@ -15,16 +15,14 @@ extension BenchmarkRunner {}
 // swiftlint disable: attributes
 @_dynamicReplacement(for: registerBenchmarks)
 func benchmarks() {
-    Benchmark.defaultDesiredDuration = .milliseconds(10)
-    Benchmark.defaultDesiredIterations = .giga(1)
+    Benchmark.defaultConfiguration = .init(desiredDuration: .milliseconds(10),
+                                           desiredIterations: .giga(1))
 
     Benchmark("Basic",
-              metrics: [.wallClock, .throughput],
-              skip: false) { _ in
+              configuration: .init(metrics: [.wallClock, .throughput])) { _ in
     }
 
     Benchmark("All metrics",
-              metrics: BenchmarkMetric.all,
-              skip: true) { _ in
+              configuration: .init(metrics: BenchmarkMetric.all, skip: true)) { _ in
     }
 }

--- a/Benchmarks/DateTime/DateTime.swift
+++ b/Benchmarks/DateTime/DateTime.swift
@@ -13,9 +13,9 @@ import BenchmarkSupport
 
 @_dynamicReplacement(for: registerBenchmarks)
 func benchmarks() {
-    Benchmark.defaultDesiredDuration = .seconds(2)
-    Benchmark.defaultDesiredIterations = 10_000
-    Benchmark.defaultThroughputScalingFactor = .kilo
+    Benchmark.defaultConfiguration = .init(throughputScalingFactor: .kilo,
+                                           desiredDuration: .seconds(2),
+                                           desiredIterations: .kilo(10))
 
     Benchmark("InternalUTCClock.now") { benchmark in
         for _ in benchmark.throughputIterations {

--- a/Benchmarks/Histogram/HistogramBenchmark.swift
+++ b/Benchmarks/Histogram/HistogramBenchmark.swift
@@ -16,13 +16,12 @@ extension BenchmarkRunner {}
 // swiftlint disable: attributes
 @_dynamicReplacement(for: registerBenchmarks)
 func benchmarks() {
-    Benchmark.defaultDesiredDuration = .seconds(2)
-    Benchmark.defaultDesiredIterations = .kilo(1)
-    Benchmark.defaultThroughputScalingFactor = .mega
+    Benchmark.defaultConfiguration = .init(throughputScalingFactor: .mega,
+                                           desiredDuration: .seconds(1),
+                                           desiredIterations: .kilo(1))
 
     Benchmark("Record",
-              metrics: [.wallClock, .throughput] + BenchmarkMetric.memory,
-              skip: false) { benchmark in
+              configuration: .init(metrics: [.wallClock, .throughput] + BenchmarkMetric.memory)) { benchmark in
         let maxValue: UInt64 = 1_000_000
 
         var histogram = Histogram<UInt64>(highestTrackableValue: maxValue, numberOfSignificantValueDigits: .three)
@@ -38,8 +37,7 @@ func benchmarks() {
     }
 
     Benchmark("Record to autoresizing",
-              metrics: [.wallClock, .throughput] + BenchmarkMetric.memory,
-              skip: false) { benchmark in
+              configuration: .init(metrics: [.wallClock, .throughput] + BenchmarkMetric.memory)) { benchmark in
         var histogram = Histogram<UInt64>(numberOfSignificantValueDigits: .three)
 
         let numValues = 1_024 // so compiler can optimize modulo below
@@ -53,9 +51,8 @@ func benchmarks() {
     }
 
     Benchmark("ValueAtPercentile",
-              metrics: [.wallClock, .throughput],
-              throughputScalingFactor: .kilo,
-              skip: false) { benchmark in
+              configuration: .init(metrics: [.wallClock, .throughput] + BenchmarkMetric.memory,
+                                   throughputScalingFactor: .kilo)) { benchmark in
         let maxValue: UInt64 = 1_000_000
 
         var histogram = Histogram<UInt64>(highestTrackableValue: maxValue, numberOfSignificantValueDigits: .three)
@@ -75,9 +72,7 @@ func benchmarks() {
     }
 
     Benchmark("Mean",
-              metrics: [.wallClock, .throughput],
-              throughputScalingFactor: .kilo,
-              skip: false) { benchmark in
+              configuration: .init(metrics: [.wallClock, .throughput], throughputScalingFactor: .kilo)) { benchmark in
         let maxValue: UInt64 = 1_000_000
 
         var histogram = Histogram<UInt64>(highestTrackableValue: maxValue, numberOfSignificantValueDigits: .three)

--- a/Plugins/Benchmark/ArgumentExtractor+Extensions.swift
+++ b/Plugins/Benchmark/ArgumentExtractor+Extensions.swift
@@ -20,7 +20,6 @@ enum ArgumentParsingError: Error, CustomStringConvertible {
     var errorDescription: String? {
         description
     }
-
 }
 
 @available(macOS 13.0, *)
@@ -35,7 +34,7 @@ extension ArgumentExtractor {
             for specifiedTarget in specifiedTargets {
                 let regex = try Regex(specifiedTarget)
 
-                if target.name.wholeMatch(of:regex) != nil {
+                if target.name.wholeMatch(of: regex) != nil {
                     if let swiftSourceModuleTarget = target as? SwiftSourceModuleTarget {
                         if swiftSourceModuleTarget.kind != .test {
                             targets.append(swiftSourceModuleTarget)
@@ -47,7 +46,7 @@ extension ArgumentExtractor {
             }
         }
 
-        if !specifiedTargets.isEmpty && !anyMatching {
+        if !specifiedTargets.isEmpty, !anyMatching {
             throw ArgumentParsingError.noMatchingTargetsForRegex
         }
 

--- a/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
@@ -41,7 +41,7 @@ extension BenchmarkTool {
 
             switch benchmarkReply {
             case let .result(benchmark: benchmark, results: results):
-                let filteredResults = results.filter { benchmark.metrics.contains($0.metric) }
+                let filteredResults = results.filter { benchmark.configuration.metrics.contains($0.metric) }
 
                 benchmarkResults[BenchmarkIdentifier(target: target, name: benchmark.name)] = filteredResults
             case .end:

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -11,6 +11,60 @@
 import Dispatch
 import Statistics
 
+public extension Benchmark {
+    struct Configuration: Codable {
+        /// Defines the metrics that should be measured for the benchmark
+        public var metrics: [BenchmarkMetric]
+        /// Override the automatic detection of timeunits for metrics related to time to a specific
+        /// one (auto should work for most use cases)
+        public var timeUnits: BenchmarkTimeUnits
+        /// Specifies a number of warmup iterations should be performed before the measurement to
+        /// reduce outliers due to e.g. cache population
+        public var warmupIterations: Int
+        /// Specifies the number of logical subiterations being done, scaling throughput measurements accordingly.
+        /// E.g. `.kilo`will scale results with 1000. Any iteration done in the benchmark should use
+        /// `benchmark.throughputScalingFactor.rawvalue` for the number of iterations.
+        public var throughputScalingFactor: StatisticsUnits
+        /// The target wall clock runtime for the benchmark, currenty defaults to `.seconds(1)` if not set
+        public var desiredDuration: Duration
+        /// The target number of iterations for the benchmark., currently defaults to 100K iterations if not set
+        public var desiredIterations: Int
+        /// Whether to skip this test (convenience for not having to comment out tests that have issues)
+        public var skip = false
+        /// Customized CI failure thresholds for a given metric for the Benchmark
+        public var thresholds: [BenchmarkMetric: BenchmarkResult.PercentileThresholds]?
+
+        public init(metrics: [BenchmarkMetric] = defaultConfiguration.metrics,
+                    timeUnits: BenchmarkTimeUnits = defaultConfiguration.timeUnits,
+                    warmupIterations: Int = defaultConfiguration.warmupIterations,
+                    throughputScalingFactor: StatisticsUnits = defaultConfiguration.throughputScalingFactor,
+                    desiredDuration: Duration = defaultConfiguration.desiredDuration,
+                    desiredIterations: Int = defaultConfiguration.desiredIterations,
+                    skip: Bool = defaultConfiguration.skip,
+                    thresholds: [BenchmarkMetric: BenchmarkResult.PercentileThresholds]? =
+                        defaultConfiguration.thresholds) {
+            self.metrics = metrics
+            self.timeUnits = timeUnits
+            self.warmupIterations = warmupIterations
+            self.throughputScalingFactor = throughputScalingFactor
+            self.desiredDuration = desiredDuration
+            self.desiredIterations = desiredIterations
+            self.skip = skip
+            self.thresholds = thresholds
+        }
+// swiftlint:disable nesting
+        enum CodingKeys: String, CodingKey {
+            case metrics
+            case timeUnits
+            case warmupIterations
+            case throughputScalingFactor
+            case desiredDuration
+            case desiredIterations
+            case thresholds
+        }
+    }
+}
+
 /// Defines a benchmark
 public final class Benchmark: Codable, Hashable {
     public typealias BenchmarkClosure = (_ benchmark: Benchmark) -> Void
@@ -22,32 +76,17 @@ public final class Benchmark: Codable, Hashable {
 
     /// The name used for display purposes of the benchmark (also used for matching when comparing to baselines)
     public var name: String
-    /// Defines the metrics that should be measured for the benchmark
-    public var metrics: [BenchmarkMetric]
-    /// Override the automatic detection of timeunits for metrics related to time to a specific
-    /// one (auto should work for most use cases)
-    public var timeUnits: BenchmarkTimeUnits
-    /// Specifies a number of warmup iterations should be performed before the measurement to
-    /// reduce outliers due to e.g. cache population
-    public var warmupIterations: Int
-    /// Specifies the number of logical subiterations being done, scaling throughput measurements accordingly.
-    /// E.g. `.kilo`will scale results with 1000. Any iteration done in the benchmark should use
-    /// `benchmark.throughputScalingFactor.rawvalue` for the number of iterations.
-    public var throughputScalingFactor: StatisticsUnits
-    /// The target wall clock runtime for the benchmark, currenty defaults to `.seconds(1)` if not set
-    public var desiredDuration: Duration
-    /// The target number of iterations for the benchmark., currently defaults to 100K iterations if not set
-    public var desiredIterations: Int
+
+    public var configuration: Configuration = .init()
+
     /// The reason for a benchmark failure, not set if successful
     public var failureReason: String?
     /// The current benchmark iteration (also includes warmup iterations), can be useful when
     /// e.g. unique keys will be needed for different iterations
     public var currentIteration: Int = 0
-    /// Customized CI failure thresholds for a given metric for the Benchmark
-    public var thresholds: [BenchmarkMetric: BenchmarkResult.PercentileThresholds]?
 
     /// Convenience range to iterate over for benchmarks
-    public var throughputIterations: Range<Int> { 0 ..< throughputScalingFactor.rawValue }
+    public var throughputIterations: Range<Int> { 0 ..< configuration.throughputScalingFactor.rawValue }
 
     ///   - closure: The actual benchmark closure that will be measured
     var closure: BenchmarkClosure? // The actual benchmark to run
@@ -60,15 +99,15 @@ public final class Benchmark: Codable, Hashable {
     // Hook for custom metrics capturing
     public var customMetricMeasurement: BenchmarkCustomMetricMeasurement?
 
-    /// Hooks for setting defaults for a whole benchmark suite
-    public static var defaultMetrics: [BenchmarkMetric] = BenchmarkMetric.default
-    public static var defaultTimeUnits: BenchmarkTimeUnits = .automatic
-    public static var defaultWarmupIterations = 3
-    public static var defaultThroughputScalingFactor: StatisticsUnits = .count
-    public static var defaultDesiredDuration: Duration = .seconds(1)
-    public static var defaultDesiredIterations: Int = 100_000
-    public static var defaultSkip = false
-    public static var defaultThresholds: [BenchmarkMetric: BenchmarkResult.PercentileThresholds]?
+    /// Hook for setting defaults for a whole benchmark suite
+    public static var defaultConfiguration: Configuration = .init(metrics: BenchmarkMetric.default,
+                                                                  timeUnits: .automatic,
+                                                                  warmupIterations: 3,
+                                                                  throughputScalingFactor: .count,
+                                                                  desiredDuration: .seconds(1),
+                                                                  desiredIterations: 100_000,
+                                                                  skip: false,
+                                                                  thresholds: nil)
 
     internal static var testSkipBenchmarkRegistrations = false // true in test to avoid bench registration fail
 
@@ -76,13 +115,6 @@ public final class Benchmark: Codable, Hashable {
 
     enum CodingKeys: String, CodingKey {
         case name
-        case metrics
-        case timeUnits
-        case warmupIterations
-        case throughputScalingFactor
-        case desiredDuration
-        case desiredIterations
-        case thresholds
         case failureReason
     }
 
@@ -98,103 +130,58 @@ public final class Benchmark: Codable, Hashable {
     /// - Parameters:
     ///   - name: The name used for display purposes of the benchmark (also used for
     ///   matching when comparing to baselines)
-    ///   - metrics: Defines the metrics that should be measured for the benchmark
-    ///   - timeUnits: Override the automatic detection of timeunits for metrics related to time
-    ///   to a specific one (auto should work for most use cases)
-    ///   - warmupIterations: Specifies  a number of warmup iterations should be performed before the
-    ///   measurement to reduce outliers due to e.g. cache population, currently 3 warmup iterations will be run.
-    ///   - throughputScalingFactor: Specifies the number of logical subiterations being done, scaling
-    ///   throughput measurements accordingly. E.g. `.kilo`
-    ///   will scale results with 1000. Any iteration done in the benchmark should use
-    ///   `benchmark.throughputScalingFactor.rawvalue` for the number of iterations.
-    ///   - desiredDuration: The target wall clock runtime for the benchmark
-    ///   - desiredIterations: The target number of iterations for the benchmark.
-    ///   - skip: Set to true if the benchmark should be excluded from benchmark runs
-    ///   - thresholds: Defines custom threshold per metric for failing the benchmark in CI for in `benchmark compare`
+    ///   - configuration: Defines the settings that should be used for this benchmark
     ///   - closure: The actual benchmark closure that will be measured
     @discardableResult
     public init?(_ name: String,
-                 metrics: [BenchmarkMetric] = Benchmark.defaultMetrics,
-                 timeUnits: BenchmarkTimeUnits = Benchmark.defaultTimeUnits,
-                 warmupIterations: Int = Benchmark.defaultWarmupIterations,
-                 throughputScalingFactor: StatisticsUnits = Benchmark.defaultThroughputScalingFactor,
-                 desiredDuration: Duration = Benchmark.defaultDesiredDuration,
-                 desiredIterations: Int = Benchmark.defaultDesiredIterations,
-                 skip: Bool = Benchmark.defaultSkip,
-                 thresholds: [BenchmarkMetric: BenchmarkResult.PercentileThresholds]? = Benchmark.defaultThresholds,
+                 configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
                  closure: @escaping BenchmarkClosure) {
-        if skip {
+        if configuration.skip {
             return nil
         }
         self.name = name
-        self.metrics = metrics
-        self.timeUnits = timeUnits
-        self.warmupIterations = warmupIterations
-        self.throughputScalingFactor = throughputScalingFactor
-        self.desiredDuration = desiredDuration
-        self.desiredIterations = desiredIterations
-        self.thresholds = thresholds
+        self.configuration = configuration
         self.closure = closure
 
-        if Self.testSkipBenchmarkRegistrations == false {
-            guard Self.benchmarks.contains(self) == false else {
-                fatalError("Duplicate registration of benchmark '\(self.name)', name must be unique.")
-            }
-
-            Self.benchmarks.append(self)
-        }
-
-        self.thresholds?.forEach { thresholdMetric, _ in
-            if self.metrics.contains(thresholdMetric) == false {
-                print("Warning: Custom threshold defined for metric `\(thresholdMetric)` " +
-                    "which isn't used by benchmark `\(name)`")
-            }
-        }
+        benchmarkRegistration()
     }
 
     /// Definition of a Benchmark
     /// - Parameters:
     ///   - name: The name used for display purposes of the benchmark (also used for
     ///   matching when comparing to baselines)
-    ///   - metrics: Defines the metrics that should be measured for the benchmark
-    ///   - timeUnits: Override the automatic detection of timeunits for metrics related to time
-    ///   to a specific one (auto should work for most use cases)
-    ///   - warmupIterations: Specifies a number of warmup iterations should be performed before the
-    ///   measurement to reduce outliers due to e.g. cache population
-    ///   - throughputScalingFactor: Specifies the number of logical subiterations being done, scaling
-    ///   throughput measurements accordingly. E.g. `.kilo`
-    ///   will scale results with 1000. Any iteration done in the benchmark should use
-    ///   `benchmark.throughputScalingFactor.rawvalue` for the number of iterations.
-    ///   - desiredDuration: The target wall clock runtime for the benchmark
-    ///   - desiredIterations: The target number of iterations for the benchmark.
-    ///   - skip: Set to true if the benchmark should be excluded from benchmark runs
-    ///   - thresholds: Defines custom threshold per metric for failing the benchmark in CI for in `benchmark compare`
+    ///   - configuration: Defines the settings that should be used for this benchmark
     ///   - closure: The actual `async` benchmark closure that will be measured
     @discardableResult
     public init?(_ name: String,
-                 metrics: [BenchmarkMetric] = Benchmark.defaultMetrics,
-                 timeUnits: BenchmarkTimeUnits = Benchmark.defaultTimeUnits,
-                 warmupIterations: Int = Benchmark.defaultWarmupIterations,
-                 throughputScalingFactor: StatisticsUnits = Benchmark.defaultThroughputScalingFactor,
-                 desiredDuration: Duration = Benchmark.defaultDesiredDuration,
-                 desiredIterations: Int = Benchmark.defaultDesiredIterations,
-                 skip: Bool = Benchmark.defaultSkip,
-                 thresholds: [BenchmarkMetric: BenchmarkResult.PercentileThresholds]? = Benchmark.defaultThresholds,
+                 configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
                  closure: @escaping BenchmarkAsyncClosure) {
-        if skip {
+        if configuration.skip {
             return nil
         }
         self.name = name
-        self.metrics = metrics
-        self.timeUnits = timeUnits
-        self.warmupIterations = warmupIterations
-        self.throughputScalingFactor = throughputScalingFactor
-        self.desiredDuration = desiredDuration
-        self.desiredIterations = desiredIterations
-        self.thresholds = thresholds
+        self.configuration = configuration
         asyncClosure = closure
 
-        Self.benchmarks.append(self)
+        benchmarkRegistration()
+    }
+
+    // Shared between sync/async actual benchmark registration
+    internal func benchmarkRegistration() {
+        if Self.testSkipBenchmarkRegistrations == false {
+            guard Self.benchmarks.contains(self) == false else {
+                fatalError("Duplicate registration of benchmark '\(name)', name must be unique.")
+            }
+
+            Self.benchmarks.append(self)
+        }
+
+        configuration.thresholds?.forEach { thresholdMetric, _ in
+            if self.configuration.metrics.contains(thresholdMetric) == false {
+                print("Warning: Custom threshold defined for metric `\(thresholdMetric)` " +
+                    "which isn't used by benchmark `\(name)`")
+            }
+        }
     }
 
     /// `measurement` registers custom metric measurements

--- a/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
@@ -16,11 +16,11 @@ import XCTest
 
 @_dynamicReplacement(for: registerBenchmarks) // Register benchmarks
 func benchmarks() {
-    Benchmark("Minimal benchmark", metrics: BenchmarkMetric.all, desiredIterations: 1) { _ in
+    Benchmark("Minimal benchmark", configuration: .init(metrics: BenchmarkMetric.all, desiredIterations: 1)) { _ in
     }
-    Benchmark("Minimal benchmark 2", warmupIterations: 0, desiredIterations: 2) { _ in
+    Benchmark("Minimal benchmark 2", configuration: .init(warmupIterations: 0, desiredIterations: 2)) { _ in
     }
-    Benchmark("Minimal benchmark 3", timeUnits: .seconds, desiredIterations: 3) { _ in
+    Benchmark("Minimal benchmark 3", configuration: .init(timeUnits: .seconds, desiredIterations: 3)) { _ in
     }
 }
 

--- a/Tests/BenchmarkTests/BenchmarkTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkTests.swift
@@ -31,7 +31,7 @@ final class BenchmarkTests: XCTestCase {
 
     func testBenchmarkRunCustomMetric() throws {
         let benchmark = Benchmark("testBenchmarkRunCustomMetric benchmark",
-                                  metrics: [.custom("customMetric")]) { benchmark in
+                                  configuration: .init(metrics: [.custom("customMetric")])) { benchmark in
             for measurement in 1 ... 100 {
                 benchmark.measurement(.custom("customMetric"), measurement)
             }
@@ -50,7 +50,7 @@ final class BenchmarkTests: XCTestCase {
 
     func testBenchmarkRunFailure() throws {
         let benchmark = Benchmark("testBenchmarkRunFailure benchmark",
-                                  metrics: [.custom("customMetric")]) { benchmark in
+                                  configuration: .init(metrics: [.custom("customMetric")])) { benchmark in
             benchmark.error("Benchmark failed")
         }
         XCTAssertNotNil(benchmark)
@@ -61,10 +61,12 @@ final class BenchmarkTests: XCTestCase {
 
     func testBenchmarkRunMoreParameters() throws {
         let benchmark = Benchmark("testBenchmarkRunMoreParameters benchmark",
-                                  metrics: BenchmarkMetric.all,
-                                  timeUnits: .milliseconds,
-                                  warmupIterations: 0,
-                                  throughputScalingFactor: .mega) { benchmark in
+                                  configuration: .init(
+                                      metrics: BenchmarkMetric.all,
+                                      timeUnits: .milliseconds,
+                                      warmupIterations: 0,
+                                      throughputScalingFactor: .mega
+                                  )) { benchmark in
             for outerloop in benchmark.throughputIterations {
                 blackHole(outerloop)
             }


### PR DESCRIPTION
## Description

Refactored configuration into a separate type and simplified the benchmark init signature accordingly.

This allows for sharing of configurations between benchmarks more easily, but is a source break.

It's trivial to change existing options for a benchmark though, e.g.

```swift
    Benchmark("Memory transient allocations + 1 large leak",
              metrics: BenchmarkMetric.memory,
              throughputScalingFactor: .kilo) { benchmark in
        performAllocations(count: benchmark.throughputScalingFactor.rawValue, size: 11 * 1024 * 1024)
        performAllocations(count: 1, size: 32 * 1024 * 1024, shouldFree: false)
    }
```

becomes
```swift
    Benchmark("Memory transient allocations + 1 large leak",
         configuration: .init(metrics: BenchmarkMetric.memory,
                                         throughputScalingFactor: .kilo)) { benchmark in
        performAllocations(count: benchmark.throughputScalingFactor.rawValue, size: 11 * 1024 * 1024)
        performAllocations(count: 1, size: 32 * 1024 * 1024, shouldFree: false)
    }
```

and 
```swift
    Benchmark.defaultDesiredDuration = .milliseconds(10)
    Benchmark.defaultDesiredIterations = .giga(1)
```
becomes analogous
```swift
    Benchmark.defaultConfiguration = .init(desiredDuration: .milliseconds(10),
                                           desiredIterations: .giga(1))
```
or (both works)
```swift
Benchmark.defaultConfiguration.desiredDuration = .milliseconds(10)
Benchmark.defaultConfiguration.desiredIterations = .giga(1)
```

Gives nicer API and reusability of settings among targets.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
