### PR TITLE
docs: Correct readme for adding benchmark targets manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,14 @@ For each executable target, include dependencies on both `Benchmark` (supporting
 The following example shows an benchmark suite named `My-Benchmark` with the required dependency on `Benchmark` and the source files for the benchmark that reside in the directory `Benchmarks/My-Benchmark`:
 ```swift
 .executableTarget(
-    name: "My-Benchmark",
-    dependencies: [
-        .product(name: "Benchmark", package: "package-benchmark"),
-        .product(name: "BenchmarkPlugin", package: "package-benchmark"),
-    ],
-    path: "Benchmarks/My-Benchmark"
+      name: "My-Benchmark",
+      dependencies: [
+          .product(name: "Benchmark", package: "package-benchmark"),
+      ],
+      path: "Benchmarks/My-Benchmark",
+      plugins: [
+          .plugin(name: "BenchmarkPlugin", package: "package-benchmark"),
+      ]
 ),
 ```
 


### PR DESCRIPTION
## Description

Small tweak to README to correct adding a plugin to a benchmark target as per the [spm docs](https://github.com/apple/swift-package-manager/blob/main/Documentation/Plugins.md#making-use-of-a-build-tool-plugin)

## How Has This Been Tested?
I've updated my own usage of package-benchmark to the correct `plugins: [...]` syntax and confirmed that benchmarks still work as expected

## Minimal checklist:

- [x] I have performed a self-review of my own code 
~~- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package~~ N/A
~~- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works~~ N/A
