### PR TITLE
fix: fixed up external references after rename

### DIFF
--- a/Benchmarks/Basic/BenchmarkRunner.swift
+++ b/Benchmarks/Basic/BenchmarkRunner.swift
@@ -15,8 +15,8 @@ extension BenchmarkRunner {}
 // swiftlint disable: attributes
 @_dynamicReplacement(for: registerBenchmarks)
 func benchmarks() {
-    Benchmark.defaultConfiguration = .init(desiredDuration: .seconds(5),
-                                           desiredIterations: Int.max)
+    Benchmark.defaultConfiguration = .init(maxDuration: .seconds(5),
+                                           maxIterations: Int.max)
 
     Benchmark("Basic",
               configuration: .init(metrics: [.wallClock, .throughput])) { _ in

--- a/Sources/BenchmarkSupport/BenchmarkRunner.swift
+++ b/Sources/BenchmarkSupport/BenchmarkRunner.swift
@@ -262,11 +262,11 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
 
                     // Run the benchmark at a minimum the desired iterations/runtime --
 
-                    while iterations <= benchmark.configuration.desiredIterations ||
-                            wallClockDuration <= benchmark.configuration.desiredDuration {
+                    while iterations <= benchmark.configuration.maxIterations ||
+                            wallClockDuration <= benchmark.configuration.maxDuration {
                         // and at a maximum the same...
-                        guard wallClockDuration < benchmark.configuration.desiredDuration,
-                              iterations < benchmark.configuration.desiredIterations
+                        guard wallClockDuration < benchmark.configuration.maxDuration,
+                              iterations < benchmark.configuration.maxIterations
                         else {
                             break
                         }
@@ -287,13 +287,12 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                                 Double(benchmark.configuration.maxIterations)
 
                             let timePercentage = 100.0 * (wallClockDuration /
-                                benchmark.configuration.desiredDuration)
+                                benchmark.configuration.maxDuration)
 
                             let maxPercentage = max(iterationsPercentage, timePercentage)
 
                             if Int(maxPercentage) > currentPercentage {
                                 currentPercentage = Int(maxPercentage)
-                                
                                 progressBar.setValue(currentPercentage)
 
                                 fflush(stdout)


### PR DESCRIPTION
- desiredIterations => maxIterations
- desiredDuration => maxDuration

## Description

Resolving build breakage in Xcode

## How Has This Been Tested?

build in Xcode
`swift build`

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works

I tried `swift test`, but while it's building - on macOS I'm getting `error: Exited with signal code 11`.
I started to try and add a .devContainers directory setup to run within Docker, but ran into some permissions errors just doing `swift package resolve`, so I suspect it's unrelated to these changes.