### PR TITLE
chore: adding internal .gitignore

### DIFF
--- a/Sources/Benchmark/Documentation.docc/.gitignore
+++ b/Sources/Benchmark/Documentation.docc/.gitignore
@@ -1,0 +1,1 @@
+.docc-build


### PR DESCRIPTION

## Description

- hides .docc-build for local builds
- added locally since the repository organization maintains top-level .gitignore constructs (related to #79), and this is specific to this repository

## How Has This Been Tested?

- ran local docc build with CLI
- verified files aren't included or listed by git CLI

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
