### PR TITLE
chore(patch): Fix spi builds

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics",
       "state" : {
-        "revision" : "ff3d2212b6b093db7f177d0855adbc4ef9c5f036",
-        "version" : "1.0.3"
+        "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
+        "version" : "1.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -114,6 +114,19 @@ let package = Package(
         ),
     ]
 )
+// Check if this is a SPI build, then we need to disable jemalloc for macOS
+
+let spiBuild: Bool
+
+#if canImport(Darwin)
+if let spiBuildEnvironment = ProcessInfo.processInfo.environment["SPI_BUILD"], spiBuildEnvironment == "1" {
+    spiBuild = true
+} else {
+    spiBuild = false
+}
+#else
+spiBuild = false
+#endif
 
 // Add Benchmark target dynamically
 
@@ -131,7 +144,7 @@ var dependencies: [PackageDescription.Target.Dependency] = [
     "SwiftRuntimeHooks",
 ]
 
-if let disableJemalloc, disableJemalloc != "false", disableJemalloc != "0" {
+if let disableJemalloc, disableJemalloc != "false", disableJemalloc != "0", spiBuild != true {
 } else {
     package.dependencies += [.package(url: "https://github.com/ordo-one/package-jemalloc", .upToNextMajor(from: "1.0.0"))]
     dependencies += [.product(name: "jemalloc", package: "package-jemalloc")]

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
@@ -13,6 +13,9 @@
     import Darwin
     import Dispatch
 
+#if swift(>=5.8)
+@_documentation(visibility: internal)
+#endif
     final class OperatingSystemStatsProducer {
         var nsPerMachTick: Double
         var nsPerSchedulerTick: Int

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
@@ -14,6 +14,9 @@
     import Glibc
     import SystemPackage
 
+#if swift(>=5.8)
+@_documentation(visibility: internal)
+#endif
     public class OperatingSystemStatsProducer {
         var nsPerSchedulerTick: Int
         var pageSize: Int


### PR DESCRIPTION
## Description

Disable jemalloc for SPI macOS builds to more properly reflect build status of the project (using https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/discussions/2307)

Hide internal OperatingSystemStatsProducer class from DocC generation

Update dependencies to get swift-atomics 1.1.

## How Has This Been Tested?

Manual testing.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
