### PR TITLE
feat: adds devContainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+{
+    "name": "Swift",
+    "image": "swift:5.7",
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": "false",
+            "username": "vscode",
+            "userUid": "1000",
+            "userGid": "1000",
+            "upgradePackages": "false"
+        },
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "os-provided",
+            "ppa": "false"
+        },
+        "ghcr.io/heckj/jemalloc/jemalloc:1": {
+        }
+    },
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined"
+    ],
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "lldb.library": "/usr/lib/liblldb.so"
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "sswg.swift-lang"
+            ]
+        }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "swift --version",
+
+    // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode"
+}


### PR DESCRIPTION
- I'm working from a mac, so this makes it a lot easier for me to open, build, and test the package within a container while working from Visual Studio Code. It's leveraging the swift:5.7 docker container provided by Swift.org, and I extended that setup with a "devContainer feature" that ensures that jemalloc is installed in the related container.

## Description

Include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [X] I have added `DocC` code-level documentation for any public interfaces exported by the package (n/a)
- [X] I have added unit and/or integration tests that prove my fix is effective or that my feature works


The way I verified this:
- open the folder of checked out package within VSCode
- "Reopen with Container"
- Open an additional terminal and run the following commands:
```
swift package resolve
swift build
swift test
swift package benchmark
```

Not the speediest thing ever, but it's reasonably convenient for the development work.