### PR TITLE
fix: Remove target name from benchmarkrunner as some characters causes issues

### DIFF
--- a/Plugins/BenchmarkBoilerplateGenerator/BenchmarkBoilerplateGenerator.swift
+++ b/Plugins/BenchmarkBoilerplateGenerator/BenchmarkBoilerplateGenerator.swift
@@ -25,9 +25,9 @@ struct Benchmark: AsyncParsableCommand {
         import Benchmark
 
         @main
-        struct \(target)BenchmarkRunner: BenchmarkRunnerHooks {
+        struct BenchmarkRunner: BenchmarkRunnerHooks {
           static func registerBenchmarks() {
-            benchmarks()
+            _ = benchmarks()
           }
         }
         """


### PR DESCRIPTION
## Description

E.g. Target names with e.g. '-' failed.

## How Has This Been Tested?

Testing ported sample test suite.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
