### PR TITLE
fix: doc cleanup after refactor and reorg

### DIFF
--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -52,12 +52,23 @@ public enum BenchmarkTimeUnits: Int, Codable, CustomStringConvertible {
     }
 }
 
+/// The scaling factor for benchmark iterations.
+///
+/// Typically used for very fast-running benchmarks.
+/// In those cases, the time to measure the benchmark can impact as much as the time to run the code being benchmarked.
+/// Use a scaling factor when running your short benchmarks to provide greater numerical stability to the results.
 public enum BenchmarkScalingFactor: Int, Codable {
+    /// No scaling factor, the raw count of iterations.
     case one = 1 // e.g. nanoseconds, or count
+    /// Scaling factor of 1e03.
     case kilo = 1_000 // microseconds
+    /// Scaling factor of 1e06.
     case mega = 1_000_000 // milliseconds
+    /// Scaling factor of 1e09.
     case giga = 1_000_000_000 // seconds
+    /// Scaling factor of 1e12.
     case tera = 1_000_000_000_000 // 1K seconds
+    /// Scaling factor of 1e15.
     case peta = 1_000_000_000_000_000 // 1M
 
     public var description: String {

--- a/Sources/Benchmark/Documentation.docc/BenchmarkScalingFactor.md
+++ b/Sources/Benchmark/Documentation.docc/BenchmarkScalingFactor.md
@@ -1,0 +1,19 @@
+# ``Benchmark/BenchmarkScalingFactor``
+
+## Topics
+
+### Selecting Scaling Factors
+
+- ``Benchmark/BenchmarkScalingFactor/one``
+- ``Benchmark/BenchmarkScalingFactor/kilo``
+- ``Benchmark/BenchmarkScalingFactor/mega``
+- ``Benchmark/BenchmarkScalingFactor/giga``
+- ``Benchmark/BenchmarkScalingFactor/tera``
+- ``Benchmark/BenchmarkScalingFactor/peta``
+- ``Benchmark/BenchmarkScalingFactor/init(_:)``
+- ``Benchmark/BenchmarkScalingFactor/init(rawValue:)``
+
+### Describing the Scaling Factor
+
+- ``Benchmark/BenchmarkScalingFactor/description``
+

--- a/Sources/Benchmark/Documentation.docc/Documentation.md
+++ b/Sources/Benchmark/Documentation.docc/Documentation.md
@@ -28,7 +28,6 @@ That being said, some of the export formats do include more traditional average/
 
 - <doc:GettingStarted>
 - <doc:WritingBenchmarks>
-- <doc:ConfiguringBenchmarks>
 - <doc:Metrics>
 - <doc:RunningBenchmarks>
 - <doc:Workflows>
@@ -39,9 +38,10 @@ That being said, some of the export formats do include more traditional average/
 
 ### Configuring Benchmarks
 
-- ``Benchmark/Benchmark/Configuration-swift.struct`` 
+- ``Benchmark/Benchmark/Configuration-swift.struct``
 - ``Benchmark/BenchmarkMetric``
 - ``Benchmark/BenchmarkTimeUnits``
+- ``Benchmark/BenchmarkScalingFactor``
 
 ### Registering Benchmarks
 


### PR DESCRIPTION
## Description

- added curation for Scaling Factor
- added source documentation in scaling factor enum

## How Has This Been Tested?

Visually reviewed in Xcode, published into [GH pages fork](https://heckj.github.io/package-benchmark/documentation/benchmark/):
- https://heckj.github.io/package-benchmark/documentation/benchmark/
- https://heckj.github.io/package-benchmark/documentation/benchmark/benchmarkscalingfactor

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [X] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
