### PR TITLE
feat: Add metrics for ARC

### DIFF
--- a/Benchmarks/DateTime/BenchmarkRunner+DateTime.swift
+++ b/Benchmarks/DateTime/BenchmarkRunner+DateTime.swift
@@ -11,7 +11,7 @@ import Benchmark
 import DateTime
 
 let benchmarks = {
-    Benchmark.defaultConfiguration = .init(metrics: [.throughput, .wallClock],
+    Benchmark.defaultConfiguration = .init(metrics: [.throughput, .wallClock] + BenchmarkMetric.arc,
                                            warmupIterations: 10,
                                            scalingFactor: .kilo,
                                            maxDuration: .seconds(1),

--- a/Benchmarks/Histogram/BenchmarkRunner+Histogram.swift
+++ b/Benchmarks/Histogram/BenchmarkRunner+Histogram.swift
@@ -40,7 +40,6 @@ let benchmarks = {
         let numValues = 1_024 // so compiler can optimize modulo below
         let values = [UInt64]((0 ..< numValues).map { _ in UInt64.random(in: 100 ... 10_000) })
 
-
         for i in benchmark.scaledIterations {
             blackHole(histogram.record(values[i % numValues]))
         }

--- a/Package.resolved
+++ b/Package.resolved
@@ -46,6 +46,15 @@
       }
     },
     {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics",
+      "state" : {
+        "revision" : "ff3d2212b6b093db7f177d0855adbc4ef9c5f036",
+        "version" : "1.0.3"
+      }
+    },
+    {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",

--- a/Package.swift
+++ b/Package.swift
@@ -105,6 +105,8 @@ let package = Package(
             path: "Platform/CLinuxOperatingSystemStats"
         ),
 
+        .target(name: "SwiftRuntimeHooks", dependencies: []),
+
         // Benchmark of the benchmark package
         .executableTarget(
             name: "Basic",
@@ -156,6 +158,7 @@ if let disableJemalloc, disableJemalloc != "false", disableJemalloc != "0" {
                 .product(name: "Progress", package: "Progress.swift"),
                 .byNameItem(name: "CDarwinOperatingSystemStats", condition: .when(platforms: [.macOS])),
                 .byNameItem(name: "CLinuxOperatingSystemStats", condition: .when(platforms: [.linux])),
+                "SwiftRuntimeHooks",
             ]
         )]
 } else {
@@ -173,6 +176,7 @@ if let disableJemalloc, disableJemalloc != "false", disableJemalloc != "0" {
                 .product(name: "Progress", package: "Progress.swift"),
                 .byNameItem(name: "CDarwinOperatingSystemStats", condition: .when(platforms: [.macOS])),
                 .byNameItem(name: "CLinuxOperatingSystemStats", condition: .when(platforms: [.linux])),
+                "SwiftRuntimeHooks",
             ]
         )]
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version: 5.7
 
-import PackageDescription
 import class Foundation.ProcessInfo
+import PackageDescription
 
 // If the environment variable BENCHMARK_DISABLE_JEMALLOC is set, we'll build the package without Jemalloc support
 let disableJemalloc = ProcessInfo.processInfo.environment["BENCHMARK_DISABLE_JEMALLOC"]
@@ -134,7 +134,7 @@ var dependencies: [PackageDescription.Target.Dependency] = [
 if let disableJemalloc, disableJemalloc != "false", disableJemalloc != "0" {
 } else {
     package.dependencies += [.package(url: "https://github.com/ordo-one/package-jemalloc", .upToNextMajor(from: "1.0.0"))]
-    dependencies += [ .product(name: "jemalloc", package: "package-jemalloc")]
+    dependencies += [.product(name: "jemalloc", package: "package-jemalloc")]
 }
 
 package.targets += [.target(name: "Benchmark", dependencies: dependencies)]

--- a/Plugins/BenchmarkCommandPlugin/BenchmarkPlugin+Help.swift
+++ b/Plugins/BenchmarkCommandPlugin/BenchmarkPlugin+Help.swift
@@ -44,13 +44,15 @@ let help =
     --skip-target <skip-target>
                           Benchmark targets matching the regexp filter that should be skipped
     --format <format>       The output format to use, one of: ["text", "markdown", "influx", "jmh", "histogramEncoded", "histogram", "histogramSamples", "histogramPercentiles"], default is 'text'
-    --metric <metric>       Specifies that the benchmark run should use one or more specific metrics instead of the ones defined by the benchmarks, valid values are: ["cpuUser", "cpuSystem", "cpuTotal", "wallClock", "throughput", "peakMemoryResident", "peakMemoryVirtual",
-                          "mallocCountSmall", "mallocCountLarge", "mallocCountTotal", "allocatedResidentMemory", "memoryLeaked", "syscalls", "contextSwitches", "threads", "threadsRunning", "readSyscalls", "writeSyscalls", "readBytesLogical", "writeBytesLogical",
-                          "readBytesPhysical", "writeBytesPhysical", "custom"]
+    --metric <metric>       Specifies that the benchmark run should use one or more specific metrics instead of the ones defined by the benchmarks, valid values are: ["cpuUser", "cpuSystem", "cpuTotal", "wallClock",
+                          "throughput", "peakMemoryResident", "peakMemoryVirtual", "mallocCountSmall", "mallocCountLarge", "mallocCountTotal", "allocatedResidentMemory", "memoryLeaked", "syscalls",
+                          "contextSwitches", "threads", "threadsRunning", "readSyscalls", "writeSyscalls", "readBytesLogical", "writeBytesLogical", "readBytesPhysical", "writeBytesPhysical", "retainCount",
+                          "releaseCount", "retainReleaseDelta", "custom"]
     --path <path>           The path where exported data is stored, default is the current directory (".").
     --quiet                 Specifies that output should be suppressed (useful for if you just want to check return code)
     --scale                 Specifies that some of the text output should be scaled using the scalingFactor (denoted by '*' in output)
-    --check-absolute        Set to true if thresholds should be checked against an absolute reference point rather than delta between baselines.
+    --check-absolute-thresholds
+                          Set to true if thresholds should be checked against an absolute reference point rather than delta between baselines.
                           This is used for CI workflows when you want to validate the thresholds vs. a persisted benchmark baseline
                           rather than comparing PR vs main or vs a current run. This is useful to cut down the build matrix needed
                           for those wanting to validate performance of e.g. toolchains or OS:s as well (or have other reasons for wanting

--- a/Plugins/BenchmarkHelpGenerator/BenchmarkHelpGenerator.swift
+++ b/Plugins/BenchmarkHelpGenerator/BenchmarkHelpGenerator.swift
@@ -36,6 +36,9 @@ let availableMetrics = [
     "writeBytesLogical",
     "readBytesPhysical",
     "writeBytesPhysical",
+    "retainCount",
+    "releaseCount",
+    "retainReleaseDelta",
     "custom"
 ]
 

--- a/Sources/Benchmark/ARCStats/ARCStats.swift
+++ b/Sources/Benchmark/ARCStats/ARCStats.swift
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2023 Ordo One AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+
+/// The ARC stats the ARCStatsProducer can provide
+#if swift(>=5.8)
+@_documentation(visibility: internal)
+#endif
+
+internal struct ARCStats {
+    var retainCount: Int /// total number retains
+    var releaseCount: Int /// total number of releases
+}

--- a/Sources/Benchmark/ARCStats/ARCStats.swift
+++ b/Sources/Benchmark/ARCStats/ARCStats.swift
@@ -10,7 +10,7 @@
 
 /// The ARC stats the ARCStatsProducer can provide
 #if swift(>=5.8)
-@_documentation(visibility: internal)
+    @_documentation(visibility: internal)
 #endif
 
 internal struct ARCStats {

--- a/Sources/Benchmark/ARCStats/ARCStatsProducer.swift
+++ b/Sources/Benchmark/ARCStats/ARCStatsProducer.swift
@@ -12,7 +12,7 @@ import Atomics
 import SwiftRuntimeHooks
 
 // swiftlint:disable prefer_self_in_static_references
-class ARCStatsProducer {
+final class ARCStatsProducer {
     typealias SwiftRuntimeHook = @convention(c) (UnsafeRawPointer?, UnsafeMutableRawPointer?) -> Void
 
     static var retainCount: UnsafeAtomic<Int> = .create(0)

--- a/Sources/Benchmark/ARCStats/ARCStatsProducer.swift
+++ b/Sources/Benchmark/ARCStats/ARCStatsProducer.swift
@@ -8,22 +8,22 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 
-import SwiftRuntimeHooks
 import Atomics
+import SwiftRuntimeHooks
 
+// swiftlint:disable prefer_self_in_static_references
 class ARCStatsProducer {
     typealias SwiftRuntimeHook = @convention(c) (UnsafeRawPointer?, UnsafeMutableRawPointer?) -> Void
 
     static var retainCount: UnsafeAtomic<Int> = .create(0)
     static var releaseCount: UnsafeAtomic<Int> = .create(0)
 
-    // TODO: Review orderings used
     func hook() {
-        let retainHook: SwiftRuntimeHook = { ptr, context in
+        let retainHook: SwiftRuntimeHook = { _, _ in
             ARCStatsProducer.retainCount.wrappingIncrement(ordering: .relaxed)
         }
 
-        let releaseHook: SwiftRuntimeHook = { ptr, context in
+        let releaseHook: SwiftRuntimeHook = { _, _ in
             ARCStatsProducer.releaseCount.wrappingIncrement(ordering: .relaxed)
         }
 
@@ -40,7 +40,7 @@ class ARCStatsProducer {
     }
 
     func makeARCStats() -> ARCStats {
-         ARCStats(retainCount: ARCStatsProducer.retainCount.load(ordering: .relaxed),
-                  releaseCount: ARCStatsProducer.releaseCount.load(ordering: .relaxed))
+        ARCStats(retainCount: ARCStatsProducer.retainCount.load(ordering: .relaxed),
+                 releaseCount: ARCStatsProducer.releaseCount.load(ordering: .relaxed))
     }
 }

--- a/Sources/Benchmark/ARCStats/ARCStatsProducer.swift
+++ b/Sources/Benchmark/ARCStats/ARCStatsProducer.swift
@@ -1,0 +1,46 @@
+//
+// Copyright (c) 2023 Ordo One AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+
+import SwiftRuntimeHooks
+import Atomics
+
+class ARCStatsProducer {
+    typealias SwiftRuntimeHook = @convention(c) (UnsafeRawPointer?, UnsafeMutableRawPointer?) -> Void
+
+    static var retainCount: UnsafeAtomic<Int> = .create(0)
+    static var releaseCount: UnsafeAtomic<Int> = .create(0)
+
+    // TODO: Review orderings used
+    func hook() {
+        let retainHook: SwiftRuntimeHook = { ptr, context in
+            ARCStatsProducer.retainCount.wrappingIncrement(ordering: .relaxed)
+        }
+
+        let releaseHook: SwiftRuntimeHook = { ptr, context in
+            ARCStatsProducer.releaseCount.wrappingIncrement(ordering: .relaxed)
+        }
+
+        swift_runtime_set_retain_hook(retainHook, nil)
+        swift_runtime_set_release_hook(releaseHook, nil)
+
+        ARCStatsProducer.retainCount.store(0, ordering: .relaxed)
+        ARCStatsProducer.releaseCount.store(0, ordering: .relaxed)
+    }
+
+    func unhook() {
+        swift_runtime_set_release_hook(nil, nil)
+        swift_runtime_set_retain_hook(nil, nil)
+    }
+
+    func makeARCStats() -> ARCStats {
+         ARCStats(retainCount: ARCStatsProducer.retainCount.load(ordering: .relaxed),
+                  releaseCount: ARCStatsProducer.releaseCount.load(ordering: .relaxed))
+    }
+}

--- a/Sources/Benchmark/BenchmarkExecutor+Extensions.swift
+++ b/Sources/Benchmark/BenchmarkExecutor+Extensions.swift
@@ -66,3 +66,14 @@ extension BenchmarkExecutor {
         }
     }
 }
+
+extension BenchmarkExecutor {
+    func arcStatsProducerNeeded(_ metric: BenchmarkMetric) -> Bool {
+        switch metric {
+        case .retainCount, .releaseCount, .retainReleaseDelta:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/Benchmark/BenchmarkMetric+Defaults.swift
+++ b/Sources/Benchmark/BenchmarkMetric+Defaults.swift
@@ -44,6 +44,13 @@ public extension BenchmarkMetric {
          .allocatedResidentMemory]
     }
 
+    /// A collection of ARC metrics
+    static var arc: [BenchmarkMetric] {
+        [.retainCount,
+         .releaseCount,
+         .retainReleaseDelta]
+    }
+
     /// A collection of system benchmarks.
     static var system: [BenchmarkMetric] {
         [.wallClock,
@@ -87,6 +94,9 @@ public extension BenchmarkMetric {
          .writeBytesLogical,
          .readBytesPhysical,
          .writeBytesPhysical,
-         .allocatedResidentMemory]
+         .allocatedResidentMemory,
+         .retainCount,
+         .releaseCount,
+         .retainReleaseDelta]
     }
 }

--- a/Sources/Benchmark/BenchmarkMetric.swift
+++ b/Sources/Benchmark/BenchmarkMetric.swift
@@ -58,6 +58,12 @@ public enum BenchmarkMetric: Hashable, Equatable, Codable, CustomStringConvertib
     case readBytesPhysical
     /// The number of bytes physicall written to a block device (i.e. disk) -- Linux only
     case writeBytesPhysical
+    /// Number of retains (ARC)
+    case retainCount
+    /// Number of releases (ARC)
+    case releaseCount
+    /// ABS(retains-releases) - if this is non-zero, it would typically mean the benchmark has a retain cycle (use Memory Graph Debugger to troubleshoot) or that startMeasurement/stopMeasurement aren't used properly
+    case retainReleaseDelta
     /// Custom metric
     case custom(_ name: String, polarity: Polarity = .prefersSmaller, useScalingFactor: Bool = true)
 
@@ -119,6 +125,8 @@ public extension BenchmarkMetric {
         case .readSyscalls, .readBytesLogical, .readBytesPhysical:
             return true
         case .writeSyscalls, .writeBytesLogical, .writeBytesPhysical:
+            return true
+        case .retainCount, .releaseCount, .retainReleaseDelta:
             return true
         case let .custom(_, _, useScaleFactor):
             return useScaleFactor
@@ -185,6 +193,12 @@ public extension BenchmarkMetric {
             return "Bytes (read physical)"
         case .writeBytesPhysical:
             return "Bytes (write physical)"
+        case .retainCount:
+            return "Retains"
+        case .releaseCount:
+            return "Releases"
+        case .retainReleaseDelta:
+            return "Retain / Release Δ"
         case .delta:
             return "Δ"
         case .deltaPercentage:
@@ -245,6 +259,12 @@ public extension BenchmarkMetric {
             return "readBytesPhysical"
         case .writeBytesPhysical:
             return "writeBytesPhysical"
+        case .retainCount:
+            return "retainCount"
+        case .releaseCount:
+            return "releaseCount"
+        case .retainReleaseDelta:
+            return "retainReleaseDelta"
         case .delta:
             return "Δ"
         case .deltaPercentage:
@@ -307,6 +327,12 @@ public extension BenchmarkMetric {
             self = BenchmarkMetric.readBytesPhysical
         case "writeBytesPhysical":
             self = BenchmarkMetric.writeBytesPhysical
+        case "retainCount":
+            self = BenchmarkMetric.retainCount
+        case "releaseCount":
+            self = BenchmarkMetric.releaseCount
+        case "retainReleaseDelta":
+            self = BenchmarkMetric.retainReleaseDelta
         default:
             self = BenchmarkMetric.custom(argument)
         }

--- a/Sources/Benchmark/BenchmarkMetric.swift
+++ b/Sources/Benchmark/BenchmarkMetric.swift
@@ -275,7 +275,7 @@ public extension BenchmarkMetric {
     }
 }
 
-// swiftlint:disable cyclomatic_complexity
+// swiftlint:disable cyclomatic_complexity function_body_length
 // As we can't have raw values and associated data we add this...
 #if swift(>=5.8)
     @_documentation(visibility: internal)

--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -11,7 +11,7 @@
 // swiftlint: disable file_length identifier_name
 
 #if swift(>=5.8)
-@_documentation(visibility: internal)
+    @_documentation(visibility: internal)
 #endif
 public extension BenchmarkResult {
     enum Percentile: Int, Codable {

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -72,6 +72,9 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
         """)
     var checkAbsoluteThresholds = false
 
+    @Flag(name: .shortAndLong, help: "True if we should run the benchmarks for all metrics.")
+    var allMetrics = false
+
     var debug = false
 
     func shouldRunBenchmark(_ name: String) throws -> Bool {
@@ -158,6 +161,10 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                             }
                         }
                         benchmark.configuration.metrics = benchmarkToRun.configuration.metrics
+                    }
+
+                    if debug && allMetrics {
+                        benchmark.configuration.metrics = BenchmarkMetric.all
                     }
 
                     benchmark.target = benchmarkToRun.target

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -163,7 +163,7 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                         benchmark.configuration.metrics = benchmarkToRun.configuration.metrics
                     }
 
-                    if debug && allMetrics {
+                    if debug, allMetrics {
                         benchmark.configuration.metrics = BenchmarkMetric.all
                     }
 

--- a/Sources/Benchmark/Documentation.docc/BenchmarkMetric.md
+++ b/Sources/Benchmark/Documentation.docc/BenchmarkMetric.md
@@ -41,6 +41,12 @@
 - ``BenchmarkMetric/memoryLeaked``
 - ``BenchmarkMetric/allocatedResidentMemory``
 
+### Reference Counting (retain/release)
+
+- ``BenchmarkMetric/retainCount``
+- ``BenchmarkMetric/releaseCount``
+- ``BenchmarkMetric/retainReleaseDelta``
+
 ### Disk Metrics
 
 - ``BenchmarkMetric/readSyscalls``

--- a/Sources/Benchmark/Documentation.docc/Metrics.md
+++ b/Sources/Benchmark/Documentation.docc/Metrics.md
@@ -32,6 +32,9 @@ Currently supported metrics are:
 - term `writeBytesLogical`: The number bytes written to storage (but may be cached) -- Linux only
 - term `readBytesPhysical`: The number of bytes physically read from a block device (i.e. disk) -- Linux only
 - term `writeBytesPhysical`: The number of bytes physicall written to a block device (i.e. disk) -- Linux only
+- term `retainCount`: The number of retain calls (ARC)
+- term `releaseCount`: The number of release calls (ARC)
+- term `retainReleaseDelta`: abs(retainCount - releaseCount) - if this is non-zero, it would typically mean the benchmark has a retain cycle (use Memory Graph Debugger to troubleshoot)
 
 Additionally, _custom metrics_ are supported `custom(_ name: String, polarity: Polarity = .prefersSmaller, useScalingFactor: Bool = true)` as outlined in the writing benchmarks documentation.
 

--- a/Sources/Benchmark/Documentation.docc/RunningBenchmarks.md
+++ b/Sources/Benchmark/Documentation.docc/RunningBenchmarks.md
@@ -80,13 +80,15 @@ OPTIONS:
 --skip-target <skip-target>
 Benchmark targets matching the regexp filter that should be skipped
 --format <format>       The output format to use, one of: ["text", "markdown", "influx", "jmh", "histogramEncoded", "histogram", "histogramSamples", "histogramPercentiles"], default is 'text'
---metric <metric>       Specifies that the benchmark run should use one or more specific metrics instead of the ones defined by the benchmarks, valid values are: ["cpuUser", "cpuSystem", "cpuTotal", "wallClock", "throughput", "peakMemoryResident", "peakMemoryVirtual",
-"mallocCountSmall", "mallocCountLarge", "mallocCountTotal", "allocatedResidentMemory", "memoryLeaked", "syscalls", "contextSwitches", "threads", "threadsRunning", "readSyscalls", "writeSyscalls", "readBytesLogical", "writeBytesLogical",
-"readBytesPhysical", "writeBytesPhysical", "custom"]
---path <path>           The path where exported data is stored, default is the current directory (".").
+--metric <metric>       Specifies that the benchmark run should use one or more specific metrics instead of the ones defined by the benchmarks, valid values are: ["cpuUser", "cpuSystem", "cpuTotal", "wallClock",
+"throughput", "peakMemoryResident", "peakMemoryVirtual", "mallocCountSmall", "mallocCountLarge", "mallocCountTotal", "allocatedResidentMemory", "memoryLeaked", "syscalls",
+"contextSwitches", "threads", "threadsRunning", "readSyscalls", "writeSyscalls", "readBytesLogical", "writeBytesLogical", "readBytesPhysical", "writeBytesPhysical", "retainCount",
+"releaseCount", "retainReleaseDelta", "custom"]
+--path <path>           The path where exported data is stored, default is the current directory ("."). 
 --quiet                 Specifies that output should be suppressed (useful for if you just want to check return code)
 --scale                 Specifies that some of the text output should be scaled using the scalingFactor (denoted by '*' in output)
---check-absolute        Set to true if thresholds should be checked against an absolute reference point rather than delta between baselines.
+--check-absolute-thresholds
+Set to true if thresholds should be checked against an absolute reference point rather than delta between baselines.
 This is used for CI workflows when you want to validate the thresholds vs. a persisted benchmark baseline
 rather than comparing PR vs main or vs a current run. This is useful to cut down the build matrix needed
 for those wanting to validate performance of e.g. toolchains or OS:s as well (or have other reasons for wanting

--- a/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
+++ b/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
@@ -11,75 +11,75 @@
 import ExtrasJSON
 
 #if canImport(jemalloc)
-import jemalloc
+    import jemalloc
 
-// We currently register a number of MIB:s that aren't in use that
-// was used during development to figure out most relevant stats,
-// Keeping them around as we may want to expand malloc statistics
-// to become more detailed.
-#if swift(>=5.8)
-    @_documentation(visibility: internal)
-#endif
-class MallocStatsProducer {
-    var threadCacheMIB: [size_t]
-    var epochMIB: [size_t]
+    // We currently register a number of MIB:s that aren't in use that
+    // was used during development to figure out most relevant stats,
+    // Keeping them around as we may want to expand malloc statistics
+    // to become more detailed.
+    #if swift(>=5.8)
+        @_documentation(visibility: internal)
+    #endif
+    class MallocStatsProducer {
+        var threadCacheMIB: [size_t]
+        var epochMIB: [size_t]
 //    var smallNMallocMIB: [size_t]
 //    var largeNMallocMIB: [size_t]
 //    var smallNDallocMIB: [size_t]
 //    var largeNDallocMIB: [size_t]
 //    var smallAlloctedMIB: [size_t]
 //    var largeAllocatedMIB: [size_t]
-    var totalAllocatedMIB: [size_t]
-    var smallNRequestsMIB: [size_t]
-    var largeNRequestsMIB: [size_t]
+        var totalAllocatedMIB: [size_t]
+        var smallNRequestsMIB: [size_t]
+        var largeNRequestsMIB: [size_t]
 //    var smallNFillsMIB: [size_t]
 //    var largeNFillsMIB: [size_t]
 
-    // Update jemalloc internal statistics, this is the magic incantation to do it
-    @discardableResult
-    func updateEpoch() -> Int {
-        var allocated = 0
-        var size = MemoryLayout<Int>.size
-        var epoch = 0
-        let epochSize = MemoryLayout<Int>.size
-        var result: Int32 = 0
+        // Update jemalloc internal statistics, this is the magic incantation to do it
+        @discardableResult
+        func updateEpoch() -> Int {
+            var allocated = 0
+            var size = MemoryLayout<Int>.size
+            var epoch = 0
+            let epochSize = MemoryLayout<Int>.size
+            var result: Int32 = 0
 
-        // Must flush thread cache stats first
-        result = mallctlbymib(threadCacheMIB, threadCacheMIB.count, nil, nil, nil, 0)
-        if result != 0 {
-            print("mallctlbymib threadCacheMIB returned \(result)")
-        }
-
-        // Then update epoch
-        result = mallctlbymib(epochMIB, epochMIB.count, &allocated, &size, &epoch, epochSize)
-        if result != 0 {
-            print("mallctlbymib epochMIB returned \(result)")
-        }
-
-        return epoch
-    }
-
-    // Basically just set up a number of cached MIB structures for
-    // more efficient queries later of malloc statistics.
-    init() {
-        func setupMIB(name: String) -> [size_t] {
-            precondition(!name.split(separator: ".").isEmpty, "setupMIB with 0 count")
-            var mib = [size_t](repeating: 0, count: name.split(separator: ".").count)
-            var mibSize = mib.count
-            mib.withUnsafeMutableBufferPointer { pointer in
-                let result = mallctlnametomib(name, pointer.baseAddress, &mibSize)
-                if result != 0 {
-                    print("mallctlnametomib \(name) returned \(result)")
-                }
+            // Must flush thread cache stats first
+            result = mallctlbymib(threadCacheMIB, threadCacheMIB.count, nil, nil, nil, 0)
+            if result != 0 {
+                print("mallctlbymib threadCacheMIB returned \(result)")
             }
-            return mib
+
+            // Then update epoch
+            result = mallctlbymib(epochMIB, epochMIB.count, &allocated, &size, &epoch, epochSize)
+            if result != 0 {
+                print("mallctlbymib epochMIB returned \(result)")
+            }
+
+            return epoch
         }
 
-        epochMIB = setupMIB(name: "epoch")
-        threadCacheMIB = setupMIB(name: "thread.tcache.flush")
-        smallNRequestsMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.nrequests")
-        largeNRequestsMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.nrequests")
-        totalAllocatedMIB = setupMIB(name: "stats.resident")
+        // Basically just set up a number of cached MIB structures for
+        // more efficient queries later of malloc statistics.
+        init() {
+            func setupMIB(name: String) -> [size_t] {
+                precondition(!name.split(separator: ".").isEmpty, "setupMIB with 0 count")
+                var mib = [size_t](repeating: 0, count: name.split(separator: ".").count)
+                var mibSize = mib.count
+                mib.withUnsafeMutableBufferPointer { pointer in
+                    let result = mallctlnametomib(name, pointer.baseAddress, &mibSize)
+                    if result != 0 {
+                        print("mallctlnametomib \(name) returned \(result)")
+                    }
+                }
+                return mib
+            }
+
+            epochMIB = setupMIB(name: "epoch")
+            threadCacheMIB = setupMIB(name: "thread.tcache.flush")
+            smallNRequestsMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.nrequests")
+            largeNRequestsMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.nrequests")
+            totalAllocatedMIB = setupMIB(name: "stats.resident")
 //        smallNMallocMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.nmalloc")
 //        largeNMallocMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.nmalloc")
 //        smallNDallocMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.ndalloc")
@@ -88,96 +88,96 @@ class MallocStatsProducer {
 //        largeAllocatedMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.allocated")
 //        smallNFillsMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.nfills")
 //        largeNFillsMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.nfills")
-    }
-
-    // Read the actual stats using a cached MIB as the key
-    func readStats(_ mib: [Int]) -> Int {
-        var allocated = 0
-        var size = MemoryLayout<Int>.size
-
-        if mallctlbymib(mib, mib.count, &allocated, &size, nil, 0) == 0 {
-            return allocated
         }
 
-        return 0
-    }
+        // Read the actual stats using a cached MIB as the key
+        func readStats(_ mib: [Int]) -> Int {
+            var allocated = 0
+            var size = MemoryLayout<Int>.size
 
-    func makeMallocStats() -> MallocStats {
-        updateEpoch()
-        let allocationsCountSmall = readStats(smallNRequestsMIB)
-        let allocationsCountLarge = readStats(largeNRequestsMIB)
-        let allocatedResidentMemory = readStats(totalAllocatedMIB)
-        return MallocStats(mallocCountTotal: allocationsCountSmall + allocationsCountLarge,
-                           mallocCountSmall: allocationsCountSmall,
-                           mallocCountLarge: allocationsCountLarge,
-                           allocatedResidentMemory: allocatedResidentMemory)
-    }
+            if mallctlbymib(mib, mib.count, &allocated, &size, nil, 0) == 0 {
+                return allocated
+            }
 
-    // Finally we have some features to get to *all* jemalloc data, either as a json or
-    // as a parsed struct tree using the definitons from `MallocStats+jemalloc-support.swift`
-    // This is exhaustive complete information, but quite slow to extract - we may want to
-    // provide an option for the user to dump this in the future if useful.
-
-    class CallbackDataCarrier<T> {
-        init(_ data: T) {
-            self.data = data
+            return 0
         }
 
-        var data: T
-    }
-
-    // Parsed stats for convenience, this is a heavy and slow operation not suitable for
-    // being called within benchmark iterations
-    func jemallocStatistics() -> Jemalloc? {
-        // C style callback needs to use a class instance as a data carrier as we can't
-        // capture state in a c-style closure, thus the dance with from/to Opaque.
-        typealias CallbackType = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Void
-        let callback: CallbackType = { callbackCarrier, output in
-            let carrier = Unmanaged<CallbackDataCarrier<[UInt8]>>.fromOpaque(callbackCarrier!).takeUnretainedValue()
-            carrier.data.append(contentsOf: Array(String(cString: output!).utf8))
+        func makeMallocStats() -> MallocStats {
+            updateEpoch()
+            let allocationsCountSmall = readStats(smallNRequestsMIB)
+            let allocationsCountLarge = readStats(largeNRequestsMIB)
+            let allocatedResidentMemory = readStats(totalAllocatedMIB)
+            return MallocStats(mallocCountTotal: allocationsCountSmall + allocationsCountLarge,
+                               mallocCountSmall: allocationsCountSmall,
+                               mallocCountLarge: allocationsCountLarge,
+                               allocatedResidentMemory: allocatedResidentMemory)
         }
 
-        let carrier = CallbackDataCarrier<[UInt8]>([])
+        // Finally we have some features to get to *all* jemalloc data, either as a json or
+        // as a parsed struct tree using the definitons from `MallocStats+jemalloc-support.swift`
+        // This is exhaustive complete information, but quite slow to extract - we may want to
+        // provide an option for the user to dump this in the future if useful.
 
-        malloc_stats_print(callback, UnsafeMutableRawPointer(Unmanaged.passUnretained(carrier.self).toOpaque()), "J")
+        class CallbackDataCarrier<T> {
+            init(_ data: T) {
+                self.data = data
+            }
 
-        do {
-            let mallocStats = try XJSONDecoder().decode(Pokedex.self, from: carrier.data)
-            return mallocStats.jemalloc
-        } catch {}
-
-        return nil
-    }
-
-    // Full JSON with stats, this is a heavy and slow operation not suitable for
-    // being called within benchmark iterations
-    func jsonStatistics() -> String {
-        // C style callback needs to use a class instance as a data carrier as we can't
-        // capture state in a c-style closure, thus the dance with from/to Opaque.
-        typealias CallbackType = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Void
-        let callback: CallbackType = { callbackCarrier, output in
-            let carrier = Unmanaged<CallbackDataCarrier<String>>.fromOpaque(callbackCarrier!).takeUnretainedValue()
-            carrier.data += String(cString: output!)
+            var data: T
         }
 
-        let carrier = CallbackDataCarrier<String>("")
+        // Parsed stats for convenience, this is a heavy and slow operation not suitable for
+        // being called within benchmark iterations
+        func jemallocStatistics() -> Jemalloc? {
+            // C style callback needs to use a class instance as a data carrier as we can't
+            // capture state in a c-style closure, thus the dance with from/to Opaque.
+            typealias CallbackType = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Void
+            let callback: CallbackType = { callbackCarrier, output in
+                let carrier = Unmanaged<CallbackDataCarrier<[UInt8]>>.fromOpaque(callbackCarrier!).takeUnretainedValue()
+                carrier.data.append(contentsOf: Array(String(cString: output!).utf8))
+            }
 
-        malloc_stats_print(callback, UnsafeMutableRawPointer(Unmanaged.passUnretained(carrier.self).toOpaque()), "J")
+            let carrier = CallbackDataCarrier<[UInt8]>([])
 
-        return carrier.data
+            malloc_stats_print(callback, UnsafeMutableRawPointer(Unmanaged.passUnretained(carrier.self).toOpaque()), "J")
+
+            do {
+                let mallocStats = try XJSONDecoder().decode(Pokedex.self, from: carrier.data)
+                return mallocStats.jemalloc
+            } catch {}
+
+            return nil
+        }
+
+        // Full JSON with stats, this is a heavy and slow operation not suitable for
+        // being called within benchmark iterations
+        func jsonStatistics() -> String {
+            // C style callback needs to use a class instance as a data carrier as we can't
+            // capture state in a c-style closure, thus the dance with from/to Opaque.
+            typealias CallbackType = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Void
+            let callback: CallbackType = { callbackCarrier, output in
+                let carrier = Unmanaged<CallbackDataCarrier<String>>.fromOpaque(callbackCarrier!).takeUnretainedValue()
+                carrier.data += String(cString: output!)
+            }
+
+            let carrier = CallbackDataCarrier<String>("")
+
+            malloc_stats_print(callback, UnsafeMutableRawPointer(Unmanaged.passUnretained(carrier.self).toOpaque()), "J")
+
+            return carrier.data
+        }
     }
-}
 
 #else
 
-// stub if no jemalloc available
-class MallocStatsProducer {
-    func makeMallocStats() -> MallocStats {
-        return MallocStats(mallocCountTotal: 0,
-                           mallocCountSmall: 0,
-                           mallocCountLarge: 0,
-                           allocatedResidentMemory: 0)
+    // stub if no jemalloc available
+    class MallocStatsProducer {
+        func makeMallocStats() -> MallocStats {
+            MallocStats(mallocCountTotal: 0,
+                        mallocCountSmall: 0,
+                        mallocCountLarge: 0,
+                        allocatedResidentMemory: 0)
+        }
     }
-}
 
 #endif

--- a/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
+++ b/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
@@ -20,7 +20,7 @@ import ExtrasJSON
     #if swift(>=5.8)
         @_documentation(visibility: internal)
     #endif
-    class MallocStatsProducer {
+    final class MallocStatsProducer {
         var threadCacheMIB: [size_t]
         var epochMIB: [size_t]
 //    var smallNMallocMIB: [size_t]
@@ -171,7 +171,7 @@ import ExtrasJSON
 #else
 
     // stub if no jemalloc available
-    class MallocStatsProducer {
+    final class MallocStatsProducer {
         func makeMallocStats() -> MallocStats {
             MallocStats(mallocCountTotal: 0,
                         mallocCountSmall: 0,

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
@@ -13,7 +13,7 @@
     import Darwin
     import Dispatch
 
-    class OperatingSystemStatsProducer {
+    final class OperatingSystemStatsProducer {
         var nsPerMachTick: Double
         var nsPerSchedulerTick: Int
 
@@ -31,7 +31,7 @@
         }
 
         internal
-        class CallbackDataCarrier<T> {
+        final class CallbackDataCarrier<T> {
             init(_ data: T) {
                 self.data = data
             }

--- a/Sources/Benchmark/Statistics.swift
+++ b/Sources/Benchmark/Statistics.swift
@@ -14,7 +14,7 @@ import Numerics
 
 // A type that provides distribution / percentile calculations of latency measurements
 #if swift(>=5.8)
-@_documentation(visibility: internal)
+    @_documentation(visibility: internal)
 #endif
 /// Internal type that will be hidden from documentation when upgrading doc generation to Swift 5.8+
 public final class Statistics: Codable {

--- a/Sources/SwiftRuntimeHooks/include/SwiftRuntimeHooks.h
+++ b/Sources/SwiftRuntimeHooks/include/SwiftRuntimeHooks.h
@@ -1,0 +1,11 @@
+#ifndef SwiftRuntimeHooks_hpp
+#define SwiftRuntimeHooks_hpp
+
+#include <stdio.h>
+
+typedef void (*swift_runtime_hook_t)(const void *, void *);
+
+void swift_runtime_set_retain_hook(swift_runtime_hook_t hook, void * context);
+void swift_runtime_set_release_hook(swift_runtime_hook_t hook, void * context);
+
+#endif

--- a/Sources/SwiftRuntimeHooks/include/SwiftRuntimeHooks.h
+++ b/Sources/SwiftRuntimeHooks/include/SwiftRuntimeHooks.h
@@ -1,7 +1,5 @@
-#ifndef SwiftRuntimeHooks_hpp
-#define SwiftRuntimeHooks_hpp
-
-#include <stdio.h>
+#ifndef PACKAGE_BENCHMARK_SWIFT_RUNTIME_HOOKS_H
+#define PACKAGE_BENCHMARK_SWIFT_RUNTIME_HOOKS_H
 
 typedef void (*swift_runtime_hook_t)(const void *, void *);
 

--- a/Sources/SwiftRuntimeHooks/shims.c
+++ b/Sources/SwiftRuntimeHooks/shims.c
@@ -1,0 +1,59 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "SwiftRuntimeHooks.h"
+
+typedef struct HeapObject_s HeapObject;
+
+extern HeapObject * (*_swift_retain)(HeapObject*);
+extern HeapObject * (*_swift_release)(HeapObject*);
+
+struct hook_data_s {
+    HeapObject * (*orig)(HeapObject*);
+    swift_runtime_hook_t hook;
+    void * context;
+};
+
+/*===========================================================================*/
+
+static struct hook_data_s _swift_retain_hook_data = {NULL, NULL, NULL};
+
+static HeapObject * _swift_retain_hook(HeapObject * heapObject) {
+    HeapObject * ret = (*_swift_retain_hook_data.orig)(heapObject);
+    (*_swift_retain_hook_data.hook)(heapObject, _swift_retain_hook_data.context);
+    return ret;
+}
+
+void swift_runtime_set_retain_hook(swift_runtime_hook_t hook, void * context) {
+    if (hook == NULL) {
+        _swift_retain = _swift_retain_hook_data.orig;
+        struct hook_data_s hook_data = {NULL, NULL, NULL};
+        _swift_retain_hook_data = hook_data;
+    } else {
+        struct hook_data_s hook_data = {_swift_retain, hook, context};
+        _swift_retain_hook_data = hook_data;
+        _swift_retain = _swift_retain_hook;
+    }
+}
+
+/*===========================================================================*/
+
+static struct hook_data_s _swift_release_hook_data = {NULL, NULL, NULL};
+
+static HeapObject * _swift_release_hook(HeapObject * heapObject) {
+    HeapObject * ret = (*_swift_release_hook_data.orig)(heapObject);
+    (*_swift_release_hook_data.hook)(heapObject, _swift_release_hook_data.context);
+    return ret;
+}
+
+void swift_runtime_set_release_hook(swift_runtime_hook_t hook, void * context) {
+    if (hook == NULL) {
+        _swift_release = _swift_release_hook_data.orig;
+        struct hook_data_s hook_data = {NULL, NULL, NULL};
+        _swift_release_hook_data = hook_data;
+    } else {
+        struct hook_data_s hook_data = {_swift_release, hook, context};
+        _swift_release_hook_data = hook_data;
+        _swift_release = _swift_release_hook;
+    }
+}

--- a/Sources/SwiftRuntimeHooks/shims.c
+++ b/Sources/SwiftRuntimeHooks/shims.c
@@ -8,15 +8,20 @@ typedef struct HeapObject_s HeapObject;
 extern HeapObject * (*_swift_retain)(HeapObject*);
 extern HeapObject * (*_swift_release)(HeapObject*);
 
+// unclear if the following two needs hooking and they don't seem to be called on Apple Silicon
+extern HeapObject * (*_swift_retain_n)(HeapObject *object, uint32_t n);
+extern HeapObject * (*_swift_release_n)(HeapObject *object, uint32_t n);
+
 struct hook_data_s {
     HeapObject * (*orig)(HeapObject*);
+    HeapObject * (*orig_n)(HeapObject*, uint32_t);
     swift_runtime_hook_t hook;
     void * context;
 };
 
 /*===========================================================================*/
 
-static struct hook_data_s _swift_retain_hook_data = {NULL, NULL, NULL};
+static struct hook_data_s _swift_retain_hook_data = {NULL, NULL, NULL, NULL};
 
 static HeapObject * _swift_retain_hook(HeapObject * heapObject) {
     HeapObject * ret = (*_swift_retain_hook_data.orig)(heapObject);
@@ -24,21 +29,33 @@ static HeapObject * _swift_retain_hook(HeapObject * heapObject) {
     return ret;
 }
 
+// This doesn't seem to be called for Apple Silicon at least, but keeping it here
+static HeapObject * _swift_retain_n_hook(HeapObject * heapObject, uint32_t n) {
+    int i;
+    HeapObject * ret = (*_swift_retain_hook_data.orig_n)(heapObject, n);
+    for (i = 0; i < n; i++) {
+        (*_swift_retain_hook_data.hook)(heapObject, _swift_retain_hook_data.context);
+    }
+    return ret;
+}
+
 void swift_runtime_set_retain_hook(swift_runtime_hook_t hook, void * context) {
     if (hook == NULL) {
         _swift_retain = _swift_retain_hook_data.orig;
-        struct hook_data_s hook_data = {NULL, NULL, NULL};
+        _swift_retain_n = _swift_retain_hook_data.orig_n;
+        struct hook_data_s hook_data = {NULL, NULL, NULL, NULL};
         _swift_retain_hook_data = hook_data;
     } else {
-        struct hook_data_s hook_data = {_swift_retain, hook, context};
+        struct hook_data_s hook_data = {_swift_retain, _swift_retain_n, hook, context};
         _swift_retain_hook_data = hook_data;
         _swift_retain = _swift_retain_hook;
+        _swift_retain_n = _swift_retain_n_hook;
     }
 }
 
 /*===========================================================================*/
 
-static struct hook_data_s _swift_release_hook_data = {NULL, NULL, NULL};
+static struct hook_data_s _swift_release_hook_data = {NULL, NULL, NULL, NULL};
 
 static HeapObject * _swift_release_hook(HeapObject * heapObject) {
     HeapObject * ret = (*_swift_release_hook_data.orig)(heapObject);
@@ -46,14 +63,26 @@ static HeapObject * _swift_release_hook(HeapObject * heapObject) {
     return ret;
 }
 
+// This doesn't seem to be called for Apple Silicon at least, but keeping it here
+static HeapObject * _swift_release_n_hook(HeapObject * heapObject, uint32_t n) {
+    int i;
+    HeapObject * ret = (*_swift_release_hook_data.orig_n)(heapObject, n);
+    for (i = 0; i < n; i++) {
+        (*_swift_release_hook_data.hook)(heapObject, _swift_release_hook_data.context);
+    }
+    return ret;
+}
+
 void swift_runtime_set_release_hook(swift_runtime_hook_t hook, void * context) {
     if (hook == NULL) {
         _swift_release = _swift_release_hook_data.orig;
-        struct hook_data_s hook_data = {NULL, NULL, NULL};
+        _swift_release_n = _swift_release_hook_data.orig_n;
+        struct hook_data_s hook_data = {NULL, NULL, NULL, NULL};
         _swift_release_hook_data = hook_data;
     } else {
-        struct hook_data_s hook_data = {_swift_release, hook, context};
+        struct hook_data_s hook_data = {_swift_release, _swift_release_n, hook, context};
         _swift_release_hook_data = hook_data;
         _swift_release = _swift_release_hook;
+        _swift_release_n = _swift_release_n_hook;
     }
 }

--- a/Sources/SwiftRuntimeHooks/shims.c
+++ b/Sources/SwiftRuntimeHooks/shims.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #include "SwiftRuntimeHooks.h"
 

--- a/Sources/SwiftRuntimeHooks/shims.c
+++ b/Sources/SwiftRuntimeHooks/shims.c
@@ -1,6 +1,5 @@
-#include <stdlib.h>
-#include <stdio.h>
 #include <stdint.h>
+#include <stddef.h>
 
 #include "SwiftRuntimeHooks.h"
 

--- a/Tests/BenchmarkTests/BenchmarkMetricsTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkMetricsTests.swift
@@ -35,6 +35,9 @@ final class BenchmarkMetricsTests: XCTestCase {
         .writeBytesLogical,
         .readBytesPhysical,
         .writeBytesPhysical,
+        .retainCount,
+        .releaseCount,
+        .retainReleaseDelta,
         .custom("test", polarity: .prefersSmaller, useScalingFactor: false),
         .custom("test2", polarity: .prefersLarger, useScalingFactor: true)
     ]
@@ -61,7 +64,10 @@ final class BenchmarkMetricsTests: XCTestCase {
         "readBytesLogical",
         "writeBytesLogical",
         "readBytesPhysical",
-        "writeBytesPhysical"
+        "writeBytesPhysical",
+        "retainCount",
+        "releaseCount",
+        "retainReleaseDelta"
     ]
 
     func testBenchmarkMetrics() throws {

--- a/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
+++ b/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
@@ -53,23 +53,23 @@ final class OperatingSystemAndMallocTests: XCTestCase {
         blackHole(operatingSystemStatsProducer.metricSupported(.writeBytesPhysical))
         blackHole(operatingSystemStatsProducer.metricSupported(.throughput))
     }
-    
-#if canImport(jemalloc)
-    func testMallocProducerLeaks() throws {
-        let mallocStatsProducer = MallocStatsProducer()
-        let startMallocStats = mallocStatsProducer.makeMallocStats()
 
-        for outerloop in 1 ... 100 {
-            blackHole(malloc(outerloop * 1_024))
+    #if canImport(jemalloc)
+        func testMallocProducerLeaks() throws {
+            let mallocStatsProducer = MallocStatsProducer()
+            let startMallocStats = mallocStatsProducer.makeMallocStats()
+
+            for outerloop in 1 ... 100 {
+                blackHole(malloc(outerloop * 1_024))
+            }
+
+            let stopMallocStats = mallocStatsProducer.makeMallocStats()
+
+            XCTAssertGreaterThanOrEqual(stopMallocStats.mallocCountTotal - startMallocStats.mallocCountTotal, 100)
+            XCTAssertGreaterThanOrEqual(stopMallocStats.allocatedResidentMemory - startMallocStats.allocatedResidentMemory,
+                                        100 * 1_024)
         }
-
-        let stopMallocStats = mallocStatsProducer.makeMallocStats()
-
-        XCTAssertGreaterThanOrEqual(stopMallocStats.mallocCountTotal - startMallocStats.mallocCountTotal, 100)
-        XCTAssertGreaterThanOrEqual(stopMallocStats.allocatedResidentMemory - startMallocStats.allocatedResidentMemory,
-                                    100 * 1_024)
-    }
-#endif
+    #endif
 
     func testARCStatsProducer() throws {
         let statsProducer = ARCStatsProducer()
@@ -80,10 +80,10 @@ final class OperatingSystemAndMallocTests: XCTestCase {
         let startStats = statsProducer.makeARCStats()
 
         for outerloop in 1 ... 100 {
-            var b = array
-            b.append(outerloop)
+            var arrayCopy = array
+            arrayCopy.append(outerloop)
             blackHole(array)
-            blackHole(b)
+            blackHole(arrayCopy)
         }
 
         let stopStats = statsProducer.makeARCStats()


### PR DESCRIPTION
## Description

Adds retains, releases and abs(retain-release) metrics based (thanks to @ser-0xff for the low level hooking).

Fixes #115 
and
Fixes #128

Sample output:
```bash
Releases
╒═══════════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Test                                          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Basic:Scaled metrics                          │       8 │       8 │       8 │       8 │       8 │       8 │       8 │    7630 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ BenchmarkDateTime:BenchmarkClock-now          │       2 │       2 │       2 │       2 │       2 │       2 │       2 │   10000 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ BenchmarkDateTime:Foundation-Date             │       2 │       2 │       2 │       2 │       2 │       2 │       2 │   10000 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ BenchmarkDateTime:InternalUTCClock-now        │       2 │       2 │       2 │       2 │       2 │       2 │       2 │   10000 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ HistogramBenchmark:Mean (K)                   │    1992 │    1993 │    1993 │    1993 │    1993 │    1993 │    1993 │       3 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ HistogramBenchmark:Record                     │       1 │       1 │       1 │       1 │       1 │       1 │       1 │     200 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ HistogramBenchmark:Record to autoresizing     │       9 │      12 │      12 │      12 │      12 │      12 │      12 │     183 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ HistogramBenchmark:ValueAtPercentile          │    1001 │    1001 │    1001 │    1001 │    1001 │    1001 │    1001 │      33 │
╘═══════════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

Retain / Release Δ
╒═══════════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Test                                          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Basic:Scaled metrics                          │       0 │       0 │       0 │       0 │       0 │       0 │       0 │    7630 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ BenchmarkDateTime:BenchmarkClock-now          │       0 │       0 │       0 │       0 │       0 │       0 │       0 │   10000 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ BenchmarkDateTime:Foundation-Date             │       0 │       0 │       0 │       0 │       0 │       0 │       0 │   10000 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ BenchmarkDateTime:InternalUTCClock-now        │       0 │       0 │       0 │       0 │       0 │       0 │       0 │   10000 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ HistogramBenchmark:Mean                       │       0 │       0 │       0 │       0 │       0 │       0 │       0 │       3 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ HistogramBenchmark:Record                     │       0 │       0 │       0 │       0 │       0 │       0 │       0 │     200 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ HistogramBenchmark:Record to autoresizing     │       2 │       3 │       3 │       3 │       3 │       3 │       3 │     183 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ HistogramBenchmark:ValueAtPercentile          │       0 │       0 │       0 │       0 │       0 │       0 │       0 │      33 │
╘═══════════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

Retains
╒═══════════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Test                                          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Basic:Scaled metrics                          │       8 │       8 │       8 │       8 │       8 │       8 │       8 │    7630 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ BenchmarkDateTime:BenchmarkClock-now          │       2 │       2 │       2 │       2 │       2 │       2 │       2 │   10000 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ BenchmarkDateTime:Foundation-Date             │       2 │       2 │       2 │       2 │       2 │       2 │       2 │   10000 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ BenchmarkDateTime:InternalUTCClock-now        │       2 │       2 │       2 │       2 │       2 │       2 │       2 │   10000 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ HistogramBenchmark:Mean (K)                   │    1992 │    1993 │    1993 │    1993 │    1993 │    1993 │    1993 │       3 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ HistogramBenchmark:Record                     │       1 │       1 │       1 │       1 │       1 │       1 │       1 │     200 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ HistogramBenchmark:Record to autoresizing     │       7 │       9 │       9 │       9 │       9 │       9 │       9 │     183 │
├───────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ HistogramBenchmark:ValueAtPercentile          │    1001 │    1001 │    1001 │    1001 │    1001 │    1001 │    1001 │      33 │
╘═══════════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
## How Has This Been Tested?

Manual testing of sample benchmarks here, added a simple test.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
