### PR TITLE
fix: Tab separated value output was broken

### DIFF
--- a/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
@@ -56,6 +56,8 @@ extension BenchmarkTool {
 
         outputPath.append(csvFile.components)
 
+        print("Writing output to \(outputPath)")
+
         do {
             let fd = try FileDescriptor.open(
                 outputPath, .writeOnly, options: [.truncate, .create], permissions: .ownerReadWrite
@@ -107,6 +109,8 @@ extension BenchmarkTool {
 
         outputPath.append(jsonFile.components)
 
+        print("Writing output to \(outputPath)")
+
         do {
             let fd = try FileDescriptor.open(
                 outputPath, .writeOnly, options: [.truncate, .create], permissions: .ownerReadWrite
@@ -147,19 +151,19 @@ extension BenchmarkTool {
             prettyPrint(baseline, header: "Baseline '\(baselineName)'")
         case .influx:
             try write(exportData: "\(convertToInflux(baseline))",
-                      fileName: "\(baselineName)-influx-export.csv")
+                      fileName: "\(baselineName).influx.csv")
         case .percentiles:
             try baseline.results.forEach { key, results in
                 try results.forEach { values in
                     let outputString = values.statistics.histogram
-                    let description = values.metric.description
+                    let description = values.metric.rawDescription
                     try write(exportData: "\(outputString)",
-                              fileName: cleanupStringForShellSafety("\(baselineName).\(key.name).\(description).histogram-export.txt"))
+                              fileName: cleanupStringForShellSafety("\(baselineName).\(key.target).\(key.name).\(description).histogram.txt"))
                 }
             }
         case .jmh:
             try write(exportData: "\(convertToJMH(baseline))",
-                      fileName: cleanupStringForShellSafety("\(baselineName)-jmh-export.json"))
+                      fileName: cleanupStringForShellSafety("\(baselineName).jmh.json"))
         case .tsv:
             try baseline.results.forEach { key, results in
                 var outputString = ""
@@ -172,8 +176,10 @@ extension BenchmarkTool {
                             outputString += "\(value.value)\n"
                         }
                     }
+                    let description = values.metric.rawDescription
                     try write(exportData: "\(outputString)",
-                              fileName: cleanupStringForShellSafety("\(baselineName).\(key.target).\(key.name).\(values.metric).tsv"))
+                              fileName: cleanupStringForShellSafety("\(baselineName).\(key.target).\(key.name).\(description).tsv"))
+                    outputString = ""
                 }
             }
         case .encodedHistogram:
@@ -183,8 +189,9 @@ extension BenchmarkTool {
                 try results.forEach { values in
                     let histogram = values.statistics.histogram
                     let jsonData = try encoder.encode(histogram)
+                    let description = values.metric.rawDescription
                     try write(exportData: jsonData,
-                              fileName: cleanupStringForShellSafety("\(baselineName).\(key.target).\(key.name).\(values.metric).json"))
+                              fileName: cleanupStringForShellSafety("\(baselineName).\(key.target).\(key.name).\(description).json"))
                 }
             }
         }

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -181,7 +181,7 @@ struct BenchmarkTool: AsyncParsableCommand {
 
         // If we just need data from disk, skip running benchmarks
 
-        if let operation = baselineOperation, [.delete, .list].contains(operation) {
+        if let operation = baselineOperation, [.delete, .list, .read].contains(operation) {
             try postProcessBenchmarkResults()
             return
         }

--- a/Sources/Benchmark/BenchmarkMetric.swift
+++ b/Sources/Benchmark/BenchmarkMetric.swift
@@ -195,6 +195,66 @@ public extension BenchmarkMetric {
     }
 }
 
+#if swift(>=5.8)
+@_documentation(visibility: internal)
+#endif
+public extension BenchmarkMetric {
+    var rawDescription: String { // As we can't have raw values due to custom support, we do this...
+        switch self {
+        case .cpuUser:
+            return "cpuUser"
+        case .cpuSystem:
+            return "cpuSystem"
+        case .cpuTotal:
+            return "cpuTotal"
+        case .wallClock:
+            return "wallClock"
+        case .throughput:
+            return "throughput"
+        case .peakMemoryResident:
+            return "peakMemoryResident"
+        case .peakMemoryVirtual:
+            return "peakMemoryVirtual"
+        case .mallocCountSmall:
+            return "mallocCountSmall"
+        case .mallocCountLarge:
+            return "mallocCountLarge"
+        case .mallocCountTotal:
+            return "mallocCountTotal"
+        case .allocatedResidentMemory:
+            return "allocatedResidentMemory"
+        case .memoryLeaked:
+            return "memoryLeaked"
+        case .syscalls:
+            return "syscalls"
+        case .contextSwitches:
+            return "contextSwitches"
+        case .threads:
+            return "threads"
+        case .threadsRunning:
+            return "threadsRunning"
+        case .readSyscalls:
+            return "readSyscalls"
+        case .writeSyscalls:
+            return "writeSyscalls"
+        case .readBytesLogical:
+            return "readBytesLogical"
+        case .writeBytesLogical:
+            return "writeBytesLogical"
+        case .readBytesPhysical:
+            return "readBytesPhysical"
+        case .writeBytesPhysical:
+            return "writeBytesPhysical"
+        case .delta:
+            return "Δ"
+        case .deltaPercentage:
+            return "Δ %"
+        case let .custom(name, _, _):
+            return name
+        }
+    }
+}
+
 // swiftlint:disable cyclomatic_complexity
 // As we can't have raw values and associated data we add this...
 #if swift(>=5.8)


### PR DESCRIPTION
## Description

Fixes https://github.com/ordo-one/package-benchmark/issues/92
Also unifies file naming for exported data.

## How Has This Been Tested?

Manually tested.

## Minimal checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
