### PR TITLE
chore: Make CPU time units consistent and polish scaling factor usage, improve debugging

### DIFF
--- a/Benchmarks/Basic/BenchmarkRunner.swift
+++ b/Benchmarks/Basic/BenchmarkRunner.swift
@@ -25,8 +25,8 @@ func benchmarks() {
 
     Benchmark("Scaled metrics",
               configuration: .init(metrics: BenchmarkMetric.all, scalingFactor: .kilo)) { benchmark in
-        for _ in benchmark.scaledIterations  {
-           blackHole(Int.random(in: benchmark.scaledIterations))
+        for _ in benchmark.scaledIterations {
+            blackHole(Int.random(in: benchmark.scaledIterations))
         }
     }
 

--- a/Benchmarks/Basic/BenchmarkRunner.swift
+++ b/Benchmarks/Basic/BenchmarkRunner.swift
@@ -15,7 +15,9 @@ extension BenchmarkRunner {}
 // swiftlint disable: attributes
 @_dynamicReplacement(for: registerBenchmarks)
 func benchmarks() {
-    Benchmark.defaultConfiguration = .init(maxDuration: .seconds(1),
+    Benchmark.defaultConfiguration = .init(// timeUnits: .microseconds,
+                                            warmupIterations:0,
+                                           maxDuration: .seconds(1),
                                            maxIterations: Int.max)
 
     Benchmark("Basic",
@@ -24,10 +26,13 @@ func benchmarks() {
 
     Benchmark("Scaled metrics",
               configuration: .init(metrics: BenchmarkMetric.all, scalingFactor: .kilo)) { benchmark in
-        for _ in benchmark.scaledIterations {
-            for _ in 0..<2 {
-                blackHole(Int.random(in: benchmark.scaledIterations))
-            }
+        for _ in benchmark.scaledIterations  {
+//            for _ in 0..<1_00 {
+ //               blackHole(Int.random(in: benchmark.scaledIterations))
+//            }
+        }
+        for _ in 0..<150000 {
+                       blackHole(Int.random(in: benchmark.scaledIterations))
         }
     }
 

--- a/Benchmarks/Basic/BenchmarkRunner.swift
+++ b/Benchmarks/Basic/BenchmarkRunner.swift
@@ -15,8 +15,7 @@ extension BenchmarkRunner {}
 // swiftlint disable: attributes
 @_dynamicReplacement(for: registerBenchmarks)
 func benchmarks() {
-    Benchmark.defaultConfiguration = .init(// timeUnits: .microseconds,
-                                            warmupIterations:0,
+    Benchmark.defaultConfiguration = .init(warmupIterations: 0,
                                            maxDuration: .seconds(1),
                                            maxIterations: Int.max)
 
@@ -27,12 +26,7 @@ func benchmarks() {
     Benchmark("Scaled metrics",
               configuration: .init(metrics: BenchmarkMetric.all, scalingFactor: .kilo)) { benchmark in
         for _ in benchmark.scaledIterations  {
-//            for _ in 0..<1_00 {
- //               blackHole(Int.random(in: benchmark.scaledIterations))
-//            }
-        }
-        for _ in 0..<150000 {
-                       blackHole(Int.random(in: benchmark.scaledIterations))
+           blackHole(Int.random(in: benchmark.scaledIterations))
         }
     }
 

--- a/Benchmarks/Basic/BenchmarkRunner.swift
+++ b/Benchmarks/Basic/BenchmarkRunner.swift
@@ -15,11 +15,20 @@ extension BenchmarkRunner {}
 // swiftlint disable: attributes
 @_dynamicReplacement(for: registerBenchmarks)
 func benchmarks() {
-    Benchmark.defaultConfiguration = .init(maxDuration: .seconds(5),
+    Benchmark.defaultConfiguration = .init(maxDuration: .seconds(2),
                                            maxIterations: Int.max)
 
     Benchmark("Basic",
               configuration: .init(metrics: [.wallClock, .throughput])) { _ in
+    }
+
+    Benchmark("Scaled metrics",
+              configuration: .init(metrics: BenchmarkMetric.all, scalingFactor: .kilo)) { benchmark in
+        for _ in benchmark.scaledIterations {
+            for _ in 0..<2 {
+                blackHole(Int.random(in: benchmark.scaledIterations))
+            }
+        }
     }
 
     Benchmark("All metrics",

--- a/Benchmarks/Basic/BenchmarkRunner.swift
+++ b/Benchmarks/Basic/BenchmarkRunner.swift
@@ -15,8 +15,8 @@ extension BenchmarkRunner {}
 // swiftlint disable: attributes
 @_dynamicReplacement(for: registerBenchmarks)
 func benchmarks() {
-    Benchmark.defaultConfiguration = .init(desiredDuration: .seconds(5),
-                                           desiredIterations: Int.max)
+    Benchmark.defaultConfiguration = .init(maxDuration: .seconds(5),
+                                           maxIterations: Int.max)
 
     Benchmark("Basic",
               configuration: .init(metrics: [.wallClock, .throughput])) { _ in

--- a/Benchmarks/DateTime/DateTime.swift
+++ b/Benchmarks/DateTime/DateTime.swift
@@ -15,24 +15,24 @@ import BenchmarkSupport
 func benchmarks() {
     Benchmark.defaultConfiguration = .init(metrics: [.throughput, .wallClock],
                                            warmupIterations: 10,
-                                           throughputScalingFactor: .kilo,
+                                           scalingFactor: .kilo,
                                            maxDuration: .seconds(1),
                                            maxIterations: .kilo(10))
 
     Benchmark("InternalUTCClock-now") { benchmark in
-        for _ in benchmark.throughputIterations {
+        for _ in benchmark.scaledIterations {
             BenchmarkSupport.blackHole(InternalUTCClock.now)
         }
     }
 
     Benchmark("BenchmarkClock-now") { benchmark in
-        for _ in benchmark.throughputIterations {
+        for _ in benchmark.scaledIterations {
             BenchmarkSupport.blackHole(BenchmarkClock.now)
         }
     }
 
     Benchmark("Foundation-Date") { benchmark in
-        for _ in benchmark.throughputIterations {
+        for _ in benchmark.scaledIterations {
             BenchmarkSupport.blackHole(Foundation.Date())
         }
     }

--- a/Benchmarks/Histogram/HistogramBenchmark.swift
+++ b/Benchmarks/Histogram/HistogramBenchmark.swift
@@ -16,7 +16,6 @@ extension BenchmarkRunner {}
 // swiftlint disable: attributes
 @_dynamicReplacement(for: registerBenchmarks)
 func benchmarks() {
-
     Benchmark.defaultConfiguration = .init(scalingFactor: .mega,
                                            maxDuration: .seconds(1),
                                            maxIterations: .kilo(1))

--- a/Benchmarks/Histogram/HistogramBenchmark.swift
+++ b/Benchmarks/Histogram/HistogramBenchmark.swift
@@ -16,7 +16,8 @@ extension BenchmarkRunner {}
 // swiftlint disable: attributes
 @_dynamicReplacement(for: registerBenchmarks)
 func benchmarks() {
-    Benchmark.defaultConfiguration = .init(throughputScalingFactor: .mega,
+
+    Benchmark.defaultConfiguration = .init(scalingFactor: .mega,
                                            maxDuration: .seconds(1),
                                            maxIterations: .kilo(1))
 
@@ -31,7 +32,7 @@ func benchmarks() {
 
         benchmark.startMeasurement()
 
-        for i in benchmark.throughputIterations {
+        for i in benchmark.scaledIterations {
             blackHole(histogram.record(values[i % numValues]))
         }
     }
@@ -45,14 +46,14 @@ func benchmarks() {
 
         benchmark.startMeasurement()
 
-        for i in benchmark.throughputIterations {
+        for i in benchmark.scaledIterations {
             blackHole(histogram.record(values[i % numValues]))
         }
     }
 
     Benchmark("ValueAtPercentile",
               configuration: .init(metrics: [.wallClock, .throughput] + BenchmarkMetric.memory,
-                                   throughputScalingFactor: .kilo)) { benchmark in
+                                   scalingFactor: .kilo)) { benchmark in
         let maxValue: UInt64 = 1_000_000
 
         var histogram = Histogram<UInt64>(highestTrackableValue: maxValue, numberOfSignificantValueDigits: .three)
@@ -66,13 +67,13 @@ func benchmarks() {
 
         benchmark.startMeasurement()
 
-        for i in benchmark.throughputIterations {
+        for i in benchmark.scaledIterations {
             blackHole(histogram.valueAtPercentile(percentiles[i % percentiles.count]))
         }
     }
 
     Benchmark("Mean",
-              configuration: .init(metrics: BenchmarkMetric.all, throughputScalingFactor: .kilo)) { benchmark in
+              configuration: .init(metrics: BenchmarkMetric.all, scalingFactor: .kilo)) { benchmark in
         let maxValue: UInt64 = 1_000_000
 
         var histogram = Histogram<UInt64>(highestTrackableValue: maxValue, numberOfSignificantValueDigits: .three)
@@ -84,7 +85,7 @@ func benchmarks() {
 
         benchmark.startMeasurement()
 
-        for _ in benchmark.throughputIterations {
+        for _ in benchmark.scaledIterations {
             blackHole(histogram.mean)
         }
     }

--- a/Documentation/WritingBenchmarks.md
+++ b/Documentation/WritingBenchmarks.md
@@ -37,8 +37,8 @@ func benchmarks() {
                                                         .cpuUser: .strict])
 
     Benchmark("Foundation Date()",
-              configuration: .init(metrics: [.throughput, .wallClock], throughputScalingFactor: .mega)) { benchmark in
-        for _ in benchmark.throughputIterations {
+              configuration: .init(metrics: [.throughput, .wallClock], scalingFactor: .mega)) { benchmark in
+        for _ in benchmark.scaledIterations {
             blackHole(Date())
         }
     }
@@ -86,8 +86,8 @@ public extension Benchmark {
         public var warmupIterations: Int
         /// Specifies the number of logical subiterations being done, scaling throughput measurements accordingly.
         /// E.g. `.kilo`will scale results with 1000. Any iteration done in the benchmark should use
-        /// `benchmark.throughputScalingFactor.rawvalue` for the number of iterations.
-        public var throughputScalingFactor: StatisticsUnits
+        /// `benchmark.scalingFactor.rawvalue` for the number of iterations.
+        public var scalingFactor: StatisticsUnits
         /// The target wall clock runtime for the benchmark, currenty defaults to `.seconds(1)` if not set
         public var maxDuration: Duration
         /// The target number of iterations for the benchmark., currently defaults to 100K iterations if not set
@@ -99,15 +99,15 @@ public extension Benchmark {
 ...
 ```
 
-### throughputScalingFactor
-It's sometimes desireable to view `.throughput` scaled to a given number of iterations performed by the test (as for smaller test a large number of iterations is desirable to get stable results). This can be done by using `throughputScalingFactor`.
+### scalingFactor
+It's sometimes desireable to view `.throughput` scaled to a given number of iterations performed by the test (as for smaller test a large number of iterations is desirable to get stable results). This can be done by using `scalingFactor`.
 
 An example would be:
 
 ```swift
     Benchmark("Foundation Date()",
-              configuration: .init(metrics: [.throughput, .wallClock], throughputScalingFactor: .mega)) { benchmark in
-        for _ in benchmark.throughputIterations {
+              configuration: .init(metrics: [.throughput, .wallClock], scalingFactor: .mega)) { benchmark in
+        for _ in benchmark.scaledIterations {
             blackHole(Date())
         }
     }
@@ -145,9 +145,9 @@ Benchmark.defaultConfiguration = .init(...)
     Benchmark("Foundation Date()",
               configuration: .init(
               metrics: [.throughput, .wallClock],
-              throughputScalingFactor: .mega,
+              scalingFactor: .mega,
               thresholds: [.throughput : customThreshold, .wallClock : customThreshold])) { benchmark in
-        for _ in benchmark.throughputIterations {
+        for _ in benchmark.scaledIterations {
             blackHole(Date())
         }
     }

--- a/Plugins/Benchmark/BenchmarkPlugin+Help.swift
+++ b/Plugins/Benchmark/BenchmarkPlugin+Help.swift
@@ -42,6 +42,7 @@ let help =
     --format <format>       The output format to use, one of: ["text", "markdown", "influx", "percentiles", "tsv", "jmh"], default is 'text'
     --path <path>           The path where exported data is stored, default is the current directory (".").
     --quiet                 Specifies that output should be supressed (useful for if you just want to check return code)
+    --scale                 Specifies that some of the text output should be scaled using the scalingFactor
     --no-progress           Specifies that benchmark progress information should not be displayed
     --grouping <grouping>   The grouping to use, one of: ["metric", "benchmark"]. default is 'benchmark'
     """

--- a/Plugins/Benchmark/BenchmarkPlugin.swift
+++ b/Plugins/Benchmark/BenchmarkPlugin.swift
@@ -43,20 +43,7 @@ import PackagePlugin
         case metric
         case benchmark
     }
-/*
-    enum TimeUnit: String {
-        case automatic
-        case s
-        case ms
-        case us
-        case ns
-    }
 
-    enum Scale: String {
-        case automatic
-        case scaled
-    }
-*/
     func withCStrings(_ strings: [String], scoped: ([UnsafeMutablePointer<CChar>?]) throws -> Void) rethrows {
         let cStrings = strings.map { strdup($0) }
         try scoped(cStrings + [nil])

--- a/Plugins/Benchmark/BenchmarkPlugin.swift
+++ b/Plugins/Benchmark/BenchmarkPlugin.swift
@@ -43,7 +43,20 @@ import PackagePlugin
         case metric
         case benchmark
     }
+/*
+    enum TimeUnit: String {
+        case automatic
+        case s
+        case ms
+        case us
+        case ns
+    }
 
+    enum Scale: String {
+        case automatic
+        case scaled
+    }
+*/
     func withCStrings(_ strings: [String], scoped: ([UnsafeMutablePointer<CChar>?]) throws -> Void) rethrows {
         let cStrings = strings.map { strdup($0) }
         try scoped(cStrings + [nil])
@@ -66,6 +79,7 @@ import PackagePlugin
         let noProgress = argumentExtractor.extractFlag(named: "no-progress")
         let groupingToUse = argumentExtractor.extractOption(named: "grouping")
         let debug = argumentExtractor.extractFlag(named: "debug")
+        let scale = argumentExtractor.extractFlag(named: "scale")
         var outputFormat: Format = .text
         var grouping = "benchmark"
         var exportPath = "."
@@ -211,6 +225,10 @@ import PackagePlugin
 
         if noProgress > 0 {
             args.append(contentsOf: ["--no-progress"])
+        }
+
+        if scale > 0 {
+            args.append(contentsOf: ["--scale"])
         }
 
         if compareSpecified.count > 0 {

--- a/Plugins/BenchmarkHelpGenerator/BenchmarkHelpGenerator.swift
+++ b/Plugins/BenchmarkHelpGenerator/BenchmarkHelpGenerator.swift
@@ -84,6 +84,9 @@ struct Benchmark: AsyncParsableCommand {
     @Flag(name: .long, help: "Specifies that output should be supressed (useful for if you just want to check return code)")
     var quiet: Int
 
+    @Flag(name: .long, help: "Specifies that some of the text output should be scaled using the scalingFactor (denoted by '*' in output)")
+    var scale: Int
+
     @Flag(name: .long, help: "Specifies that benchmark progress information should not be displayed")
     var noProgress: Int
 

--- a/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
@@ -284,6 +284,8 @@ extension BenchmarkTool {
 
         outputPath.append(subPath.components)
 
+        print("Writing baseline to \(outputPath), \(baselineName)")
+
         if let hostIdentifier {
             outputPath.append("\(hostIdentifier).results.json")
         } else {

--- a/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
@@ -12,8 +12,8 @@
 
 import Benchmark
 import ExtrasJSON
-import SystemPackage
 import Foundation
+import SystemPackage
 
 #if canImport(Darwin)
     import Darwin
@@ -174,11 +174,11 @@ let baselinesDirectory: String = ".benchmarkBaselines"
 
 extension BenchmarkTool {
     func printAllBaselines() {
-        var storagePath: FilePath = FilePath(baselineStoragePath)
+        var storagePath = FilePath(baselineStoragePath)
         storagePath.append(baselinesDirectory) // package/.benchmarkBaselines
         for file in storagePath.directoryEntries {
-            if file.ends(with: ".") == false &&
-                file.ends(with: "..")  == false {
+            if file.ends(with: ".") == false,
+               file.ends(with: "..") == false {
                 var subDirectory = storagePath
                 subDirectory.append(file.lastComponent!)
                 if let directoryName = file.lastComponent {
@@ -188,8 +188,8 @@ extension BenchmarkTool {
                     print(separator)
                     for file in subDirectory.directoryEntries {
                         if let subdirectoryName = file.lastComponent {
-                            if file.ends(with: ".") == false &&
-                                file.ends(with: "..")  == false {
+                            if file.ends(with: ".") == false,
+                               file.ends(with: "..") == false {
                                 print("\(subdirectoryName.description)")
                             }
                         }
@@ -201,21 +201,21 @@ extension BenchmarkTool {
     }
 
     func removeBaselinesNamed(target: String, baselineName: String) {
-        var storagePath: FilePath = FilePath(baselineStoragePath)
+        var storagePath = FilePath(baselineStoragePath)
         let filemanager = FileManager.default
 
         storagePath.append(baselinesDirectory) // package/.benchmarkBaselines
         for file in storagePath.directoryEntries {
-            if file.ends(with: ".") == false &&
-                file.ends(with: "..")  == false {
+            if file.ends(with: ".") == false,
+               file.ends(with: "..") == false {
                 if target == file.lastComponent!.description {
                     var subDirectory = storagePath
                     subDirectory.append(file.lastComponent!)
                     if file.lastComponent != nil {
                         for file in subDirectory.directoryEntries {
                             if let subdirectoryName = file.lastComponent {
-                                if file.ends(with: ".") == false &&
-                                    file.ends(with: "..")  == false {
+                                if file.ends(with: ".") == false,
+                                   file.ends(with: "..") == false {
                                     if subdirectoryName.description == baselineName {
                                         do {
                                             try filemanager.removeItem(atPath: file.description)

--- a/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
@@ -284,8 +284,6 @@ extension BenchmarkTool {
 
         outputPath.append(subPath.components)
 
-        print("Writing baseline to \(outputPath), \(baselineName)")
-
         if let hostIdentifier {
             outputPath.append("\(hostIdentifier).results.json")
         } else {

--- a/Plugins/BenchmarkTool/BenchmarkTool+Export+InfluxCSVFormatter.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export+InfluxCSVFormatter.swift
@@ -173,7 +173,7 @@ extension BenchmarkTool {
                                 testName _: String) -> TestMetricData {
         var testData: [Int] = []
 
-        var percentiles = test.statistics
+        let percentiles = test.statistics
 
         percentiles.percentiles().forEach { result in
             testData.append(result)

--- a/Plugins/BenchmarkTool/BenchmarkTool+Export+InfluxCSVFormatter.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export+InfluxCSVFormatter.swift
@@ -29,7 +29,6 @@ struct TestMetricData: Codable {
     var units: String
     var average: Double
     var metricsdata: [Int]
-//    var percentiles: [Statistics.Percentile: Int]
 }
 
 class InfluxCSVFormatter {
@@ -174,7 +173,9 @@ extension BenchmarkTool {
                                 testName _: String) -> TestMetricData {
         var testData: [Int] = []
 
-        test.statistics.percentiles().forEach { result in
+        var percentiles = test.statistics
+
+        percentiles.percentiles().forEach { result in
             testData.append(result)
         }
 
@@ -186,6 +187,5 @@ extension BenchmarkTool {
                               units: test.unitDescription,
                               average: averageValue,
                               metricsdata: testData)
-//                              percentiles: test.percentiles)
     }
 }

--- a/Plugins/BenchmarkTool/BenchmarkTool+Export+InfluxCSVFormatter.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export+InfluxCSVFormatter.swift
@@ -29,7 +29,7 @@ struct TestMetricData: Codable {
     var units: String
     var average: Double
     var metricsdata: [Int]
-    var percentiles: [BenchmarkResult.Percentile: Int]
+//    var percentiles: [Statistics.Percentile: Int]
 }
 
 class InfluxCSVFormatter {
@@ -152,7 +152,7 @@ extension BenchmarkTool {
                                                testName: test.name)
                     )
 
-                    iterations = results.measurements
+                    iterations = results.statistics.measurementCount
                     warmupIterations = results.warmupIterations
                 }
 
@@ -173,8 +173,9 @@ extension BenchmarkTool {
     func processBenchmarkResult(test: BenchmarkResult,
                                 testName _: String) -> TestMetricData {
         var testData: [Int] = []
-        test.percentiles.forEach { result in
-            testData.append(result.value)
+
+        test.statistics.percentiles().forEach { result in
+            testData.append(result)
         }
 
         let totalValue = Double(testData.reduce(0, +))
@@ -184,7 +185,7 @@ extension BenchmarkTool {
         return TestMetricData(metric: test.metric.description,
                               units: test.unitDescription,
                               average: averageValue,
-                              metricsdata: testData,
-                              percentiles: test.percentiles)
+                              metricsdata: testData)
+//                              percentiles: test.percentiles)
     }
 }

--- a/Plugins/BenchmarkTool/BenchmarkTool+Export+JMHFormatter.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export+JMHFormatter.swift
@@ -18,7 +18,7 @@ import Statistics
 
 extension JMHPrimaryMetric {
     init(_ result: BenchmarkResult) {
-        let histogram = result.statistics!.histogram
+        let histogram = result.statistics.histogram
 
         // TODO: Must validate the calculation of scoreError
         // below was cobbled together according to https://stackoverflow.com/a/24725075
@@ -35,18 +35,18 @@ extension JMHPrimaryMetric {
         let factor = result.metric.countable() == false ? 1_000 : 1
 
         for p in percentiles {
-            percentileValues[String(p)] = roundToDecimalplaces(Double(histogram.valueAtPercentile(p)) / Double(factor), 3)
+            percentileValues[String(p)] = Statistics.roundToDecimalplaces(Double(histogram.valueAtPercentile(p)) / Double(factor), 3)
         }
 
         for value in histogram.recordedValues() {
             for _ in 0 ..< value.count {
-                recordedValues.append(roundToDecimalplaces(Double(value.value) / Double(factor), 3))
+                recordedValues.append(Statistics.roundToDecimalplaces(Double(value.value) / Double(factor), 3))
             }
         }
 
-        self.score = roundToDecimalplaces(score / Double(factor), 3)
-        scoreError = roundToDecimalplaces(error / Double(factor), 3)
-        scoreConfidence = [roundToDecimalplaces(score - error) / Double(factor), roundToDecimalplaces(score + error) / Double(factor)]
+        self.score = Statistics.roundToDecimalplaces(score / Double(factor), 3)
+        scoreError = Statistics.roundToDecimalplaces(error / Double(factor), 3)
+        scoreConfidence = [Statistics.roundToDecimalplaces(score - error) / Double(factor), Statistics.roundToDecimalplaces(score + error) / Double(factor)]
         scorePercentiles = percentileValues
         if result.metric.countable() {
             scoreUnit = result.metric == .throughput ? "# / s" : "#"
@@ -92,7 +92,7 @@ extension BenchmarkTool {
                                      warmupIterations: primaryResult.warmupIterations,
                                      warmupTime: "1 s",
                                      warmupBatchSize: 1,
-                                     measurementIterations: primaryResult.measurements,
+                                     measurementIterations: primaryResult.statistics.measurementCount,
                                      measurementTime: "1 s",
                                      measurementBatchSize: 1,
                                      primaryMetric: primaryMetrics,

--- a/Plugins/BenchmarkTool/BenchmarkTool+Export+JMHFormatter.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export+JMHFormatter.swift
@@ -32,7 +32,7 @@ extension JMHPrimaryMetric {
         var percentileValues: [String: Double] = [:]
         var recordedValues: [Double] = []
 //        let factor = 1 // result.metric == .throughput ? 1 : 1_000_000_000 / result.timeUnits.rawValue
-        let factor = result.metric.countable() == false ? 1_000 : 1
+        let factor = result.metric.countable == false ? 1_000 : 1
 
         for p in percentiles {
             percentileValues[String(p)] = Statistics.roundToDecimalplaces(Double(histogram.valueAtPercentile(p)) / Double(factor), 3)
@@ -48,7 +48,7 @@ extension JMHPrimaryMetric {
         scoreError = Statistics.roundToDecimalplaces(error / Double(factor), 3)
         scoreConfidence = [Statistics.roundToDecimalplaces(score - error) / Double(factor), Statistics.roundToDecimalplaces(score + error) / Double(factor)]
         scorePercentiles = percentileValues
-        if result.metric.countable() {
+        if result.metric.countable {
             scoreUnit = result.metric == .throughput ? "# / s" : "#"
         } else {
             scoreUnit = "μs" // result.timeUnits.description

--- a/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
@@ -101,7 +101,7 @@ extension BenchmarkTool {
         case .percentiles:
             try baseline.results.forEach { key, results in
                 try results.forEach { values in
-                    let outputString = values.statistics!.histogram
+                    let outputString = values.statistics.histogram
                     let description = values.metric.description
                     try write(exportData: "\(outputString)",
                               fileName: cleanupStringForShellSafety("\(baselineName).\(key.name).\(description).histogram-export.txt"))
@@ -115,11 +115,11 @@ extension BenchmarkTool {
                 var outputString = ""
 
                 try results.forEach { values in
-                    if let histogram = values.statistics?.histogram {
-                        histogram.recordedValues().forEach { value in
-                            for _ in 0 ..< value.count {
-                                outputString += "\(value.value)\n"
-                            }
+                    let histogram = values.statistics.histogram
+
+                    histogram.recordedValues().forEach { value in
+                        for _ in 0 ..< value.count {
+                            outputString += "\(value.value)\n"
                         }
                     }
                     try write(exportData: "\(outputString)",

--- a/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
@@ -9,14 +9,13 @@
 //
 
 import Benchmark
+import Statistics
 import SystemPackage
 import TextTable
-import Statistics
 
-fileprivate let percentileWidth = 8
+private let percentileWidth = 8
 
 extension BenchmarkTool {
-
     private func printMarkdown(_ markdown: String, terminator: String = "\n") {
         if format == .markdown {
             print(markdown, terminator: terminator)
@@ -60,24 +59,24 @@ extension BenchmarkTool {
 
     fileprivate struct ScaledResults {
         fileprivate struct Percentiles {
-            var p0:Int = 0
-            var p25:Int = 0
-            var p50:Int = 0
-            var p75:Int = 0
-            var p90:Int = 0
-            var p99:Int = 0
-            var p100:Int = 0
+            var p0: Int = 0
+            var p25: Int = 0
+            var p50: Int = 0
+            var p75: Int = 0
+            var p90: Int = 0
+            var p99: Int = 0
+            var p100: Int = 0
         }
+
         var description: String
         var percentiles: Percentiles
-        var samples:Int
+        var samples: Int
     }
 
     private func _prettyPrint(title: String,
                               key: String,
                               results: [BenchmarkBaseline.ResultsEntry],
                               width: Int = 30) {
-
         let table = TextTable<ScaledResults> {
             [Column(title: title, value: "\($0.description)", width: width, align: .left),
              Column(title: "p0", value: $0.percentiles.p0, width: percentileWidth, align: .right),
@@ -99,7 +98,7 @@ extension BenchmarkTool {
 
             var adjustmentFunction: (Int) -> Int
 
-            if self.scale > 0 && result.metrics.metric.useScalingFactor {
+            if self.scale > 0, result.metrics.metric.useScalingFactor {
                 description = "\(result.metrics.metric.description) \(result.metrics.scaledUnitDescriptionPretty)"
                 adjustmentFunction = result.metrics.scale
             } else {
@@ -265,7 +264,7 @@ extension BenchmarkTool {
                                 var adjustmentFunction: (Int) -> Int
                                 let samples = result.statistics.measurementCount - base.statistics.measurementCount
 
-                                if self.scale > 0 && base.metric.useScalingFactor {
+                                if self.scale > 0, base.metric.useScalingFactor {
                                     adjustmentFunction = base.scale
                                 } else {
                                     adjustmentFunction = base.normalize
@@ -283,7 +282,7 @@ extension BenchmarkTool {
                                                                    percentiles: basePercentiles,
                                                                    samples: base.statistics.measurementCount))
 
-                                if self.scale > 0 && result.metric.useScalingFactor {
+                                if self.scale > 0, result.metric.useScalingFactor {
                                     adjustmentFunction = result.scale
                                 } else {
                                     adjustmentFunction = result.normalize
@@ -323,28 +322,27 @@ extension BenchmarkTool {
                                                                                  resultPercentiles.p0,
                                                                                  reversedPolarity)
                                 percentageDeltaPercentiles.p25 = formatTableEntry(basePercentiles.p25,
-                                                                                 resultPercentiles.p25,
-                                                                                 reversedPolarity)
+                                                                                  resultPercentiles.p25,
+                                                                                  reversedPolarity)
                                 percentageDeltaPercentiles.p50 = formatTableEntry(basePercentiles.p50,
-                                                                                 resultPercentiles.p50,
-                                                                                 reversedPolarity)
+                                                                                  resultPercentiles.p50,
+                                                                                  reversedPolarity)
                                 percentageDeltaPercentiles.p75 = formatTableEntry(basePercentiles.p75,
-                                                                                 resultPercentiles.p75,
-                                                                                 reversedPolarity)
+                                                                                  resultPercentiles.p75,
+                                                                                  reversedPolarity)
                                 percentageDeltaPercentiles.p90 = formatTableEntry(basePercentiles.p90,
-                                                                                 resultPercentiles.p90,
-                                                                                 reversedPolarity)
+                                                                                  resultPercentiles.p90,
+                                                                                  reversedPolarity)
                                 percentageDeltaPercentiles.p99 = formatTableEntry(basePercentiles.p99,
-                                                                                 resultPercentiles.p99,
-                                                                                 reversedPolarity)
+                                                                                  resultPercentiles.p99,
+                                                                                  reversedPolarity)
                                 percentageDeltaPercentiles.p100 = formatTableEntry(basePercentiles.p100,
-                                                                                 resultPercentiles.p100,
-                                                                                 reversedPolarity)
+                                                                                   resultPercentiles.p100,
+                                                                                   reversedPolarity)
 
                                 scaledResults.append(ScaledResults(description: "Improvement %",
                                                                    percentiles: percentageDeltaPercentiles,
                                                                    samples: samples))
-
 
                                 printMarkdown("```")
                                 table.print(scaledResults, style: Style.fancy)

--- a/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
@@ -93,7 +93,8 @@ extension BenchmarkTool {
         var scaledResults: [ScaledResults] = []
         results.forEach { result in
             let description: String
-            let percentiles = result.metrics.statistics.percentiles()
+            var metrics = result.metrics
+            let percentiles = metrics.statistics.percentiles()
             var resultPercentiles = ScaledResults.Percentiles()
 
             var adjustmentFunction: (Int) -> Int
@@ -216,7 +217,7 @@ extension BenchmarkTool {
 
                     value.forEach { currentResult in
                         var result = currentResult
-                        if let base = baselineComparison.first(where: { $0.metric == result.metric }) {
+                        if var base = baselineComparison.first(where: { $0.metric == result.metric }) {
                             if result == base {
                                 //                            print(" \(result.metric) results were identical.")
                                 //                            print("")

--- a/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
@@ -92,7 +92,7 @@ extension BenchmarkTool {
         var scaledResults: [ScaledResults] = []
         results.forEach { result in
             let description: String
-            var metrics = result.metrics
+            let metrics = result.metrics
             let percentiles = metrics.statistics.percentiles()
             var resultPercentiles = ScaledResults.Percentiles()
 
@@ -216,7 +216,7 @@ extension BenchmarkTool {
 
                     value.forEach { currentResult in
                         var result = currentResult
-                        if var base = baselineComparison.first(where: { $0.metric == result.metric }) {
+                        if let base = baselineComparison.first(where: { $0.metric == result.metric }) {
                             if result == base {
                                 //                            print(" \(result.metric) results were identical.")
                                 //                            print("")

--- a/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
@@ -282,7 +282,7 @@ extension BenchmarkTool {
                                 let title = "\(result.metric.description) \(result.unitDescriptionPretty)"
                                 let width = 40
                                 let table = TextTable<ScaledResults> {
-                                    [Column(title: title, value: "\($0.description)", width: width, align: .left),
+                                    [Column(title: title, value: "\($0.description)", width: width, align: .center),
                                      Column(title: "p0", value: $0.p0, width: percentileWidth, align: .right),
                                      Column(title: "p25", value: $0.p25, width: percentileWidth, align: .right),
                                      Column(title: "p50", value: $0.p50, width: percentileWidth, align: .right),
@@ -304,21 +304,21 @@ extension BenchmarkTool {
                                 var p0, p25, p50, p75, p90, p99, p100: Int
 
                                 if self.scale > 0 && base.metric.useScalingFactor {
-                                    p0 = base.scale(percentiles[0])
-                                    p25 = base.scale(percentiles[1])
-                                    p50 = base.scale(percentiles[2])
-                                    p75 = base.scale(percentiles[3])
-                                    p90 = base.scale(percentiles[4])
-                                    p99 = base.scale(percentiles[5])
-                                    p100 = base.scale(percentiles[6])
+                                    p0 = base.scale(basePercentiles[0])
+                                    p25 = base.scale(basePercentiles[1])
+                                    p50 = base.scale(basePercentiles[2])
+                                    p75 = base.scale(basePercentiles[3])
+                                    p90 = base.scale(basePercentiles[4])
+                                    p99 = base.scale(basePercentiles[5])
+                                    p100 = base.scale(basePercentiles[6])
                                 } else {
-                                    p0 = base.normalize(percentiles[0])
-                                    p25 = base.normalize(percentiles[1])
-                                    p50 = base.normalize(percentiles[2])
-                                    p75 = base.normalize(percentiles[3])
-                                    p90 = base.normalize(percentiles[4])
-                                    p99 = base.normalize(percentiles[5])
-                                    p100 = base.normalize(percentiles[6])
+                                    p0 = base.normalize(basePercentiles[0])
+                                    p25 = base.normalize(basePercentiles[1])
+                                    p50 = base.normalize(basePercentiles[2])
+                                    p75 = base.normalize(basePercentiles[3])
+                                    p90 = base.normalize(basePercentiles[4])
+                                    p99 = base.normalize(basePercentiles[5])
+                                    p100 = base.normalize(basePercentiles[6])
                                 }
                                 scaledResults.append(ScaledResults(description: baseBaselineName,
                                                                    p0: p0,
@@ -365,21 +365,21 @@ extension BenchmarkTool {
 
 
                                 if self.scale > 0 && result.metric.useScalingFactor {
-                                    p0 = result.scale(percentiles[0]) - base.scale(percentiles[0])
-                                    p25 = result.scale(percentiles[1]) - base.scale(percentiles[1])
-                                    p50 = result.scale(percentiles[2]) - base.scale(percentiles[2])
-                                    p75 = result.scale(percentiles[3]) - base.scale(percentiles[3])
-                                    p90 = result.scale(percentiles[4]) - base.scale(percentiles[4])
-                                    p99 = result.scale(percentiles[5]) - base.scale(percentiles[5])
-                                    p100 = result.scale(percentiles[6]) - base.scale(percentiles[6])
+                                    p0 = result.scale(percentiles[0]) - base.scale(basePercentiles[0])
+                                    p25 = result.scale(percentiles[1]) - base.scale(basePercentiles[1])
+                                    p50 = result.scale(percentiles[2]) - base.scale(basePercentiles[2])
+                                    p75 = result.scale(percentiles[3]) - base.scale(basePercentiles[3])
+                                    p90 = result.scale(percentiles[4]) - base.scale(basePercentiles[4])
+                                    p99 = result.scale(percentiles[5]) - base.scale(basePercentiles[5])
+                                    p100 = result.scale(percentiles[6]) - base.scale(basePercentiles[6])
                                 } else {
-                                    p0 = result.normalize(percentiles[0]) - base.normalize(percentiles[0])
-                                    p25 = result.normalize(percentiles[1]) - base.normalize(percentiles[1])
-                                    p50 = result.normalize(percentiles[2]) - base.normalize(percentiles[2])
-                                    p75 = result.normalize(percentiles[3]) - base.normalize(percentiles[3])
-                                    p90 = result.normalize(percentiles[4]) - base.normalize(percentiles[4])
-                                    p99 = result.normalize(percentiles[5]) - base.normalize(percentiles[5])
-                                    p100 = result.normalize(percentiles[6]) - base.normalize(percentiles[6])
+                                    p0 = result.normalize(percentiles[0]) - base.normalize(basePercentiles[0])
+                                    p25 = result.normalize(percentiles[1]) - base.normalize(basePercentiles[1])
+                                    p50 = result.normalize(percentiles[2]) - base.normalize(basePercentiles[2])
+                                    p75 = result.normalize(percentiles[3]) - base.normalize(basePercentiles[3])
+                                    p90 = result.normalize(percentiles[4]) - base.normalize(basePercentiles[4])
+                                    p99 = result.normalize(percentiles[5]) - base.normalize(basePercentiles[5])
+                                    p100 = result.normalize(percentiles[6]) - base.normalize(basePercentiles[6])
                                 }
 
                                 let samples = result.statistics.measurementCount - base.statistics.measurementCount
@@ -397,47 +397,47 @@ extension BenchmarkTool {
 
 
                                 if self.scale > 0 && result.metric.useScalingFactor {
-                                    p0 = formatTableEntry(base.scale(percentiles[0]),
+                                    p0 = formatTableEntry(base.scale(basePercentiles[0]),
                                                                      result.scale(percentiles[0]),
                                                                                   reversedPolarity)
-                                    p25 = formatTableEntry(base.scale(percentiles[1]),
+                                    p25 = formatTableEntry(base.scale(basePercentiles[1]),
                                                                      result.scale(percentiles[1]),
                                                                                   reversedPolarity)
-                                    p50 = formatTableEntry(base.scale(percentiles[2]),
+                                    p50 = formatTableEntry(base.scale(basePercentiles[2]),
                                                                      result.scale(percentiles[2]),
                                                                                   reversedPolarity)
-                                    p75 = formatTableEntry(base.scale(percentiles[3]),
+                                    p75 = formatTableEntry(base.scale(basePercentiles[3]),
                                                                      result.scale(percentiles[3]),
                                                                                   reversedPolarity)
-                                    p90 = formatTableEntry(base.scale(percentiles[4]),
+                                    p90 = formatTableEntry(base.scale(basePercentiles[4]),
                                                                      result.scale(percentiles[4]),
                                                                                   reversedPolarity)
-                                    p99 = formatTableEntry(base.scale(percentiles[5]),
+                                    p99 = formatTableEntry(base.scale(basePercentiles[5]),
                                                                      result.scale(percentiles[5]),
                                                                                   reversedPolarity)
-                                    p100 = formatTableEntry(base.scale(percentiles[6]),
+                                    p100 = formatTableEntry(base.scale(basePercentiles[6]),
                                                                      result.scale(percentiles[6]),
                                                                                   reversedPolarity)
                                 } else {
-                                    p0 = formatTableEntry(base.normalize(percentiles[0]),
+                                    p0 = formatTableEntry(base.normalize(basePercentiles[0]),
                                                                      result.normalize(percentiles[0]),
                                                                                   reversedPolarity)
-                                    p25 = formatTableEntry(base.normalize(percentiles[1]),
+                                    p25 = formatTableEntry(base.normalize(basePercentiles[1]),
                                                                       result.normalize(percentiles[1]),
                                                                                    reversedPolarity)
-                                    p50 = formatTableEntry(base.normalize(percentiles[2]),
+                                    p50 = formatTableEntry(base.normalize(basePercentiles[2]),
                                                                       result.normalize(percentiles[2]),
                                                                                    reversedPolarity)
-                                    p75 = formatTableEntry(base.normalize(percentiles[3]),
+                                    p75 = formatTableEntry(base.normalize(basePercentiles[3]),
                                                                       result.normalize(percentiles[3]),
                                                                                    reversedPolarity)
-                                    p90 = formatTableEntry(base.normalize(percentiles[4]),
+                                    p90 = formatTableEntry(base.normalize(basePercentiles[4]),
                                                                       result.normalize(percentiles[4]),
                                                                                    reversedPolarity)
-                                    p99 = formatTableEntry(base.normalize(percentiles[5]),
+                                    p99 = formatTableEntry(base.normalize(basePercentiles[5]),
                                                                       result.normalize(percentiles[5]),
                                                                                    reversedPolarity)
-                                    p100 = formatTableEntry(base.normalize(percentiles[6]),
+                                    p100 = formatTableEntry(base.normalize(basePercentiles[6]),
                                                                        result.normalize(percentiles[6]),
                                                                                     reversedPolarity)
                                 }

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -175,7 +175,7 @@ struct BenchmarkTool: AsyncParsableCommand {
     }
 
     mutating func run() async throws {
-        if command == .baseline && delete == 0 && listBaselines == 0 && update == 0 { // don't need to read baseline
+        if command == .baseline, delete == 0, listBaselines == 0, update == 0 { // don't need to read baseline
             try readBaselines()
         }
 
@@ -193,7 +193,7 @@ struct BenchmarkTool: AsyncParsableCommand {
             }
         }
 
-        if delete > 0 { 
+        if delete > 0 {
             try postProcessBenchmarkResults()
             return
         }

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -80,6 +80,9 @@ struct BenchmarkTool: AsyncParsableCommand {
     @Flag(name: .long, help: "True if we should supress progress in benchmark run")
     var noProgress: Int
 
+    @Flag(name: .long, help: "True if we should scale time units, syscall rate, etc to scalingFactor")
+    var scale: Int
+
     @Option(name: .long, help: "The named baseline(s) we should display, update, delete or compare with")
     var baseline: [String] = []
 

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -251,7 +251,9 @@ struct BenchmarkTool: AsyncParsableCommand {
         }
 
         // Insert benchmark run at first position of baselines
-        baseline.insert("default", at: 0)
+        if comparisonBaseline != nil {
+            baseline.insert("default", at: 0)
+        }
         benchmarkBaselines.insert(BenchmarkBaseline(baselineName: "Current baseline",
                                                     machine: benchmarkMachine(),
                                                     results: benchmarkResults), at: 0)

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -80,7 +80,7 @@ public final class Benchmark: Codable, Hashable {
     /// Hook for setting defaults for a whole benchmark suite
     public static var defaultConfiguration: Configuration = .init(metrics: BenchmarkMetric.default,
                                                                   timeUnits: .automatic,
-                                                                  warmupIterations: 3,
+                                                                  warmupIterations: 1,
                                                                   scalingFactor: .none,
                                                                   maxDuration: .seconds(1),
                                                                   maxIterations: 10_000,

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -81,7 +81,7 @@ public final class Benchmark: Codable, Hashable {
     public static var defaultConfiguration: Configuration = .init(metrics: BenchmarkMetric.default,
                                                                   timeUnits: .automatic,
                                                                   warmupIterations: 1,
-                                                                  scalingFactor: .none,
+                                                                  scalingFactor: .one,
                                                                   maxDuration: .seconds(1),
                                                                   maxIterations: 10_000,
                                                                   skip: false,

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -14,24 +14,24 @@ import Statistics
 /// Defines a benchmark
 public final class Benchmark: Codable, Hashable {
     #if swift(>=5.8)
-    @_documentation(visibility: internal)
+        @_documentation(visibility: internal)
     #endif
     public typealias BenchmarkClosure = (_ benchmark: Benchmark) -> Void
     #if swift(>=5.8)
-    @_documentation(visibility: internal)
+        @_documentation(visibility: internal)
     #endif
     public typealias BenchmarkAsyncClosure = (_ benchmark: Benchmark) async -> Void
     #if swift(>=5.8)
-    @_documentation(visibility: internal)
+        @_documentation(visibility: internal)
     #endif
     public typealias BenchmarkMeasurementSynchronization = () -> Void
     #if swift(>=5.8)
-    @_documentation(visibility: internal)
+        @_documentation(visibility: internal)
     #endif
     public typealias BenchmarkCustomMetricMeasurement = (BenchmarkMetric, Int) -> Void
 
     #if swift(>=5.8)
-    @_documentation(visibility: internal)
+        @_documentation(visibility: internal)
     #endif
     public static var benchmarks: [Benchmark] = [] // Bookkeeping of all registered benchmarks
 
@@ -49,11 +49,11 @@ public final class Benchmark: Codable, Hashable {
 
     /// Some internal state for display purposes of the benchmark by the BenchmarkTool
     #if swift(>=5.8)
-    @_documentation(visibility: internal)
+        @_documentation(visibility: internal)
     #endif
     public var target: String
     #if swift(>=5.8)
-    @_documentation(visibility: internal)
+        @_documentation(visibility: internal)
     #endif
     public var executablePath: String?
     /// closure: The actual benchmark closure that will be measured
@@ -63,11 +63,11 @@ public final class Benchmark: Codable, Hashable {
 
     // Hooks for benchmark infrastructure to capture metrics of actual measurement() block without preamble:
     #if swift(>=5.8)
-    @_documentation(visibility: internal)
+        @_documentation(visibility: internal)
     #endif
     public var measurementPreSynchronization: BenchmarkMeasurementSynchronization?
     #if swift(>=5.8)
-    @_documentation(visibility: internal)
+        @_documentation(visibility: internal)
     #endif
     public var measurementPostSynchronization: BenchmarkMeasurementSynchronization?
 
@@ -99,16 +99,16 @@ public final class Benchmark: Codable, Hashable {
         case failureReason
     }
 
-#if swift(>=5.8)
-@_documentation(visibility: internal)
-#endif
+    #if swift(>=5.8)
+        @_documentation(visibility: internal)
+    #endif
     public func hash(into hasher: inout Hasher) {
         hasher.combine(name)
     }
 
-#if swift(>=5.8)
-@_documentation(visibility: internal)
-#endif
+    #if swift(>=5.8)
+        @_documentation(visibility: internal)
+    #endif
     public static func == (lhs: Benchmark, rhs: Benchmark) -> Bool {
         lhs.name == rhs.name
     }
@@ -243,7 +243,7 @@ public final class Benchmark: Codable, Hashable {
 
     // Public but should only be used by BenchmarkRunner
     #if swift(>=5.8)
-    @_documentation(visibility: internal)
+        @_documentation(visibility: internal)
     #endif
     public func run() {
         if closure != nil {
@@ -313,4 +313,3 @@ public extension Benchmark {
         }
     }
 }
-

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -223,25 +223,6 @@ public final class Benchmark: Codable, Hashable {
 }
 
 public extension Benchmark {
-    enum ScalingFactor: Int, Codable {
-        case none = 1 // e.g. nanoseconds, or count
-        case kilo = 1_000 // microseconds
-        case mega = 1_000_000 // milliseconds
-        case giga = 1_000_000_000 // seconds
-
-        public var description: String {
-            switch self {
-            case .none:
-                return "#"
-            case .kilo:
-                return "K"
-            case .mega:
-                return "M"
-            case .giga:
-                return "G"
-            }
-        }
-    }
 
     struct Configuration: Codable {
         /// Defines the metrics that should be measured for the benchmark
@@ -255,7 +236,7 @@ public extension Benchmark {
         /// Specifies the number of logical subiterations being done, supporting scaling of metricsi accordingly.
         /// E.g. `.kilo`will scale results with 1000. Any subiteration done in the benchmark should use
         /// `for _ in benchmark.scaledIterations` for the number of iterations.
-        public var scalingFactor: ScalingFactor
+        public var scalingFactor: BenchmarkScalingFactor
         /// The maximum wall clock runtime for the benchmark, currenty defaults to `.seconds(1)` if not set
         public var maxDuration: Duration
         /// The maximum number of iterations for the benchmark., currently defaults to 10K iterations if not set
@@ -268,7 +249,7 @@ public extension Benchmark {
         public init(metrics: [BenchmarkMetric] = defaultConfiguration.metrics,
                     timeUnits: BenchmarkTimeUnits = defaultConfiguration.timeUnits,
                     warmupIterations: Int = defaultConfiguration.warmupIterations,
-                    scalingFactor: ScalingFactor = defaultConfiguration.scalingFactor,
+                    scalingFactor: BenchmarkScalingFactor = defaultConfiguration.scalingFactor,
                     maxDuration: Duration = defaultConfiguration.maxDuration,
                     maxIterations: Int = defaultConfiguration.maxIterations,
                     skip: Bool = defaultConfiguration.skip,

--- a/Sources/Benchmark/BenchmarkInternals.swift
+++ b/Sources/Benchmark/BenchmarkInternals.swift
@@ -11,7 +11,6 @@
 
 // Internal Benchmark framework definitions used for communication with host process etc
 
-
 /// The entry point for defining benchmarks, expected to be overridden by benchmarks you write.
 ///
 /// Annotate a function that returns your benchmarks with `@_dynamicReplacement(for: registerBenchmarks)`
@@ -29,7 +28,7 @@ public dynamic func registerBenchmarks() {
 
 // Command sent from benchmark runner to the benchmark under measurement
 #if swift(>=5.8)
-@_documentation(visibility: internal)
+    @_documentation(visibility: internal)
 #endif
 public enum BenchmarkCommandRequest: Codable {
     case list
@@ -39,7 +38,7 @@ public enum BenchmarkCommandRequest: Codable {
 
 // Replies from benchmark under measure to benchmark runner
 #if swift(>=5.8)
-@_documentation(visibility: internal)
+    @_documentation(visibility: internal)
 #endif
 public enum BenchmarkCommandReply: Codable {
     case list(benchmark: Benchmark)

--- a/Sources/Benchmark/BenchmarkMetric+Defaults.swift
+++ b/Sources/Benchmark/BenchmarkMetric+Defaults.swift
@@ -7,6 +7,7 @@
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
 //
+// swiftlint:disable line_length
 
 // Convenience sets of metrics
 public extension BenchmarkMetric {

--- a/Sources/Benchmark/BenchmarkMetric+Defaults.swift
+++ b/Sources/Benchmark/BenchmarkMetric+Defaults.swift
@@ -20,7 +20,7 @@ public extension BenchmarkMetric {
          .throughput,
          .peakMemoryResident]
     }
-    
+
     /// A collection of extended system benchmarks.
     static var extended: [BenchmarkMetric] {
         [.wallClock,
@@ -32,7 +32,7 @@ public extension BenchmarkMetric {
          .memoryLeaked,
          .syscalls]
     }
-    
+
     /// A collection of memory benchmarks.
     static var memory: [BenchmarkMetric] {
         [.peakMemoryResident,
@@ -43,7 +43,7 @@ public extension BenchmarkMetric {
          .memoryLeaked,
          .allocatedResidentMemory]
     }
-    
+
     /// A collection of system benchmarks.
     static var system: [BenchmarkMetric] {
         [.wallClock,
@@ -53,7 +53,7 @@ public extension BenchmarkMetric {
          .threadsRunning,
          .cpuSystem]
     }
-    
+
     /// A collection of disk benchmarks.
     static var disk: [BenchmarkMetric] {
         [.readSyscalls,
@@ -63,7 +63,7 @@ public extension BenchmarkMetric {
          .readBytesPhysical,
          .writeBytesPhysical]
     }
-    
+
     /// A collection of all benchmarks supported by this library.
     static var all: [BenchmarkMetric] {
         [.cpuUser,

--- a/Sources/Benchmark/BenchmarkMetric.swift
+++ b/Sources/Benchmark/BenchmarkMetric.swift
@@ -8,6 +8,8 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 
+// swiftlint:disable line_length
+
 /// Metrics supported by benchmark.
 ///
 /// Some metrics are only available on macOS or Linux, but you can specify all the metrics without worrying about platform availability.

--- a/Sources/Benchmark/BenchmarkMetric.swift
+++ b/Sources/Benchmark/BenchmarkMetric.swift
@@ -63,11 +63,11 @@ public enum BenchmarkMetric: Hashable, Equatable, Codable, CustomStringConvertib
 
     /// Used internally as placeholders for formatting deltas in an easy way, please don't use
     #if swift(>=5.8)
-    @_documentation(visibility: internal)
+        @_documentation(visibility: internal)
     #endif
     case delta
     #if swift(>=5.8)
-    @_documentation(visibility: internal)
+        @_documentation(visibility: internal)
     #endif
     case deltaPercentage
 }
@@ -180,10 +180,11 @@ public extension BenchmarkMetric {
         }
     }
 }
+
 // swiftlint:disable cyclomatic_complexity
 // As we can't have raw values and associated data we add this...
 #if swift(>=5.8)
-@_documentation(visibility: internal)
+    @_documentation(visibility: internal)
 #endif
 extension BenchmarkMetric {
     init(_ textualMetric: String) {

--- a/Sources/Benchmark/BenchmarkMetric.swift
+++ b/Sources/Benchmark/BenchmarkMetric.swift
@@ -59,7 +59,7 @@ public enum BenchmarkMetric: Hashable, Equatable, Codable, CustomStringConvertib
     /// The number of bytes physicall written to a block device (i.e. disk) -- Linux only
     case writeBytesPhysical
     /// Custom metric
-    case custom(_ name: String, polarity: Polarity = .prefersSmaller)
+    case custom(_ name: String, polarity: Polarity = .prefersSmaller, useScalingFactor: Bool = true)
 
     /// Used internally as placeholders for formatting deltas in an easy way, please don't use
     #if swift(>=5.8)
@@ -84,26 +84,41 @@ public extension BenchmarkMetric {
 
 public extension BenchmarkMetric {
     // True if the metric is countable (otherwise it's a time/throughput unit)
-    func countable() -> Bool {
+    var countable: Bool {
         switch self {
-        case .cpuUser:
-            return false
-        case .cpuSystem:
-            return false
-        case .cpuTotal:
-            return false
-        case .wallClock:
+        case .cpuSystem, .cpuTotal, .cpuUser, .wallClock:
             return false
         default:
             return true
         }
     }
 
-    func polarity() -> BenchmarkMetric.Polarity {
+    /// True if this metric should be scaled to the scalingFactor if looking at scaled output.
+    var useScalingFactor: Bool {
+        switch self {
+        case .cpuSystem, .cpuTotal, .cpuUser, .wallClock:
+            return true
+        case .mallocCountLarge, .mallocCountSmall, .mallocCountTotal, .memoryLeaked:
+            return true
+        case .syscalls, .throughput:
+            return true
+        case .readSyscalls, .readBytesLogical, .readBytesPhysical:
+            return true
+        case .writeSyscalls, .writeBytesLogical, .writeBytesPhysical:
+            return true
+        case let .custom(_, _, useScaleFactor):
+            return useScaleFactor
+        default:
+            return false
+        }
+    }
+
+    /// Indicates whether larger or smaller measurements, relative to a set baseline, indicate better performance.
+    var polarity: BenchmarkMetric.Polarity {
         switch self {
         case .throughput:
             return .prefersLarger
-        case let .custom(_, polarity):
+        case let .custom(_, polarity, _):
             return polarity
         default:
             return .prefersSmaller
@@ -121,7 +136,7 @@ public extension BenchmarkMetric {
         case .wallClock:
             return "Time (wall clock)"
         case .throughput:
-            return "Throughput (scaled / s)"
+            return "Throughput (# / s)"
         case .peakMemoryResident:
             return "Memory (resident peak)"
         case .peakMemoryVirtual:
@@ -160,13 +175,16 @@ public extension BenchmarkMetric {
             return "Δ"
         case .deltaPercentage:
             return "Δ %"
-        case let .custom(name, _):
+        case let .custom(name, _, _):
             return name
         }
     }
 }
 // swiftlint:disable cyclomatic_complexity
 // As we can't have raw values and associated data we add this...
+#if swift(>=5.8)
+@_documentation(visibility: internal)
+#endif
 extension BenchmarkMetric {
     init(_ textualMetric: String) {
         switch textualMetric {

--- a/Sources/Benchmark/BenchmarkResult+Defaults.swift
+++ b/Sources/Benchmark/BenchmarkResult+Defaults.swift
@@ -15,11 +15,13 @@
 // swiftlint:disable discouraged_none_name
 // swiftlint:disable identifier_name
 
+import Statistics
+
 public extension BenchmarkResult {
     typealias PercentileRelativeThreshold = Double
     typealias PercentileAbsoluteThreshold = Int
-    typealias PercentileRelativeThresholds = [BenchmarkResult.Percentile: PercentileRelativeThreshold]
-    typealias PercentileAbsoluteThresholds = [BenchmarkResult.Percentile: PercentileAbsoluteThreshold]
+    typealias PercentileRelativeThresholds = [Statistics.Percentile: PercentileRelativeThreshold]
+    typealias PercentileAbsoluteThresholds = [Statistics.Percentile: PercentileAbsoluteThreshold]
 
     struct PercentileThresholds: Codable {
         public init(relative: BenchmarkResult.PercentileRelativeThresholds = .none,
@@ -30,16 +32,6 @@ public extension BenchmarkResult {
 
         let relative: PercentileRelativeThresholds
         let absolute: PercentileAbsoluteThresholds
-    }
-
-    enum Percentile: Codable {
-        case p0
-        case p25
-        case p50
-        case p75
-        case p90
-        case p99
-        case p100
     }
 }
 

--- a/Sources/Benchmark/BenchmarkResult+Defaults.swift
+++ b/Sources/Benchmark/BenchmarkResult+Defaults.swift
@@ -18,10 +18,22 @@
 import Statistics
 
 public extension BenchmarkResult {
+    enum Percentile: Int, Codable {
+        case p0 = 0
+        case p25 = 1
+        case p50 = 2
+        case p75 = 3
+        case p90 = 4
+        case p99 = 5
+        case p100 = 6
+    }
+}
+
+public extension BenchmarkResult {
     typealias PercentileRelativeThreshold = Double
     typealias PercentileAbsoluteThreshold = Int
-    typealias PercentileRelativeThresholds = [Statistics.Percentile: PercentileRelativeThreshold]
-    typealias PercentileAbsoluteThresholds = [Statistics.Percentile: PercentileAbsoluteThreshold]
+    typealias PercentileRelativeThresholds = [BenchmarkResult.Percentile: PercentileRelativeThreshold]
+    typealias PercentileAbsoluteThresholds = [BenchmarkResult.Percentile: PercentileAbsoluteThreshold]
 
     struct PercentileThresholds: Codable {
         public init(relative: BenchmarkResult.PercentileRelativeThresholds = .none,

--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -249,9 +249,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
         return statistics.timeUnits == .automatic ? "(\(scaledTimeUnits.description)) *" : "(\(timeUnits.description)) *"
     }
 
-    public static func == (lhsRaw: BenchmarkResult, rhsRaw: BenchmarkResult) -> Bool {
-        var lhs = lhsRaw
-        var rhs = rhsRaw
+    public static func == (lhs: BenchmarkResult, rhs: BenchmarkResult) -> Bool {
 
         guard lhs.metric == rhs.metric else {
             return false
@@ -273,9 +271,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
         return true
     }
 
-    public static func < (lhsRaw: BenchmarkResult, rhsRaw: BenchmarkResult) -> Bool {
-        var lhs = lhsRaw
-        var rhs = rhsRaw
+    public static func < (lhs: BenchmarkResult, rhs: BenchmarkResult) -> Bool {
         let reversedComparison = lhs.metric.polarity == .prefersLarger
 
         guard lhs.metric == rhs.metric else {

--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -247,10 +247,15 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
         return statistics.timeUnits == .automatic ? "(\(self.scaledTimeUnits.description)) *" : "(\(self.timeUnits.description)) *"
     }
 
-    public static func == (lhs: BenchmarkResult, rhsRaw: BenchmarkResult) -> Bool {
+    public static func == (lhsRaw: BenchmarkResult, rhsRaw: BenchmarkResult) -> Bool {
+        var lhs = lhsRaw
         var rhs = rhsRaw
 
         guard lhs.metric == rhs.metric else {
+            return false
+        }
+
+        if lhs.statistics.measurementCount != rhs.statistics.measurementCount {
             return false
         }
 
@@ -262,7 +267,8 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
         return lhsPercentiles == rhsPercentiles
     }
 
-    public static func < (lhs: BenchmarkResult, rhsRaw: BenchmarkResult) -> Bool {
+    public static func < (lhsRaw: BenchmarkResult, rhsRaw: BenchmarkResult) -> Bool {
+        var lhs = lhsRaw
         var rhs = rhsRaw
         let reversedComparison = lhs.metric.polarity == .prefersLarger
         var allIsLess = true
@@ -340,7 +346,6 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
         let rhsPercentiles = rhs.statistics.percentiles()
 
         var worse = false
-        let percentiles = lhs.statistics.percentiles
 
         for percentile in 0..<lhsPercentiles.count {
                 worse = worseResult(lhsPercentiles[percentile],

--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -210,10 +210,6 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
         value / timeUnits.rawValue
     }
 
-    public func scaleCompare(_ value: Int) -> Int {
-        value * timeUnits.divisor
-    }
-
     public var unitDescription: String {
         if metric.countable {
             let statisticsUnit = Statistics.Units(timeUnits)
@@ -320,8 +316,6 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
             return false
         }
 
-//        rhs.timeUnits = lhs.timeUnits
-
         // swiftlint:disable function_parameter_count
         func worseResult(_ lhs: Int,
                          _ rhs: Int,
@@ -363,8 +357,8 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
 
         var worse = false
         for percentile in 0 ..< lhsPercentiles.count {
-            worse = worseResult(lhs.scaleCompare(lhsPercentiles[percentile]),
-                                rhs.scaleCompare(rhsPercentiles[percentile]),
+            worse = worseResult(lhsPercentiles[percentile],
+                                rhsPercentiles[percentile],
                                 BenchmarkResult.Percentile(rawValue: percentile)!,
                                 thresholds,
                                 lhs.statistics.units().rawValue,

--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -231,7 +231,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
 
     public var scaledUnitDescriptionPretty: String {
         if metric == .throughput {
-            if scalingFactor == .none {
+            if scalingFactor == .one {
                 return "*"
             }
             return "(\(scalingFactor.description)) *"

--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -168,7 +168,6 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
         let scalingFactorMagnitude = Int(Double.log10(Double(scalingFactor.rawValue)))
         let totalMagnitude = timeUnitsMagnitude + scalingFactorMagnitude
         let newScale = pow(10, totalMagnitude)
-        print("\(timeUnitsMagnitude) \(scalingFactorMagnitude) \(totalMagnitude) \(newScale)")
 
         return BenchmarkScalingFactor(rawValue: newScale)!
     }
@@ -261,7 +260,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
         if metric.countable {
             let statisticsUnit = Statistics.Units(scaledTimeUnits)
             if statisticsUnit == .count {
-                return ""
+                return "*"
             }
             return "(\(statisticsUnit.description)) *"
         }

--- a/Sources/Benchmark/Blackhole.swift
+++ b/Sources/Benchmark/Blackhole.swift
@@ -9,6 +9,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
+// swiftlint:disable line_length
 // Borrowed from Swift Collections Benchmark, thanks!
 
 /// A function to foil compiler optimizations that would otherwise optimize out code you want to benchmark.

--- a/Sources/Benchmark/Documentation.docc/BenchmarkMetric.md
+++ b/Sources/Benchmark/Documentation.docc/BenchmarkMetric.md
@@ -53,7 +53,7 @@
 ### Custom Metrics
 
 - ``Benchmark/BenchmarkMetric/custom(_:polarity:)``
-- ``Benchmark/BenchmarkMetric/polarity()``
+- ``Benchmark/BenchmarkMetric/polarity``
 - ``Benchmark/BenchmarkMetric/Polarity``
 
 ### Inspecting Metrics

--- a/Sources/BenchmarkSupport/BenchmarkRunner.swift
+++ b/Sources/BenchmarkSupport/BenchmarkRunner.swift
@@ -98,7 +98,7 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                             statistics[metric] = Statistics(units: units)
                         default:
                             if operatingSystemStatsProducer.metricSupported(metric) == true {
-                                statistics[metric] = Statistics(prefersLarger: metric.polarity() == .prefersLarger)
+                                statistics[metric] = Statistics(prefersLarger: metric.polarity == .prefersLarger)
                             }
                         }
                         
@@ -155,8 +155,8 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                             statistics[.wallClock]?.add(Int(runningTime.nanoseconds()))
 
                             var roundedThroughput =
-                                Double(benchmark.configuration.scalingFactor.rawValue * 1_000_000_000)
-                                    / Double(runningTime.nanoseconds())
+                            Double(1_000_000_000)
+                            / Double(runningTime.nanoseconds())
                             roundedThroughput.round(.toNearestOrAwayFromZero)
 
                             let throughput = Int(roundedThroughput)
@@ -311,33 +311,15 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                         operatingSystemStatsProducer.stopSampling()
                     }
 
-                    // calculate percentiles
-  /*                  statistics.keys.forEach { metric in
-                        statistics[metric]?.calculateStatistics()
-                    }
-*/
                     // construct metric result array
                     var results: [BenchmarkResult] = []
                     statistics.forEach { key, value in
                         if value.measurementCount > 0 {
-                            /*
-                             var percentiles: [Statistics.Percentile: Int] = [:]
-
-                            percentiles = [.p0: value.percentileResults[0] ?? 0,
-                                           .p25: value.percentileResults[1] ?? 0,
-                                           .p50: value.percentileResults[2] ?? 0,
-                                           .p75: value.percentileResults[3] ?? 0,
-                                           .p90: value.percentileResults[4] ?? 0,
-                                           .p99: value.percentileResults[5] ?? 0,
-                                           .p100: value.percentileResults[6] ?? 0]
-*/
                             let result = BenchmarkResult(metric: key,
                                                          timeUnits: BenchmarkTimeUnits(value.timeUnits),
                                                          scalingFactor: benchmark.configuration.scalingFactor,
-//                                                         measurements: value.measurementCount,
                                                          warmupIterations: benchmark.configuration.warmupIterations,
                                                          thresholds: benchmark.configuration.thresholds?[key],
-//                                                         percentiles: percentiles,
                                                          statistics: value)
                             results.append(result)
                         }

--- a/Sources/BenchmarkSupport/BenchmarkRunner.swift
+++ b/Sources/BenchmarkSupport/BenchmarkRunner.swift
@@ -93,15 +93,15 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                     // Create metric statistics as needed
                     benchmark.configuration.metrics.forEach { metric in
                         switch metric {
-                        case .wallClock:
-                            statistics[.wallClock] = Statistics(timeUnits:
-                                StatisticsUnits(benchmark.configuration.timeUnits))
+                        case .wallClock, .cpuUser, .cpuTotal, .cpuSystem:
+                            let units = Statistics.Units(benchmark.configuration.timeUnits)
+                            statistics[metric] = Statistics(units: units)
                         default:
                             if operatingSystemStatsProducer.metricSupported(metric) == true {
-                                statistics[metric] = Statistics(timeUnits: .automatic,
-                                                                prefersLarger: metric.polarity() == .prefersLarger)
+                                statistics[metric] = Statistics(prefersLarger: metric.polarity() == .prefersLarger)
                             }
                         }
+                        
                         if mallocStatsProducerNeeded(metric) {
                             mallocStatsRequested = true
                         }
@@ -312,15 +312,16 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                     }
 
                     // calculate percentiles
-                    statistics.keys.forEach { metric in
+  /*                  statistics.keys.forEach { metric in
                         statistics[metric]?.calculateStatistics()
                     }
-
+*/
                     // construct metric result array
                     var results: [BenchmarkResult] = []
                     statistics.forEach { key, value in
                         if value.measurementCount > 0 {
-                            var percentiles: [BenchmarkResult.Percentile: Int] = [:]
+                            /*
+                             var percentiles: [Statistics.Percentile: Int] = [:]
 
                             percentiles = [.p0: value.percentileResults[0] ?? 0,
                                            .p25: value.percentileResults[1] ?? 0,
@@ -329,13 +330,14 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                                            .p90: value.percentileResults[4] ?? 0,
                                            .p99: value.percentileResults[5] ?? 0,
                                            .p100: value.percentileResults[6] ?? 0]
-
+*/
                             let result = BenchmarkResult(metric: key,
                                                          timeUnits: BenchmarkTimeUnits(value.timeUnits),
-                                                         measurements: value.measurementCount,
+                                                         scalingFactor: benchmark.configuration.scalingFactor,
+//                                                         measurements: value.measurementCount,
                                                          warmupIterations: benchmark.configuration.warmupIterations,
                                                          thresholds: benchmark.configuration.thresholds?[key],
-                                                         percentiles: percentiles,
+//                                                         percentiles: percentiles,
                                                          statistics: value)
                             results.append(result)
                         }

--- a/Sources/BenchmarkSupport/BenchmarkRunner.swift
+++ b/Sources/BenchmarkSupport/BenchmarkRunner.swift
@@ -101,7 +101,7 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                                 statistics[metric] = Statistics(prefersLarger: metric.polarity == .prefersLarger)
                             }
                         }
-                        
+
                         if mallocStatsProducerNeeded(metric) {
                             mallocStatsRequested = true
                         }
@@ -155,8 +155,8 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                             statistics[.wallClock]?.add(Int(runningTime.nanoseconds()))
 
                             var roundedThroughput =
-                            Double(1_000_000_000)
-                            / Double(runningTime.nanoseconds())
+                                Double(1_000_000_000)
+                                    / Double(runningTime.nanoseconds())
                             roundedThroughput.round(.toNearestOrAwayFromZero)
 
                             let throughput = Int(roundedThroughput)
@@ -264,7 +264,7 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                     // Run the benchmark at a minimum the desired iterations/runtime --
 
                     while iterations <= benchmark.configuration.maxIterations ||
-                            wallClockDuration <= benchmark.configuration.maxDuration {
+                        wallClockDuration <= benchmark.configuration.maxDuration {
                         // and at a maximum the same...
                         guard wallClockDuration < benchmark.configuration.maxDuration,
                               iterations < benchmark.configuration.maxIterations
@@ -283,20 +283,19 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
 
                         iterations += 1
 
-
                         if var progressBar {
                             let iterationsPercentage = 100.0 * Double(iterations) /
-                            Double(benchmark.configuration.maxIterations)
+                                Double(benchmark.configuration.maxIterations)
 
                             let timePercentage = 100.0 * (wallClockDuration /
-                                                          benchmark.configuration.maxDuration)
+                                benchmark.configuration.maxDuration)
 
                             let maxPercentage = max(iterationsPercentage, timePercentage)
 
                             if Int(maxPercentage) > nextPercentageToUpdateProgressBar {
                                 progressBar.setValue(Int(maxPercentage))
                                 fflush(stdout)
-                                nextPercentageToUpdateProgressBar = Int(maxPercentage) + Int.random(in: 3...9)
+                                nextPercentageToUpdateProgressBar = Int(maxPercentage) + Int.random(in: 3 ... 9)
                             }
                         }
                     }

--- a/Sources/Statistics/Statistics.swift
+++ b/Sources/Statistics/Statistics.swift
@@ -12,98 +12,102 @@
 import Histogram
 import Numerics
 
-public let defaultPercentilesToCalculate = [0.000001, 25.0, 50.0, 75.0, 90.0, 99.0, 100.0]
-private let numberPadding = 10
-public let defaultMaximumMeasurement = 60_000_000_000 // 1 min in nanoseconds
-
-public enum StatisticsUnits: Int, Codable {
-    case count = 1 // e.g. nanoseconds
-    case kilo = 1_000 // microseconds
-    case mega = 1_000_000 // milliseconds
-    case giga = 1_000_000_000 // seconds
-    case automatic = 0 // will pick time unit above automatically
-
-    public var description: String {
-        switch self {
-        case .count:
-            return "#"
-        case .kilo:
-            return "K"
-        case .mega:
-            return "M"
-        case .giga:
-            return "G"
-        case .automatic:
-            return "#"
-        }
-    }
-
-    init(fromMagnitudeOf value: Double) {
-        let magnitude = Double.log10(value)
-        switch magnitude {
-        case ..<4.0:
-            self = .count
-        case 4.0 ..< 7.0:
-            self = .kilo
-        case 7.0 ..< 10.0:
-            self = .mega
-        case 10.0...:
-            self = .giga
-        default:
-            self = .kilo
-        }
-    }
-}
-
 /// A type that provides distribution / percentile calculations of latency measurements
 public struct Statistics: Codable {
-    public let numberOfSignificantDigits: SignificantDigits
+    private static let numberPadding = 10
+    public static let defaultMaximumMeasurement = 100_000_000 // 1/10 second in nanoseconds
+    public static let defaultPercentilesToCalculate = [0.0, 25.0, 50.0, 75.0, 90.0, 99.0, 100.0]
+    
+    public enum Units: Int, Codable {
+        case count = 1 // e.g. nanoseconds
+        case kilo = 1_000 // microseconds
+        case mega = 1_000_000 // milliseconds
+        case giga = 1_000_000_000 // seconds
+        case automatic = 0 // will pick time unit above automatically
+
+        public var description: String {
+            switch self {
+            case .count:
+                return "#"
+            case .kilo:
+                return "K"
+            case .mega:
+                return "M"
+            case .giga:
+                return "G"
+            case .automatic:
+                return "#"
+            }
+        }
+
+        public init(fromMagnitudeOf value: Double) {
+            let magnitude = Double.log10(value)
+            switch magnitude {
+            case ..<4.0:
+                self = .count
+            case 4.0 ..< 7.0:
+                self = .kilo
+            case 7.0 ..< 10.0:
+                self = .mega
+            case 10.0...:
+                self = .giga
+            default:
+                self = .kilo
+            }
+        }
+    }
+
+
+    public func percentiles(for percentilesToCalculate: [Double] = defaultPercentilesToCalculate) -> [Int] {
+        var percentileResults: [Int] = []
+
+        for var p in percentilesToCalculate {
+            if prefersLarger {
+                p = 100.0 - p
+            }
+
+            let value = histogram.valueAtPercentile(p)
+            percentileResults.append(Int(value))
+        }
+
+        return percentileResults
+    }
+
     public let prefersLarger: Bool
+    private let _timeUnits: Statistics.Units
+    public var histogram: Histogram<UInt>
 
-    public let percentilesToCalculate: [Double] // current percentiles we calculate
-    public var percentileResults: [Int?] = []
-
-    private let _timeUnits: StatisticsUnits
-
-    public var timeUnits: StatisticsUnits {
+    public var timeUnits: Statistics.Units {
         // set timeUnits for proper scaling
         if _timeUnits != .automatic {
             return _timeUnits
         }
 
-        if onlyZeroMeasurements {
+        if histogram.countForValue(0) == histogram.totalCount {
             return .count
         }
 
-        return StatisticsUnits(fromMagnitudeOf: histogram.mean)
+        return Statistics.Units(fromMagnitudeOf: histogram.mean)
     }
-
-    public var histogram: Histogram<UInt>
-
-    public var onlyZeroMeasurements = true
 
     public var measurementCount: Int {
         Int(histogram.totalCount)
     }
 
-    public var averageMeasurement: Double {
+    public var average: Double {
         histogram.mean
     }
 
     public init(maximumMeasurement: Int = defaultMaximumMeasurement,
                 numberOfSignificantDigits: SignificantDigits = .three,
-                timeUnits: StatisticsUnits = .automatic,
-                percentiles: [Double] = defaultPercentilesToCalculate,
+                units: Statistics.Units = .automatic,
                 prefersLarger: Bool = false) {
-        self.numberOfSignificantDigits = numberOfSignificantDigits
         self.prefersLarger = prefersLarger
-        percentilesToCalculate = percentiles
-        _timeUnits = timeUnits
+        _timeUnits = units
 
-        histogram = Histogram(highestTrackableValue: UInt64(maximumMeasurement), numberOfSignificantValueDigits: numberOfSignificantDigits)
+        histogram = Histogram(highestTrackableValue: UInt64(maximumMeasurement),
+                              numberOfSignificantValueDigits: numberOfSignificantDigits)
         histogram.autoResize = true
-
-        reset()
     }
 
     /// Add a measurement for inclusion in statistics
@@ -113,57 +117,18 @@ public struct Statistics: Codable {
     public mutating func add(_ measurement: Int) {
         guard measurement >= 0 else {
             return // We sometimes got a <0 measurement, should run with fatalError and try to see how that could occur
-//            fatalError()
-        }
-
-        if measurement != 0, onlyZeroMeasurements {
-            onlyZeroMeasurements = false
+                   //            fatalError()
         }
 
         histogram.record(UInt64(measurement))
     }
 
-    /// Reset all acummulated statistics
-    public mutating func reset() {
-        histogram.reset()
-
-        onlyZeroMeasurements = true
-
-        percentileResults.removeAll(keepingCapacity: true)
-    }
-
-    /// Perform percentile calculations based on the accumulated statistics
-    public mutating func calculateStatistics() {
-        percentileResults.removeAll(keepingCapacity: true)
-        percentileResults.reserveCapacity(percentilesToCalculate.count)
-
-        let scaling = timeUnits.rawValue
-
-        for var p in percentilesToCalculate {
-            if prefersLarger {
-                p = 100.0 - p
-            }
-
-            let value = histogram.valueAtPercentile(p)
-            let scaledValue = (Double(value) / Double(scaling)).rounded(.toNearestOrAwayFromZero)
-
-            percentileResults.append(Int(scaledValue))
-        }
-    }
-
-    /// A printable text-based histogram+percentiles suitable for display in a fixed-size font
-    /// - Returns: All collected statistics
-    public mutating func output() -> String {
-        var out = ""
-        histogram.outputPercentileDistribution(to: &out, outputValueUnitScalingRatio: Double(timeUnits.rawValue))
-        return out
+    // Rounds decimals for display
+    public static func roundToDecimalplaces(_ original: Double, _ decimals: Int = 2) -> Double {
+        let factor: Double = .pow(10.0, Double(decimals))
+        var original: Double = original * factor
+        original.round(.toNearestOrEven)
+        return original / factor
     }
 }
 
-// Rounds decimals for display
-public func roundToDecimalplaces(_ original: Double, _ decimals: Int = 2) -> Double {
-    let factor: Double = .pow(10.0, Double(decimals))
-    var original: Double = original * factor
-    original.round(.toNearestOrEven)
-    return original / factor
-}

--- a/Sources/Statistics/Statistics.swift
+++ b/Sources/Statistics/Statistics.swift
@@ -56,7 +56,17 @@ public struct Statistics: Codable {
         }
     }
 
-    public func percentiles(for percentilesToCalculate: [Double] = defaultPercentilesToCalculate) -> [Int] {
+    internal var _cachedPercentiles: [Int] = []
+    internal var _cachedPercentilesHistogramCount: UInt64 = 0
+
+    public mutating func percentiles(for percentilesToCalculate: [Double] = defaultPercentilesToCalculate) -> [Int] {
+
+        if percentilesToCalculate == Self.defaultPercentilesToCalculate {
+            if _cachedPercentilesHistogramCount == histogram.totalCount && _cachedPercentiles.count > 0 {
+                return _cachedPercentiles
+            }
+        }
+
         var percentileResults: [Int] = []
 
         for var p in percentilesToCalculate {
@@ -66,6 +76,11 @@ public struct Statistics: Codable {
 
             let value = histogram.valueAtPercentile(p)
             percentileResults.append(Int(value))
+        }
+
+        if percentilesToCalculate == Self.defaultPercentilesToCalculate {
+            _cachedPercentilesHistogramCount = histogram.totalCount
+            _cachedPercentiles = percentileResults
         }
 
         return percentileResults

--- a/Sources/Statistics/Statistics.swift
+++ b/Sources/Statistics/Statistics.swift
@@ -60,9 +60,8 @@ public struct Statistics: Codable {
     internal var _cachedPercentilesHistogramCount: UInt64 = 0
 
     public mutating func percentiles(for percentilesToCalculate: [Double] = defaultPercentilesToCalculate) -> [Int] {
-
         if percentilesToCalculate == Self.defaultPercentilesToCalculate {
-            if _cachedPercentilesHistogramCount == histogram.totalCount && _cachedPercentiles.count > 0 {
+            if _cachedPercentilesHistogramCount == histogram.totalCount, _cachedPercentiles.count > 0 {
                 return _cachedPercentiles
             }
         }
@@ -90,13 +89,17 @@ public struct Statistics: Codable {
     public let timeUnits: Statistics.Units
     public var histogram: Histogram<UInt>
 
+    public var onlyZeroMeasurements: Bool {
+        histogram.countForValue(0) == histogram.totalCount
+    }
+
     // Returns the actual units to use (either specified, or automatic)
     public func units() -> Statistics.Units {
         if timeUnits != .automatic {
             return timeUnits
         }
 
-        if histogram.countForValue(0) == histogram.totalCount {
+        if onlyZeroMeasurements {
             return .count
         }
 
@@ -130,7 +133,7 @@ public struct Statistics: Codable {
     public mutating func add(_ measurement: Int) {
         guard measurement >= 0 else {
             return // We sometimes got a <0 measurement, should run with fatalError and try to see how that could occur
-                   //            fatalError()
+                //            fatalError()
         }
 
         histogram.record(UInt64(measurement))
@@ -144,4 +147,3 @@ public struct Statistics: Codable {
         return original / factor
     }
 }
-

--- a/Sources/Statistics/Statistics.swift
+++ b/Sources/Statistics/Statistics.swift
@@ -14,19 +14,8 @@ import Numerics
 
 /// A type that provides distribution / percentile calculations of latency measurements
 public struct Statistics: Codable {
-    private static let numberPadding = 10
-    public static let defaultMaximumMeasurement = 100_000_000 // 1/10 second in nanoseconds
+    public static let defaultMaximumMeasurement = 1_000_000_000 // 1 second in nanoseconds
     public static let defaultPercentilesToCalculate = [0.0, 25.0, 50.0, 75.0, 90.0, 99.0, 100.0]
-
-    public enum Percentile: Int, Codable {
-        case p0 = 0
-        case p25 = 1
-        case p50 = 2
-        case p75 = 3
-        case p90 = 4
-        case p99 = 5
-        case p100 = 6
-    }
 
     public enum Units: Int, Codable {
         case count = 1 // e.g. nanoseconds
@@ -67,7 +56,6 @@ public struct Statistics: Codable {
         }
     }
 
-
     public func percentiles(for percentilesToCalculate: [Double] = defaultPercentilesToCalculate) -> [Int] {
         var percentileResults: [Int] = []
 
@@ -84,13 +72,13 @@ public struct Statistics: Codable {
     }
 
     public let prefersLarger: Bool
-    private let _timeUnits: Statistics.Units
+    public let timeUnits: Statistics.Units
     public var histogram: Histogram<UInt>
 
-    public var timeUnits: Statistics.Units {
-        // set timeUnits for proper scaling
-        if _timeUnits != .automatic {
-            return _timeUnits
+    // Returns the actual units to use (either specified, or automatic)
+    public func units() -> Statistics.Units {
+        if timeUnits != .automatic {
+            return timeUnits
         }
 
         if histogram.countForValue(0) == histogram.totalCount {
@@ -113,7 +101,7 @@ public struct Statistics: Codable {
                 units: Statistics.Units = .automatic,
                 prefersLarger: Bool = false) {
         self.prefersLarger = prefersLarger
-        _timeUnits = units
+        timeUnits = units
 
         histogram = Histogram(highestTrackableValue: UInt64(maximumMeasurement),
                               numberOfSignificantValueDigits: numberOfSignificantDigits)

--- a/Sources/Statistics/Statistics.swift
+++ b/Sources/Statistics/Statistics.swift
@@ -17,7 +17,17 @@ public struct Statistics: Codable {
     private static let numberPadding = 10
     public static let defaultMaximumMeasurement = 100_000_000 // 1/10 second in nanoseconds
     public static let defaultPercentilesToCalculate = [0.0, 25.0, 50.0, 75.0, 90.0, 99.0, 100.0]
-    
+
+    public enum Percentile: Int, Codable {
+        case p0 = 0
+        case p25 = 1
+        case p50 = 2
+        case p75 = 3
+        case p90 = 4
+        case p99 = 5
+        case p100 = 6
+    }
+
     public enum Units: Int, Codable {
         case count = 1 // e.g. nanoseconds
         case kilo = 1_000 // microseconds

--- a/Tests/BenchmarkTests/BenchmarkMetricsTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkMetricsTests.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Joakim Hassila on 2023-03-02.
+//
+
+import Foundation

--- a/Tests/BenchmarkTests/BenchmarkMetricsTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkMetricsTests.swift
@@ -8,38 +8,64 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 ///
 
+@testable import Benchmark
 @testable import BenchmarkSupport
 import XCTest
 
 final class BenchmarkMetricsTests: XCTestCase {
-    func testBenchmarkRunner() throws {
-        let metrics: [BenchmarkMetric] = [
-            .cpuUser,
-            .cpuSystem,
-            .cpuTotal,
-            .wallClock,
-            .throughput,
-            .peakMemoryResident,
-            .peakMemoryVirtual,
-            .mallocCountSmall,
-            .mallocCountLarge,
-            .mallocCountTotal,
-            .allocatedResidentMemory,
-            .memoryLeaked,
-            .syscalls,
-            .contextSwitches,
-            .threads,
-            .threadsRunning,
-            .readSyscalls,
-            .writeSyscalls,
-            .readBytesLogical,
-            .writeBytesLogical,
-            .readBytesPhysical,
-            .writeBytesPhysical,
-            .custom("test"),
-            .custom("test2", polarity: .prefersLarger, useScalingFactor: true)
-        ]
+    private let metrics: [BenchmarkMetric] = [
+        .cpuUser,
+        .cpuSystem,
+        .cpuTotal,
+        .wallClock,
+        .throughput,
+        .peakMemoryResident,
+        .peakMemoryVirtual,
+        .mallocCountSmall,
+        .mallocCountLarge,
+        .mallocCountTotal,
+        .allocatedResidentMemory,
+        .memoryLeaked,
+        .syscalls,
+        .contextSwitches,
+        .threads,
+        .threadsRunning,
+        .readSyscalls,
+        .writeSyscalls,
+        .readBytesLogical,
+        .writeBytesLogical,
+        .readBytesPhysical,
+        .writeBytesPhysical,
+        .custom("test"),
+        .custom("test2", polarity: .prefersLarger, useScalingFactor: true)
+    ]
 
+    private let textualMetrics: [String] = [
+        "cpuUser",
+        "cpuSystem",
+        "cpuTotal",
+        "wallClock",
+        "throughput",
+        "peakMemoryResident",
+        "peakMemoryVirtual",
+        "mallocCountSmall",
+        "mallocCountLarge",
+        "mallocCountTotal",
+        "allocatedResidentMemory",
+        "memoryLeaked",
+        "syscalls",
+        "contextSwitches",
+        "threads",
+        "threadsRunning",
+        "readSyscalls",
+        "writeSyscalls",
+        "readBytesLogical",
+        "writeBytesLogical",
+        "readBytesPhysical",
+        "writeBytesPhysical"
+    ]
+
+    func testBenchmarkMetrics() throws {
         var description = ""
         var rawValues = 0
         metrics.forEach { metric in
@@ -50,6 +76,18 @@ final class BenchmarkMetricsTests: XCTestCase {
         }
 
         XCTAssert(rawValues > 10)
+        XCTAssert(description.count > 10)
+    }
+
+    func testBenchmarkTextualMetrics() throws {
+        var description = ""
+
+        for metricIndex in 0 ..< textualMetrics.count {
+            let metric = BenchmarkMetric(textualMetrics[metricIndex])
+            description += metric.description
+            XCTAssertEqual(metrics[metricIndex], metric)
+        }
+
         XCTAssert(description.count > 10)
     }
 }

--- a/Tests/BenchmarkTests/BenchmarkMetricsTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkMetricsTests.swift
@@ -1,8 +1,55 @@
 //
-//  File.swift
-//  
+// Copyright (c) 2023 Ordo One AB.
 //
-//  Created by Joakim Hassila on 2023-03-02.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
 //
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+///
 
-import Foundation
+@testable import BenchmarkSupport
+import XCTest
+
+final class BenchmarkMetricsTests: XCTestCase {
+    func testBenchmarkRunner() throws {
+        let metrics: [BenchmarkMetric] = [
+            .cpuUser,
+            .cpuSystem,
+            .cpuTotal,
+            .wallClock,
+            .throughput,
+            .peakMemoryResident,
+            .peakMemoryVirtual,
+            .mallocCountSmall,
+            .mallocCountLarge,
+            .mallocCountTotal,
+            .allocatedResidentMemory,
+            .memoryLeaked,
+            .syscalls,
+            .contextSwitches,
+            .threads,
+            .threadsRunning,
+            .readSyscalls,
+            .writeSyscalls,
+            .readBytesLogical,
+            .writeBytesLogical,
+            .readBytesPhysical,
+            .writeBytesPhysical,
+            .custom("test"),
+            .custom("test2", polarity: .prefersLarger, useScalingFactor: true)
+        ]
+
+        var description = ""
+        var rawValues = 0
+        metrics.forEach { metric in
+            description += metric.description
+            rawValues += metric.useScalingFactor ? 0 : 1
+            rawValues += metric.countable ? 0 : 1
+            rawValues += metric.polarity == .prefersLarger ? 0 : 1
+        }
+
+        XCTAssert(rawValues > 10)
+        XCTAssert(description.count > 10)
+    }
+}

--- a/Tests/BenchmarkTests/BenchmarkResultTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkResultTests.swift
@@ -13,79 +13,40 @@ import XCTest
 
 // swiftlint:disable function_body_length
 final class BenchmarkResultTests: XCTestCase {
-    func testBenchmarkResultEquality() throws {
-        let measurementCount = 100
-        let firstPercentiles: [BenchmarkResult.Percentile: Int] = [.p0: 0,
-                                                                   .p25: 125,
-                                                                   .p50: 150,
-                                                                   .p75: 175,
-                                                                   .p90: 190,
-                                                                   .p99: 199,
-                                                                   .p100: 200]
-
-        let secondPercentiles: [BenchmarkResult.Percentile: Int] = [.p0: 0,
-                                                                    .p25: 125_000,
-                                                                    .p50: 150_000,
-                                                                    .p75: 175_000,
-                                                                    .p90: 190_000,
-                                                                    .p99: 199_000,
-                                                                    .p100: 200_000]
-
-        let firstResult = BenchmarkResult(metric: .cpuUser,
-                                          timeUnits: .milliseconds,
-                                          measurements: measurementCount,
-                                          warmupIterations: 0,
-                                          thresholds: .default,
-                                          percentiles: firstPercentiles)
-
-        let secondResult = BenchmarkResult(metric: .cpuUser,
-                                           timeUnits: .microseconds,
-                                           measurements: measurementCount,
-                                           warmupIterations: 0,
-                                           thresholds: .default,
-                                           percentiles: secondPercentiles)
-
-        XCTAssertEqual(firstResult, secondResult)
-    }
 
     func testBenchmarkResultLessThan() throws {
-        let measurementCount = 100
-        let firstPercentiles: [BenchmarkResult.Percentile: Int] = [.p0: 0,
-                                                                   .p25: 125,
-                                                                   .p50: 150,
-                                                                   .p75: 175,
-                                                                   .p90: 190,
-                                                                   .p99: 199,
-                                                                   .p100: 200]
 
-        let secondPercentiles: [BenchmarkResult.Percentile: Int] = [.p0: 0,
-                                                                    .p25: 125_000,
-                                                                    .p50: 150_000,
-                                                                    .p75: 175_000,
-                                                                    .p90: 190_000,
-                                                                    .p99: 199_001,
-                                                                    .p100: 200_000]
+        var firstStatistics = Statistics()
+        firstStatistics.add(125)
+        firstStatistics.add(150)
+        firstStatistics.add(175)
+        firstStatistics.add(190)
+
+        var secondStatistics = Statistics()
+        secondStatistics.add(125)
+        secondStatistics.add(151)
+        secondStatistics.add(175)
 
         let firstResult = BenchmarkResult(metric: .cpuUser,
                                           timeUnits: .milliseconds,
-                                          measurements: measurementCount,
+                                          scalingFactor: .none,
                                           warmupIterations: 0,
                                           thresholds: .default,
-                                          percentiles: firstPercentiles)
+                                          statistics: firstStatistics)
 
         let secondResult = BenchmarkResult(metric: .cpuUser,
                                            timeUnits: .microseconds,
-                                           measurements: measurementCount,
+                                           scalingFactor: .none,
                                            warmupIterations: 0,
                                            thresholds: .default,
-                                           percentiles: secondPercentiles)
+                                           statistics: secondStatistics)
 
         XCTAssertLessThan(firstResult, secondResult)
     }
-
+/*
     func testBenchmarkResultLessThanFailure() throws {
         let measurementCount = 100
-        let firstPercentiles: [BenchmarkResult.Percentile: Int] = [.p0: 0,
+        let firstPercentiles: [Statistics.Percentile: Int] = [.p0: 0,
                                                                    .p25: 125,
                                                                    .p50: 150,
                                                                    .p75: 175,
@@ -95,6 +56,7 @@ final class BenchmarkResultTests: XCTestCase {
 
         let firstResult = BenchmarkResult(metric: .cpuUser,
                                           timeUnits: .microseconds,
+                                          scalingFactor: .none,
                                           measurements: measurementCount,
                                           warmupIterations: 0,
                                           thresholds: .default,
@@ -102,6 +64,7 @@ final class BenchmarkResultTests: XCTestCase {
 
         let secondResult = BenchmarkResult(metric: .cpuSystem,
                                            timeUnits: .microseconds,
+                                           scalingFactor: .none,
                                            measurements: measurementCount,
                                            warmupIterations: 0,
                                            thresholds: .default,
@@ -115,7 +78,7 @@ final class BenchmarkResultTests: XCTestCase {
 
     func testBenchmarkResultBetterOrEqualWithDefaultThresholds() throws {
         let measurementCount = 100
-        let firstPercentiles: [BenchmarkResult.Percentile: Int] = [.p0: 0,
+        let firstPercentiles: [Statistics.Percentile: Int] = [.p0: 0,
                                                                    .p25: 125,
                                                                    .p50: 150,
                                                                    .p75: 175,
@@ -123,7 +86,7 @@ final class BenchmarkResultTests: XCTestCase {
                                                                    .p99: 199,
                                                                    .p100: 200]
 
-        let secondPercentiles: [BenchmarkResult.Percentile: Int] = [.p0: 2,
+        let secondPercentiles: [Statistics.Percentile: Int] = [.p0: 2,
                                                                     .p25: 124_999,
                                                                     .p50: 149_999,
                                                                     .p75: 175_001,
@@ -133,6 +96,7 @@ final class BenchmarkResultTests: XCTestCase {
 
         let firstResult = BenchmarkResult(metric: .cpuUser,
                                           timeUnits: .milliseconds,
+                                          scalingFactor: .none,
                                           measurements: measurementCount,
                                           warmupIterations: 0,
                                           thresholds: .default,
@@ -140,6 +104,7 @@ final class BenchmarkResultTests: XCTestCase {
 
         let secondResult = BenchmarkResult(metric: .cpuUser,
                                            timeUnits: .microseconds,
+                                           scalingFactor: .none,
                                            measurements: measurementCount,
                                            warmupIterations: 0,
                                            thresholds: .default,
@@ -150,7 +115,7 @@ final class BenchmarkResultTests: XCTestCase {
 
     func testBenchmarkResultBetterOrEqualWithCustomThresholds() throws {
         let measurementCount = 100
-        let firstPercentiles: [BenchmarkResult.Percentile: Int] = [.p0: 0,
+        let firstPercentiles: [Statistics.Percentile: Int] = [.p0: 0,
                                                                    .p25: 125,
                                                                    .p50: 150,
                                                                    .p75: 175,
@@ -158,7 +123,7 @@ final class BenchmarkResultTests: XCTestCase {
                                                                    .p99: 199,
                                                                    .p100: 200]
 
-        let secondPercentiles: [BenchmarkResult.Percentile: Int] = [.p0: 0,
+        let secondPercentiles: [Statistics.Percentile: Int] = [.p0: 0,
                                                                     .p25: 126,
                                                                     .p50: 160,
                                                                     .p75: 175,
@@ -196,6 +161,7 @@ final class BenchmarkResultTests: XCTestCase {
 
         let firstResult = BenchmarkResult(metric: .cpuUser,
                                           timeUnits: .microseconds,
+                                          scalingFactor: .none,
                                           measurements: measurementCount,
                                           warmupIterations: 0,
                                           thresholds: .default,
@@ -203,6 +169,7 @@ final class BenchmarkResultTests: XCTestCase {
 
         let secondResult = BenchmarkResult(metric: .cpuUser,
                                            timeUnits: .microseconds,
+                                           scalingFactor: .none,
                                            measurements: measurementCount,
                                            warmupIterations: 0,
                                            thresholds: .default,
@@ -221,7 +188,7 @@ final class BenchmarkResultTests: XCTestCase {
 
     func testBenchmarkResultDescriptions() throws {
         let measurementCount = 100
-        let firstPercentiles: [BenchmarkResult.Percentile: Int] = [.p0: 0,
+        let firstPercentiles: [Statistics.Percentile: Int] = [.p0: 0,
                                                                    .p25: 125,
                                                                    .p50: 150,
                                                                    .p75: 175,
@@ -231,6 +198,7 @@ final class BenchmarkResultTests: XCTestCase {
 
         let firstResult = BenchmarkResult(metric: .cpuUser,
                                           timeUnits: .milliseconds,
+                                          scalingFactor: .none,
                                           measurements: measurementCount,
                                           warmupIterations: 0,
                                           thresholds: .default,
@@ -238,4 +206,5 @@ final class BenchmarkResultTests: XCTestCase {
 
         XCTAssertGreaterThan((firstResult.unitDescription + firstResult.unitDescriptionPretty).count, 5)
     }
+ */
 }

--- a/Tests/BenchmarkTests/BenchmarkResultTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkResultTests.swift
@@ -13,6 +13,30 @@ import XCTest
 
 // swiftlint:disable function_body_length
 final class BenchmarkResultTests: XCTestCase {
+    func testBenchmarkResultEqual() throws {
+        let firstStatistics = Statistics()
+        firstStatistics.add(125_000_000_000)
+        firstStatistics.add(150_000_000_000)
+        firstStatistics.add(175_000_000_000)
+        firstStatistics.add(190_000_000_000)
+
+        let firstResult = BenchmarkResult(metric: .cpuUser,
+                                          timeUnits: .nanoseconds,
+                                          scalingFactor: .one,
+                                          warmupIterations: 0,
+                                          thresholds: .default,
+                                          statistics: firstStatistics)
+
+        let secondResult = BenchmarkResult(metric: .cpuUser,
+                                           timeUnits: .nanoseconds,
+                                           scalingFactor: .giga,
+                                           warmupIterations: 20,
+                                           thresholds: .default,
+                                           statistics: firstStatistics)
+
+        XCTAssertEqual(firstResult, secondResult)
+    }
+
     func testBenchmarkResultLessThan() throws {
         let firstStatistics = Statistics()
         firstStatistics.add(125_000_000_000)
@@ -25,6 +49,11 @@ final class BenchmarkResultTests: XCTestCase {
         secondStatistics.add(151_000_000_000)
         secondStatistics.add(175_000_000_000)
 
+        let thirdStatistics = Statistics()
+        thirdStatistics.add(225_000_000_000)
+        thirdStatistics.add(251_000_000_000)
+        thirdStatistics.add(275_000_000_000)
+
         let firstResult = BenchmarkResult(metric: .cpuUser,
                                           timeUnits: .nanoseconds,
                                           scalingFactor: .one,
@@ -32,14 +61,39 @@ final class BenchmarkResultTests: XCTestCase {
                                           thresholds: .default,
                                           statistics: firstStatistics)
 
-        let secondResult = BenchmarkResult(metric: .cpuUser,
+        var secondResult = BenchmarkResult(metric: .cpuUser,
                                            timeUnits: .microseconds,
                                            scalingFactor: .one,
                                            warmupIterations: 0,
                                            thresholds: .default,
                                            statistics: secondStatistics)
 
+        var thirdResult = BenchmarkResult(metric: .cpuUser,
+                                          timeUnits: .microseconds,
+                                          scalingFactor: .one,
+                                          warmupIterations: 0,
+                                          thresholds: .default,
+                                          statistics: thirdStatistics)
+
         XCTAssertLessThan(firstResult, secondResult)
+        XCTAssertGreaterThan(thirdResult, secondResult)
+
+        secondResult = BenchmarkResult(metric: .throughput,
+                                       timeUnits: .microseconds,
+                                       scalingFactor: .one,
+                                       warmupIterations: 0,
+                                       thresholds: .default,
+                                       statistics: secondStatistics)
+
+        thirdResult = BenchmarkResult(metric: .throughput,
+                                      timeUnits: .microseconds,
+                                      scalingFactor: .one,
+                                      warmupIterations: 0,
+                                      thresholds: .default,
+                                      statistics: thirdStatistics)
+
+        // Should be reversed for throughput measurements
+        XCTAssertLessThan(thirdResult, secondResult)
     }
 
     func testBenchmarkResultLessThanFailure() throws {

--- a/Tests/BenchmarkTests/BenchmarkResultTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkResultTests.swift
@@ -243,6 +243,6 @@ final class BenchmarkResultTests: XCTestCase {
         description += scalingFactor.description
         scalingFactor = .tera
         description += scalingFactor.description
-        XCTAssert(description.count > 10)
+        XCTAssert(description.count > 4)
     }
 }

--- a/Tests/BenchmarkTests/BenchmarkResultTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkResultTests.swift
@@ -14,13 +14,13 @@ import XCTest
 // swiftlint:disable function_body_length
 final class BenchmarkResultTests: XCTestCase {
     func testBenchmarkResultLessThan() throws {
-        var firstStatistics = Statistics()
+        let firstStatistics = Statistics()
         firstStatistics.add(125_000_000_000)
         firstStatistics.add(150_000_000_000)
         firstStatistics.add(175_000_000_000)
         firstStatistics.add(190_000_000_000)
 
-        var secondStatistics = Statistics()
+        let secondStatistics = Statistics()
         secondStatistics.add(125_000_000_000)
         secondStatistics.add(151_000_000_000)
         secondStatistics.add(175_000_000_000)
@@ -43,7 +43,7 @@ final class BenchmarkResultTests: XCTestCase {
     }
 
     func testBenchmarkResultLessThanFailure() throws {
-        var firstStatistics = Statistics()
+        let firstStatistics = Statistics()
         firstStatistics.add(125_000_000_000)
         firstStatistics.add(150_000_000_000)
         firstStatistics.add(175_000_000_000)
@@ -72,7 +72,7 @@ final class BenchmarkResultTests: XCTestCase {
     }
 
     func testBenchmarkResultBetterOrEqualWithDefaultThresholds() throws {
-        var firstStatistics = Statistics()
+        let firstStatistics = Statistics()
         firstStatistics.add(0)
         firstStatistics.add(125_000_000)
         firstStatistics.add(150_000_000)
@@ -81,7 +81,7 @@ final class BenchmarkResultTests: XCTestCase {
         firstStatistics.add(199_000_000)
         firstStatistics.add(200_000_000)
 
-        var secondStatistics = Statistics()
+        let secondStatistics = Statistics()
         secondStatistics.add(2)
         secondStatistics.add(124_999)
         secondStatistics.add(149_999)
@@ -108,7 +108,7 @@ final class BenchmarkResultTests: XCTestCase {
     }
 
     func testBenchmarkResultBetterOrEqualWithCustomThresholds() throws {
-        var firstStatistics = Statistics()
+        let firstStatistics = Statistics()
         firstStatistics.add(0)
         firstStatistics.add(125)
         firstStatistics.add(150)
@@ -117,7 +117,7 @@ final class BenchmarkResultTests: XCTestCase {
         firstStatistics.add(199)
         firstStatistics.add(200)
 
-        var secondStatistics = Statistics()
+        let secondStatistics = Statistics()
         secondStatistics.add(0)
         secondStatistics.add(126)
         secondStatistics.add(160)
@@ -180,7 +180,7 @@ final class BenchmarkResultTests: XCTestCase {
     }
 
     func testBenchmarkResultDescriptions() throws {
-        var firstStatistics = Statistics()
+        let firstStatistics = Statistics()
         firstStatistics.add(0)
         firstStatistics.add(125)
         firstStatistics.add(150)

--- a/Tests/BenchmarkTests/BenchmarkResultTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkResultTests.swift
@@ -198,4 +198,38 @@ final class BenchmarkResultTests: XCTestCase {
 
         XCTAssertGreaterThan((firstResult.unitDescription + firstResult.unitDescriptionPretty).count, 5)
     }
+
+    func testBenchmarkResultScalingAndNormalization() throws {
+        let firstStatistics = Statistics()
+        firstStatistics.add(125_000_000_000)
+
+        var result = BenchmarkResult(metric: .cpuUser,
+                                          timeUnits: .milliseconds,
+                                          scalingFactor: .giga,
+                                          warmupIterations: 0,
+                                          thresholds: .default,
+                                          statistics: firstStatistics)
+
+        XCTAssert(result.normalize(125_000_000) == result.scale(125_000_000_000))
+
+        result = BenchmarkResult(metric: .cpuUser,
+                                 timeUnits: .microseconds,
+                                 scalingFactor: .mega,
+                                 warmupIterations: 0,
+                                 thresholds: .default,
+                                 statistics: firstStatistics)
+
+        XCTAssert(result.normalize(125_000_000) == result.scale(125_000_000_000))
+
+        result = BenchmarkResult(metric: .cpuUser,
+                                 timeUnits: .nanoseconds,
+                                 scalingFactor: .kilo,
+                                 warmupIterations: 0,
+                                 thresholds: .default,
+                                 statistics: firstStatistics)
+
+        XCTAssert(result.normalize(125_000_000) == result.scale(125_000_000_000))
+
+    }
+
 }

--- a/Tests/BenchmarkTests/BenchmarkResultTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkResultTests.swift
@@ -232,4 +232,18 @@ final class BenchmarkResultTests: XCTestCase {
 
     }
 
+    func testBenchmarkResultEnumerations() throws {
+        var scalingFactor: BenchmarkScalingFactor = .one
+        var description: String = ""
+        description += scalingFactor.description
+        scalingFactor = .kilo
+        description += scalingFactor.description
+        scalingFactor = .mega
+        description += scalingFactor.description
+        scalingFactor = .giga
+        description += scalingFactor.description
+        scalingFactor = .tera
+        description += scalingFactor.description
+        XCTAssert(description.count > 10)
+    }
 }

--- a/Tests/BenchmarkTests/BenchmarkResultTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkResultTests.swift
@@ -204,11 +204,11 @@ final class BenchmarkResultTests: XCTestCase {
         firstStatistics.add(125_000_000_000)
 
         var result = BenchmarkResult(metric: .cpuUser,
-                                          timeUnits: .milliseconds,
-                                          scalingFactor: .giga,
-                                          warmupIterations: 0,
-                                          thresholds: .default,
-                                          statistics: firstStatistics)
+                                     timeUnits: .milliseconds,
+                                     scalingFactor: .giga,
+                                     warmupIterations: 0,
+                                     thresholds: .default,
+                                     statistics: firstStatistics)
 
         XCTAssert(result.normalize(125_000_000) == result.scale(125_000_000_000))
 
@@ -229,12 +229,11 @@ final class BenchmarkResultTests: XCTestCase {
                                  statistics: firstStatistics)
 
         XCTAssert(result.normalize(125_000_000) == result.scale(125_000_000_000))
-
     }
 
     func testBenchmarkResultEnumerations() throws {
         var scalingFactor: BenchmarkScalingFactor = .one
-        var description: String = ""
+        var description = ""
         description += scalingFactor.description
         scalingFactor = .kilo
         description += scalingFactor.description

--- a/Tests/BenchmarkTests/BenchmarkResultTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkResultTests.swift
@@ -13,19 +13,82 @@ import XCTest
 
 // swiftlint:disable function_body_length
 final class BenchmarkResultTests: XCTestCase {
-
     func testBenchmarkResultLessThan() throws {
-
         var firstStatistics = Statistics()
+        firstStatistics.add(125_000_000_000)
+        firstStatistics.add(150_000_000_000)
+        firstStatistics.add(175_000_000_000)
+        firstStatistics.add(190_000_000_000)
+
+        var secondStatistics = Statistics()
+        secondStatistics.add(125_000_000_000)
+        secondStatistics.add(151_000_000_000)
+        secondStatistics.add(175_000_000_000)
+
+        let firstResult = BenchmarkResult(metric: .cpuUser,
+                                          timeUnits: .nanoseconds,
+                                          scalingFactor: .none,
+                                          warmupIterations: 0,
+                                          thresholds: .default,
+                                          statistics: firstStatistics)
+
+        let secondResult = BenchmarkResult(metric: .cpuUser,
+                                           timeUnits: .microseconds,
+                                           scalingFactor: .none,
+                                           warmupIterations: 0,
+                                           thresholds: .default,
+                                           statistics: secondStatistics)
+
+        XCTAssertLessThan(firstResult, secondResult)
+    }
+
+    func testBenchmarkResultLessThanFailure() throws {
+        var firstStatistics = Statistics()
+        firstStatistics.add(125_000_000_000)
+        firstStatistics.add(150_000_000_000)
+        firstStatistics.add(175_000_000_000)
+        firstStatistics.add(190_000_000_000)
+        firstStatistics.add(198_000_000_000)
+        firstStatistics.add(200_000_000_000)
+
+        let firstResult = BenchmarkResult(metric: .cpuUser,
+                                          timeUnits: .microseconds,
+                                          scalingFactor: .none,
+                                          warmupIterations: 0,
+                                          thresholds: .default,
+                                          statistics: firstStatistics)
+
+        let secondResult = BenchmarkResult(metric: .cpuSystem,
+                                           timeUnits: .microseconds,
+                                           scalingFactor: .none,
+                                           warmupIterations: 0,
+                                           thresholds: .default,
+                                           statistics: firstStatistics)
+
+        XCTAssert(firstResult != secondResult)
+        XCTAssertFalse(firstResult > secondResult)
+        XCTAssertFalse(firstResult < secondResult)
+        XCTAssertFalse(firstResult == secondResult)
+    }
+
+    func testBenchmarkResultBetterOrEqualWithDefaultThresholds() throws {
+        var firstStatistics = Statistics()
+        firstStatistics.add(0)
         firstStatistics.add(125)
         firstStatistics.add(150)
         firstStatistics.add(175)
         firstStatistics.add(190)
+        firstStatistics.add(199)
+        firstStatistics.add(200)
 
         var secondStatistics = Statistics()
-        secondStatistics.add(125)
-        secondStatistics.add(151)
-        secondStatistics.add(175)
+        secondStatistics.add(2)
+        secondStatistics.add(124_999)
+        secondStatistics.add(149_999)
+        secondStatistics.add(175_001)
+        secondStatistics.add(189_999)
+        secondStatistics.add(199_001)
+        secondStatistics.add(200_004)
 
         let firstResult = BenchmarkResult(metric: .cpuUser,
                                           timeUnits: .milliseconds,
@@ -41,95 +104,27 @@ final class BenchmarkResultTests: XCTestCase {
                                            thresholds: .default,
                                            statistics: secondStatistics)
 
-        XCTAssertLessThan(firstResult, secondResult)
-    }
-/*
-    func testBenchmarkResultLessThanFailure() throws {
-        let measurementCount = 100
-        let firstPercentiles: [Statistics.Percentile: Int] = [.p0: 0,
-                                                                   .p25: 125,
-                                                                   .p50: 150,
-                                                                   .p75: 175,
-                                                                   .p90: 190,
-                                                                   .p99: 199,
-                                                                   .p100: 200]
-
-        let firstResult = BenchmarkResult(metric: .cpuUser,
-                                          timeUnits: .microseconds,
-                                          scalingFactor: .none,
-                                          measurements: measurementCount,
-                                          warmupIterations: 0,
-                                          thresholds: .default,
-                                          percentiles: firstPercentiles)
-
-        let secondResult = BenchmarkResult(metric: .cpuSystem,
-                                           timeUnits: .microseconds,
-                                           scalingFactor: .none,
-                                           measurements: measurementCount,
-                                           warmupIterations: 0,
-                                           thresholds: .default,
-                                           percentiles: firstPercentiles)
-
-        XCTAssert(firstResult != secondResult)
-        XCTAssertFalse(firstResult > secondResult)
-        XCTAssertFalse(firstResult < secondResult)
-        XCTAssertFalse(firstResult == secondResult)
-    }
-
-    func testBenchmarkResultBetterOrEqualWithDefaultThresholds() throws {
-        let measurementCount = 100
-        let firstPercentiles: [Statistics.Percentile: Int] = [.p0: 0,
-                                                                   .p25: 125,
-                                                                   .p50: 150,
-                                                                   .p75: 175,
-                                                                   .p90: 190,
-                                                                   .p99: 199,
-                                                                   .p100: 200]
-
-        let secondPercentiles: [Statistics.Percentile: Int] = [.p0: 2,
-                                                                    .p25: 124_999,
-                                                                    .p50: 149_999,
-                                                                    .p75: 175_001,
-                                                                    .p90: 189_999,
-                                                                    .p99: 199_001,
-                                                                    .p100: 200_004]
-
-        let firstResult = BenchmarkResult(metric: .cpuUser,
-                                          timeUnits: .milliseconds,
-                                          scalingFactor: .none,
-                                          measurements: measurementCount,
-                                          warmupIterations: 0,
-                                          thresholds: .default,
-                                          percentiles: firstPercentiles)
-
-        let secondResult = BenchmarkResult(metric: .cpuUser,
-                                           timeUnits: .microseconds,
-                                           scalingFactor: .none,
-                                           measurements: measurementCount,
-                                           warmupIterations: 0,
-                                           thresholds: .default,
-                                           percentiles: secondPercentiles)
-
         XCTAssert(secondResult.betterResultsOrEqual(than: firstResult))
     }
 
     func testBenchmarkResultBetterOrEqualWithCustomThresholds() throws {
-        let measurementCount = 100
-        let firstPercentiles: [Statistics.Percentile: Int] = [.p0: 0,
-                                                                   .p25: 125,
-                                                                   .p50: 150,
-                                                                   .p75: 175,
-                                                                   .p90: 190,
-                                                                   .p99: 199,
-                                                                   .p100: 200]
+        var firstStatistics = Statistics()
+        firstStatistics.add(0)
+        firstStatistics.add(125)
+        firstStatistics.add(150)
+        firstStatistics.add(175)
+        firstStatistics.add(190)
+        firstStatistics.add(199)
+        firstStatistics.add(200)
 
-        let secondPercentiles: [Statistics.Percentile: Int] = [.p0: 0,
-                                                                    .p25: 126,
-                                                                    .p50: 160,
-                                                                    .p75: 175,
-                                                                    .p90: 190,
-                                                                    .p99: 199,
-                                                                    .p100: 200]
+        var secondStatistics = Statistics()
+        secondStatistics.add(0)
+        secondStatistics.add(126)
+        secondStatistics.add(160)
+        secondStatistics.add(175)
+        secondStatistics.add(190)
+        secondStatistics.add(199)
+        secondStatistics.add(200)
 
         let relative: BenchmarkResult.PercentileRelativeThresholds = [.p0: 0.0,
                                                                       .p25: 0.0,
@@ -160,20 +155,18 @@ final class BenchmarkResultTests: XCTestCase {
         let relativeRelaxedThresholds = BenchmarkResult.PercentileThresholds(relative: relativeRelaxed)
 
         let firstResult = BenchmarkResult(metric: .cpuUser,
-                                          timeUnits: .microseconds,
+                                          timeUnits: .nanoseconds,
                                           scalingFactor: .none,
-                                          measurements: measurementCount,
                                           warmupIterations: 0,
                                           thresholds: .default,
-                                          percentiles: firstPercentiles)
+                                          statistics: firstStatistics)
 
         let secondResult = BenchmarkResult(metric: .cpuUser,
-                                           timeUnits: .microseconds,
+                                           timeUnits: .nanoseconds,
                                            scalingFactor: .none,
-                                           measurements: measurementCount,
                                            warmupIterations: 0,
                                            thresholds: .default,
-                                           percentiles: secondPercentiles)
+                                           statistics: secondStatistics)
 
         XCTAssertFalse(secondResult.betterResultsOrEqual(than: firstResult, thresholds: bothThresholds))
         XCTAssert(secondResult.betterResultsOrEqual(than: firstResult, thresholds: relativeRelaxedThresholds))
@@ -187,24 +180,22 @@ final class BenchmarkResultTests: XCTestCase {
     }
 
     func testBenchmarkResultDescriptions() throws {
-        let measurementCount = 100
-        let firstPercentiles: [Statistics.Percentile: Int] = [.p0: 0,
-                                                                   .p25: 125,
-                                                                   .p50: 150,
-                                                                   .p75: 175,
-                                                                   .p90: 190,
-                                                                   .p99: 199,
-                                                                   .p100: 200]
+        var firstStatistics = Statistics()
+        firstStatistics.add(0)
+        firstStatistics.add(125)
+        firstStatistics.add(150)
+        firstStatistics.add(175)
+        firstStatistics.add(190)
+        firstStatistics.add(199)
+        firstStatistics.add(200)
 
         let firstResult = BenchmarkResult(metric: .cpuUser,
-                                          timeUnits: .milliseconds,
+                                          timeUnits: .nanoseconds,
                                           scalingFactor: .none,
-                                          measurements: measurementCount,
                                           warmupIterations: 0,
                                           thresholds: .default,
-                                          percentiles: firstPercentiles)
+                                          statistics: firstStatistics)
 
         XCTAssertGreaterThan((firstResult.unitDescription + firstResult.unitDescriptionPretty).count, 5)
     }
- */
 }

--- a/Tests/BenchmarkTests/BenchmarkResultTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkResultTests.swift
@@ -27,14 +27,14 @@ final class BenchmarkResultTests: XCTestCase {
 
         let firstResult = BenchmarkResult(metric: .cpuUser,
                                           timeUnits: .nanoseconds,
-                                          scalingFactor: .none,
+                                          scalingFactor: .one,
                                           warmupIterations: 0,
                                           thresholds: .default,
                                           statistics: firstStatistics)
 
         let secondResult = BenchmarkResult(metric: .cpuUser,
                                            timeUnits: .microseconds,
-                                           scalingFactor: .none,
+                                           scalingFactor: .one,
                                            warmupIterations: 0,
                                            thresholds: .default,
                                            statistics: secondStatistics)
@@ -53,14 +53,14 @@ final class BenchmarkResultTests: XCTestCase {
 
         let firstResult = BenchmarkResult(metric: .cpuUser,
                                           timeUnits: .microseconds,
-                                          scalingFactor: .none,
+                                          scalingFactor: .one,
                                           warmupIterations: 0,
                                           thresholds: .default,
                                           statistics: firstStatistics)
 
         let secondResult = BenchmarkResult(metric: .cpuSystem,
                                            timeUnits: .microseconds,
-                                           scalingFactor: .none,
+                                           scalingFactor: .one,
                                            warmupIterations: 0,
                                            thresholds: .default,
                                            statistics: firstStatistics)
@@ -92,14 +92,14 @@ final class BenchmarkResultTests: XCTestCase {
 
         let firstResult = BenchmarkResult(metric: .cpuUser,
                                           timeUnits: .milliseconds,
-                                          scalingFactor: .none,
+                                          scalingFactor: .one,
                                           warmupIterations: 0,
                                           thresholds: .default,
                                           statistics: firstStatistics)
 
         let secondResult = BenchmarkResult(metric: .cpuUser,
                                            timeUnits: .microseconds,
-                                           scalingFactor: .none,
+                                           scalingFactor: .one,
                                            warmupIterations: 0,
                                            thresholds: .default,
                                            statistics: secondStatistics)
@@ -156,14 +156,14 @@ final class BenchmarkResultTests: XCTestCase {
 
         let firstResult = BenchmarkResult(metric: .cpuUser,
                                           timeUnits: .nanoseconds,
-                                          scalingFactor: .none,
+                                          scalingFactor: .one,
                                           warmupIterations: 0,
                                           thresholds: .default,
                                           statistics: firstStatistics)
 
         let secondResult = BenchmarkResult(metric: .cpuUser,
                                            timeUnits: .nanoseconds,
-                                           scalingFactor: .none,
+                                           scalingFactor: .one,
                                            warmupIterations: 0,
                                            thresholds: .default,
                                            statistics: secondStatistics)
@@ -191,7 +191,7 @@ final class BenchmarkResultTests: XCTestCase {
 
         let firstResult = BenchmarkResult(metric: .cpuUser,
                                           timeUnits: .nanoseconds,
-                                          scalingFactor: .none,
+                                          scalingFactor: .one,
                                           warmupIterations: 0,
                                           thresholds: .default,
                                           statistics: firstStatistics)

--- a/Tests/BenchmarkTests/BenchmarkResultTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkResultTests.swift
@@ -74,12 +74,12 @@ final class BenchmarkResultTests: XCTestCase {
     func testBenchmarkResultBetterOrEqualWithDefaultThresholds() throws {
         var firstStatistics = Statistics()
         firstStatistics.add(0)
-        firstStatistics.add(125)
-        firstStatistics.add(150)
-        firstStatistics.add(175)
-        firstStatistics.add(190)
-        firstStatistics.add(199)
-        firstStatistics.add(200)
+        firstStatistics.add(125_000_000)
+        firstStatistics.add(150_000_000)
+        firstStatistics.add(175_000_000)
+        firstStatistics.add(190_000_000)
+        firstStatistics.add(199_000_000)
+        firstStatistics.add(200_000_000)
 
         var secondStatistics = Statistics()
         secondStatistics.add(2)

--- a/Tests/BenchmarkTests/BenchmarkTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkTests.swift
@@ -65,9 +65,9 @@ final class BenchmarkTests: XCTestCase {
                                       metrics: BenchmarkMetric.all,
                                       timeUnits: .milliseconds,
                                       warmupIterations: 0,
-                                      throughputScalingFactor: .mega
+                                      scalingFactor: .mega
                                   )) { benchmark in
-            for outerloop in benchmark.throughputIterations {
+            for outerloop in benchmark.scaledIterations {
                 blackHole(outerloop)
             }
         }

--- a/Tests/BenchmarkTests/StatisticsTests.swift
+++ b/Tests/BenchmarkTests/StatisticsTests.swift
@@ -14,7 +14,7 @@ import XCTest
 
 final class StatisticsTests: XCTestCase {
     func testStatisticsResults() throws {
-        var stats = Statistics(numberOfSignificantDigits: .four)
+        let stats = Statistics(numberOfSignificantDigits: .four)
         let measurementCount = 8_340
 
         // Add 2*measurementCount measurements, one 0, one max
@@ -42,7 +42,7 @@ final class StatisticsTests: XCTestCase {
     }
 
     func testOnlyZeroMeasurements() throws {
-        var stats = Statistics()
+        let stats = Statistics()
         let measurementCount = 100
         let range = 0 ..< measurementCount
 
@@ -69,7 +69,7 @@ final class StatisticsTests: XCTestCase {
     }
 
     func testFewerMeasurementsThanPercentiles() throws {
-        var stats = Statistics()
+        let stats = Statistics()
         let measurementCount = 5
         let range = 1 ..< measurementCount
         var accumulatedMeasurement = 0
@@ -118,7 +118,7 @@ final class StatisticsTests: XCTestCase {
 
     func testHistograms() throws {
         let measurementCount = 300
-        var stats = Statistics(prefersLarger: true)
+        let stats = Statistics(prefersLarger: true)
 
         for measurement in 1 ... measurementCount {
             stats.add(measurement)

--- a/Tests/BenchmarkTests/StatisticsTests.swift
+++ b/Tests/BenchmarkTests/StatisticsTests.swift
@@ -11,7 +11,7 @@
 @testable import BenchmarkSupport
 @testable import Statistics
 import XCTest
-/*
+
 final class StatisticsTests: XCTestCase {
     func testStatisticsResults() throws {
         var stats = Statistics(numberOfSignificantDigits: .four)
@@ -27,18 +27,18 @@ final class StatisticsTests: XCTestCase {
         }
 
         XCTAssertEqual(stats.measurementCount, measurementCount * 2)
-        XCTAssertEqual(stats.timeUnits, .count)
+        XCTAssertEqual(stats.units(), .count)
         XCTAssertEqual(round(stats.histogram.mean), round(Double(measurementCount / 2)))
 
-        stats.calculateStatistics()
+        let percentiles = stats.percentiles()
 
-        XCTAssertEqual(stats.percentileResults[0]!, 0)
-        XCTAssertEqual(stats.percentileResults[1]!, Int(round(Double(measurementCount) * 0.25)))
-        XCTAssertEqual(stats.percentileResults[2]!, Int(round(Double(measurementCount) * 0.5)))
-        XCTAssertEqual(stats.percentileResults[3]!, Int(round(Double(measurementCount) * 0.75)))
-        XCTAssertEqual(stats.percentileResults[4]!, Int(round(Double(measurementCount) * 0.9)))
-        XCTAssertEqual(stats.percentileResults[5]!, Int(round(Double(measurementCount) * 0.99)))
-        XCTAssertEqual(stats.percentileResults[6]!, Int(measurementCount))
+        XCTAssertEqual(percentiles[0], 0)
+        XCTAssertEqual(percentiles[1], Int(round(Double(measurementCount) * 0.25)))
+        XCTAssertEqual(percentiles[2], Int(round(Double(measurementCount) * 0.5)))
+        XCTAssertEqual(percentiles[3], Int(round(Double(measurementCount) * 0.75)))
+        XCTAssertEqual(percentiles[4], Int(round(Double(measurementCount) * 0.9)))
+        XCTAssertEqual(percentiles[5], Int(round(Double(measurementCount) * 0.99)))
+        XCTAssertEqual(percentiles[6], Int(measurementCount))
     }
 
     func testOnlyZeroMeasurements() throws {
@@ -55,17 +55,17 @@ final class StatisticsTests: XCTestCase {
 
         XCTAssert(stats.onlyZeroMeasurements)
 
-        stats.calculateStatistics()
+        let percentiles = stats.percentiles()
 
         XCTAssert(stats.onlyZeroMeasurements)
-        XCTAssertEqual(stats.timeUnits, .count)
-        XCTAssertEqual(stats.percentileResults[0]!, 0)
-        XCTAssertEqual(stats.percentileResults[1]!, 0)
-        XCTAssertEqual(stats.percentileResults[2]!, 0)
-        XCTAssertEqual(stats.percentileResults[3]!, 0)
-        XCTAssertEqual(stats.percentileResults[4]!, 0)
-        XCTAssertEqual(stats.percentileResults[5]!, 0)
-        XCTAssertEqual(stats.percentileResults[6]!, 0)
+        XCTAssertEqual(stats.units(), .count)
+        XCTAssertEqual(percentiles[0], 0)
+        XCTAssertEqual(percentiles[1], 0)
+        XCTAssertEqual(percentiles[2], 0)
+        XCTAssertEqual(percentiles[3], 0)
+        XCTAssertEqual(percentiles[4], 0)
+        XCTAssertEqual(percentiles[5], 0)
+        XCTAssertEqual(percentiles[6], 0)
     }
 
     func testFewerMeasurementsThanPercentiles() throws {
@@ -80,18 +80,18 @@ final class StatisticsTests: XCTestCase {
         }
 
         XCTAssertEqual(stats.measurementCount, range.count)
-        XCTAssertEqual(stats.timeUnits, .count)
+        XCTAssertEqual(stats.units(), .count)
         XCTAssertEqual(round(stats.histogram.mean), round(Double(accumulatedMeasurement) / Double(range.count)))
 
-        stats.calculateStatistics()
+        let percentiles = stats.percentiles()
 
-        XCTAssertEqual(stats.percentileResults[0]!, 1)
-        XCTAssertEqual(stats.percentileResults[1]!, Int(round(Double(range.count) * 0.25)))
-        XCTAssertEqual(stats.percentileResults[2]!, Int(round(Double(range.count) * 0.5)))
-        XCTAssertEqual(stats.percentileResults[3]!, Int(round(Double(range.count) * 0.75)))
-        XCTAssertEqual(stats.percentileResults[4]!, Int(round(Double(range.count) * 0.9)))
-        XCTAssertEqual(stats.percentileResults[5]!, Int(round(Double(range.count) * 0.99)))
-        XCTAssertEqual(stats.percentileResults[6]!, Int(range.count))
+        XCTAssertEqual(percentiles[0], 1)
+        XCTAssertEqual(percentiles[1], Int(round(Double(range.count) * 0.25)))
+        XCTAssertEqual(percentiles[2], Int(round(Double(range.count) * 0.5)))
+        XCTAssertEqual(percentiles[3], Int(round(Double(range.count) * 0.75)))
+        XCTAssertEqual(percentiles[4], Int(round(Double(range.count) * 0.9)))
+        XCTAssertEqual(percentiles[5], Int(round(Double(range.count) * 0.99)))
+        XCTAssertEqual(percentiles[6], Int(range.count))
     }
 
     func testAutomaticUnits() throws {
@@ -127,4 +127,3 @@ final class StatisticsTests: XCTestCase {
         XCTAssertGreaterThan(stats.histogram.totalCount, 100)
     }
 }
-*/

--- a/Tests/BenchmarkTests/StatisticsTests.swift
+++ b/Tests/BenchmarkTests/StatisticsTests.swift
@@ -124,6 +124,7 @@ final class StatisticsTests: XCTestCase {
             stats.add(measurement)
         }
 
+        XCTAssert(Int(stats.average) > (measurementCount / 3))
         XCTAssertGreaterThan(stats.histogram.totalCount, 100)
     }
 }

--- a/Tests/BenchmarkTests/StatisticsTests.swift
+++ b/Tests/BenchmarkTests/StatisticsTests.swift
@@ -26,6 +26,7 @@ final class StatisticsTests: XCTestCase {
             stats.add(measurement)
         }
 
+        XCTAssert(Statistics.roundToDecimalplaces(123.4567898972239487234) == 123.46)
         XCTAssertEqual(stats.measurementCount, measurementCount * 2)
         XCTAssertEqual(stats.units(), .count)
         XCTAssertEqual(round(stats.histogram.mean), round(Double(measurementCount / 2)))

--- a/Tests/BenchmarkTests/StatisticsTests.swift
+++ b/Tests/BenchmarkTests/StatisticsTests.swift
@@ -11,7 +11,7 @@
 @testable import BenchmarkSupport
 @testable import Statistics
 import XCTest
-
+/*
 final class StatisticsTests: XCTestCase {
     func testStatisticsResults() throws {
         var stats = Statistics(numberOfSignificantDigits: .four)
@@ -28,7 +28,7 @@ final class StatisticsTests: XCTestCase {
 
         XCTAssertEqual(stats.measurementCount, measurementCount * 2)
         XCTAssertEqual(stats.timeUnits, .count)
-        XCTAssertEqual(round(stats.averageMeasurement), round(Double(measurementCount / 2)))
+        XCTAssertEqual(round(stats.histogram.mean), round(Double(measurementCount / 2)))
 
         stats.calculateStatistics()
 
@@ -51,7 +51,7 @@ final class StatisticsTests: XCTestCase {
         }
 
         XCTAssertEqual(stats.measurementCount, range.count)
-        XCTAssertEqual(stats.averageMeasurement, 0.0)
+        XCTAssertEqual(stats.histogram.mean, 0.0)
 
         XCTAssert(stats.onlyZeroMeasurements)
 
@@ -81,7 +81,7 @@ final class StatisticsTests: XCTestCase {
 
         XCTAssertEqual(stats.measurementCount, range.count)
         XCTAssertEqual(stats.timeUnits, .count)
-        XCTAssertEqual(round(stats.averageMeasurement), round(Double(accumulatedMeasurement) / Double(range.count)))
+        XCTAssertEqual(round(stats.histogram.mean), round(Double(accumulatedMeasurement) / Double(range.count)))
 
         stats.calculateStatistics()
 
@@ -95,7 +95,7 @@ final class StatisticsTests: XCTestCase {
     }
 
     func testAutomaticUnits() throws {
-        typealias Case = (value: Int, units: StatisticsUnits)
+        typealias Case = (value: Int, units: Statistics.Units)
 
         let cases = [
             Case(value: 0, units: .count),
@@ -111,7 +111,7 @@ final class StatisticsTests: XCTestCase {
         ]
 
         for (value, expectedUnits) in cases {
-            let units = StatisticsUnits(fromMagnitudeOf: Double(value))
+            let units = Statistics.Units(fromMagnitudeOf: Double(value))
             XCTAssertEqual(units, expectedUnits, "Expected units for \(value) are \(expectedUnits)")
         }
     }
@@ -124,8 +124,7 @@ final class StatisticsTests: XCTestCase {
             stats.add(measurement)
         }
 
-        let histograms = stats.output()
-
-        XCTAssertGreaterThan(histograms.count, 100)
+        XCTAssertGreaterThan(stats.histogram.totalCount, 100)
     }
 }
+*/


### PR DESCRIPTION
## Description

Fixes #66 
Fixes #68 
Fixes #71

Adds regex filtering to debug runs, make CPU time units conform to user specified time unit also for cpu total/user/cpu times. Add `--scale` option to command line to get output scaled to per-subiteration values.

## How Has This Been Tested?
Manual testing plus a few unit tests.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
