### PR TITLE
fix: Cleanup ARC stats 

### DIFF
--- a/Benchmarks/Basic/BenchmarkRunner+Basic.swift
+++ b/Benchmarks/Basic/BenchmarkRunner+Basic.swift
@@ -69,8 +69,7 @@ let benchmarks = {
 
     Benchmark("Statistics",
               configuration: .init(metrics: BenchmarkMetric.arc + [.wallClock],
-                                   scalingFactor: .kilo, maxDuration:.seconds(1))) { benchmark in
-
+                                   scalingFactor: .kilo, maxDuration: .seconds(1))) { benchmark in
         for _ in benchmark.scaledIterations {
             blackHole(stats.percentiles())
         }

--- a/Benchmarks/Basic/BenchmarkRunner+Basic.swift
+++ b/Benchmarks/Basic/BenchmarkRunner+Basic.swift
@@ -59,4 +59,20 @@ let benchmarks = {
     Benchmark("All metrics",
               configuration: .init(metrics: BenchmarkMetric.all, skip: true)) { _ in
     }
+
+    let stats = Statistics(numberOfSignificantDigits: .four)
+    let measurementCount = 8_340
+
+    for measurement in (0 ..< measurementCount).reversed() {
+        stats.add(measurement)
+    }
+
+    Benchmark("Statistics",
+              configuration: .init(metrics: BenchmarkMetric.arc + [.wallClock],
+                                   scalingFactor: .kilo, maxDuration:.seconds(1))) { benchmark in
+
+        for _ in benchmark.scaledIterations {
+            blackHole(stats.percentiles())
+        }
+    }
 }

--- a/Sources/Benchmark/ARCStats/ARCStatsProducer.swift
+++ b/Sources/Benchmark/ARCStats/ARCStatsProducer.swift
@@ -29,14 +29,16 @@ final class ARCStatsProducer {
 
         swift_runtime_set_retain_hook(retainHook, nil)
         swift_runtime_set_release_hook(releaseHook, nil)
-
-        ARCStatsProducer.retainCount.store(0, ordering: .relaxed)
-        ARCStatsProducer.releaseCount.store(0, ordering: .relaxed)
     }
 
     func unhook() {
         swift_runtime_set_release_hook(nil, nil)
         swift_runtime_set_retain_hook(nil, nil)
+    }
+
+    func reset() {
+        ARCStatsProducer.retainCount.store(0, ordering: .relaxed)
+        ARCStatsProducer.releaseCount.store(0, ordering: .relaxed)
     }
 
     func makeARCStats() -> ARCStats {

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -10,6 +10,8 @@
 
 import Dispatch
 
+// swiftlint: disable file_length
+
 /// Defines a benchmark
 public final class Benchmark: Codable, Hashable {
     #if swift(>=5.8)

--- a/Sources/Benchmark/BenchmarkExecutor.swift
+++ b/Sources/Benchmark/BenchmarkExecutor.swift
@@ -78,6 +78,8 @@ internal final class BenchmarkExecutor {
         let initialStartTime = BenchmarkClock.now
 
         // Hook that is called before the actual benchmark closure run, so we can capture metrics here
+        // NB this code may be called twice if the user calls startMeasurement() manually and should
+        // then reset to a new starting state.
         benchmark.measurementPreSynchronization = {
             if mallocStatsRequested {
                 startMallocStats = self.mallocStatsProducer.makeMallocStats()
@@ -95,6 +97,7 @@ internal final class BenchmarkExecutor {
         }
 
         // And corresponding hook for then the benchmark has finished and capture finishing metrics here
+        // This closure will only be called once for a given run though.
         benchmark.measurementPostSynchronization = {
             stopTime = BenchmarkClock.now // must be first in closure
 
@@ -276,6 +279,7 @@ internal final class BenchmarkExecutor {
 
                 let maxPercentage = max(iterationsPercentage, timePercentage)
 
+                // Small optimization to not update every single percentage point
                 if Int(maxPercentage) > nextPercentageToUpdateProgressBar {
                     progressBar.setValue(Int(maxPercentage))
                     nextPercentageToUpdateProgressBar = Int(maxPercentage) + Int.random(in: 3 ... 9)

--- a/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
+++ b/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
@@ -17,9 +17,10 @@ import ExtrasJSON
     // was used during development to figure out most relevant stats,
     // Keeping them around as we may want to expand malloc statistics
     // to become more detailed.
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    // Disable this for now as it gives unexpected error with Swift 5.7.1 toolchain
+//    #if swift(>=5.8)
+//        @_documentation(visibility: internal)
+//    #endif
     final class MallocStatsProducer {
         var threadCacheMIB: [size_t]
         var epochMIB: [size_t]


### PR DESCRIPTION
## Description

More idiomatic Swift usage in benchmark run, in the measurement path for better ARC stats. Added some comments, Added one stats benchmark for ARC testing. Remove DocC comment that fails swift test run on toolchain 5.7.1.

## How Has This Been Tested?

Manual test and standard test suite.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
