### PR TITLE
feat: Make it possible to build and run without jemalloc available

### DIFF
--- a/Sources/Benchmark/Documentation.docc/GettingStarted.md
+++ b/Sources/Benchmark/Documentation.docc/GettingStarted.md
@@ -16,11 +16,19 @@ After having done those, running your benchmarks are as simple as running `swift
 
 Benchmark requires Swift 5.7 support as it uses Regex and Duration types introduced with the `macOS 13` runtime, most versions of Linux will work as long as Swift 5.7+ is used. 
 
-Benchmark also depends and needs the [jemalloc](https://jemalloc.net) memory allocation library, which is used by the Benchmark infrastructure to capture memory allocation statistics, as `jemalloc` provides a rich programmatic API for extracting memory allocation statistics at runtime. 
+Benchmark also by default depends on and uses the [jemalloc](https://jemalloc.net) memory allocation library, which is used by the Benchmark infrastructure to capture memory allocation statistics.
 
-The Benchmark package requires you to install jemalloc on any machine used for benchmarking. 
+For platforms where `jemalloc` isn't available it's possible to build the Benchmark package without a `jemalloc` dependency by setting the environment variable BENCHMARK_DISABLE_JEMALLOC to any value except `false` or `0`.
 
-If you want to avoid adding the `jemalloc` dependency to your project, the recommended approach is to embed a separate Swift project in a subdirectory that uses your project, then the dependency on `jemalloc` is contained to that subproject only.
+E.g. to run the benchmark on the command line without memory allocation stats could look like:
+
+```bash
+BENCHMARK_DISABLE_JEMALLOC=true swift package benchmark
+```
+
+The Benchmark package requires you to install jemalloc on any machine used for benchmarking if you want malloc statistics. 
+
+If you want to avoid adding the `jemalloc` dependency to your main project while still getting malloc statistics when benchmarking, the recommended approach is to embed a separate Swift project in a subdirectory that uses your project, then the dependency on `jemalloc` is contained to that subproject only.
 
 #### Installing `jemalloc` on macOS
 

--- a/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
+++ b/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
@@ -9,6 +9,8 @@
 //
 
 import ExtrasJSON
+
+#if canImport(jemalloc)
 import jemalloc
 
 // We currently register a number of MIB:s that aren't in use that
@@ -165,3 +167,17 @@ class MallocStatsProducer {
         return carrier.data
     }
 }
+
+#else
+
+// stub if no jemalloc available
+class MallocStatsProducer {
+    func makeMallocStats() -> MallocStats {
+        return MallocStats(mallocCountTotal: 0,
+                           mallocCountSmall: 0,
+                           mallocCountLarge: 0,
+                           allocatedResidentMemory: 0)
+    }
+}
+
+#endif

--- a/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
+++ b/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
@@ -53,7 +53,7 @@ final class OperatingSystemAndMallocTests: XCTestCase {
         blackHole(operatingSystemStatsProducer.metricSupported(.writeBytesPhysical))
         blackHole(operatingSystemStatsProducer.metricSupported(.throughput))
     }
-
+#if canImport(jemalloc)
     func testMallocProducerLeaks() throws {
         let mallocStatsProducer = MallocStatsProducer()
         let startMallocStats = mallocStatsProducer.makeMallocStats()
@@ -68,4 +68,5 @@ final class OperatingSystemAndMallocTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(stopMallocStats.allocatedResidentMemory - startMallocStats.allocatedResidentMemory,
                                     100 * 1_024)
     }
+#endif
 }


### PR DESCRIPTION
## Description
Some platforms doesn't have jemalloc available and it'd be nice to be able to use benchmark without the malloc counters there.

Fixes #15
and
Fixes #60  (sort of)

To run test suite on macOS without crash you can now use:
`BENCHMARK_DISABLE_JEMALLOC=1 swift test`

To run benchmarks without jemalloc installed:

`BENCHMARK_DISABLE_JEMALLOC=1 swift package benchmark`

## How Has This Been Tested?

Manually tested with jemalloc installed/uninstalled.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
