### PR TITLE
fix: Update parameter naming after refactor

### DIFF
--- a/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
+++ b/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
@@ -193,7 +193,7 @@ import PackagePlugin
         }
 
         if checkAbsoluteThresholds > 0 {
-            args.append(contentsOf: ["--check-absolute"])
+            args.append(contentsOf: ["--check-absolute-thresholds"])
         }
 
         if scale > 0 {

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -268,7 +268,7 @@ struct BenchmarkTool: AsyncParsableCommand {
                               "--quiet", noProgress.description]
 
         if checkAbsoluteThresholds {
-            args.append("--check-absolute")
+            args.append("--check-absolute-thresholds")
         }
 
         inputFD = fromChild.readEnd.rawValue


### PR DESCRIPTION
Hotfix wrong option naming after restructuring.