### PR TITLE
feat: add encoded histogram export

### DIFF
--- a/Plugins/Benchmark/BenchmarkPlugin.swift
+++ b/Plugins/Benchmark/BenchmarkPlugin.swift
@@ -37,6 +37,7 @@ import PackagePlugin
         case percentiles
         case tsv
         case jmh
+        case encodedHistogram
     }
 
     enum Grouping: String {

--- a/Plugins/BenchmarkHelpGenerator/BenchmarkHelpGenerator.swift
+++ b/Plugins/BenchmarkHelpGenerator/BenchmarkHelpGenerator.swift
@@ -25,6 +25,7 @@ enum OutputFormat: String, ExpressibleByArgument, CaseIterable {
     case percentiles
     case tsv
     case jmh
+    case encodedHistogram
 }
 
 enum Command: String, ExpressibleByArgument, CaseIterable {

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -27,13 +27,19 @@ enum Grouping: String, ExpressibleByArgument {
     case benchmark
 }
 
+/// The benchmark data output format.
 enum OutputFormat: String, ExpressibleByArgument, CaseIterable {
+    /// Text output formatted into a visual table
     case text
+    /// The text output format, formatted in markdown
     case markdown
+    /// Influx data import
     case influx
     case percentiles
     case tsv
     case jmh
+    /// The encoded representation of the underlying histograms capturing the benchmark data.
+    case encodedHistogram
 }
 
 enum BenchmarkOperation: String, ExpressibleByArgument {
@@ -126,10 +132,10 @@ struct BenchmarkTool: AsyncParsableCommand {
     }
 
     func shouldRunBenchmark(_ name: String) throws -> Bool {
-        if try skip.contains(where: { name.wholeMatch(of: try Regex($0)) != nil }) {
+        if try skip.contains(where: { try name.wholeMatch(of: Regex($0)) != nil }) {
             return false
         }
-        return try filter.isEmpty || filter.contains(where: { name.wholeMatch(of: try Regex($0)) != nil })
+        return try filter.isEmpty || filter.contains(where: { try name.wholeMatch(of: Regex($0)) != nil })
     }
 
     mutating func readBaselines() throws {

--- a/Sources/BenchmarkSupport/BenchmarkRunner.swift
+++ b/Sources/BenchmarkSupport/BenchmarkRunner.swift
@@ -47,10 +47,10 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
     var debug = false
 
     func shouldRunBenchmark(_ name: String) throws -> Bool {
-        if try skip.contains(where: { name.wholeMatch(of: try Regex($0)) != nil }) {
+        if try skip.contains(where: { try name.wholeMatch(of: Regex($0)) != nil }) {
             return false
         }
-        return try filter.isEmpty || filter.contains(where: { name.wholeMatch(of: try Regex($0)) != nil })
+        return try filter.isEmpty || filter.contains(where: { try name.wholeMatch(of: Regex($0)) != nil })
     }
 
     // swiftlint:disable cyclomatic_complexity function_body_length


### PR DESCRIPTION
## Description

A work-around solution to #82, adding a feature to export the underlying histograms using their codable conformance. The preferred longer term solution requires additional features/capabilities on package-histogram to support cross-platform encoding and decoding of the raw histogram data.

This encoded histogram *does not* include the units of measurement selected for the various benchmarks.

## How Has This Been Tested?

- `swift test` within a linux container (`Swift:5.7`)
- Manually verified the output from `swift package --allow-writing-to-package-directory benchmark --format encodedHistogram` from the main branch within a Linux container, and on macOS desktop.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [X] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
