### PR TITLE
fix(minor): Fix improper generation of benchmark targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -164,9 +164,11 @@ package.targets += [
         name: "BenchmarkDateTime",
         dependencies: [
             "Benchmark",
-            "BenchmarkPlugin"
         ],
-        path: "Benchmarks/DateTime"
+        path: "Benchmarks/DateTime",
+        plugins: [
+            "BenchmarkPlugin"
+        ]
     )
 ]
 
@@ -176,9 +178,11 @@ package.targets += [
         name: "Basic",
         dependencies: [
             "Benchmark",
-            "BenchmarkPlugin"
         ],
-        path: "Benchmarks/Basic"
+        path: "Benchmarks/Basic",
+        plugins: [
+            "BenchmarkPlugin"
+        ]
     ),
 ]
 
@@ -188,9 +192,11 @@ package.targets += [
         name: "HistogramBenchmark",
         dependencies: [
             "Benchmark",
-            "BenchmarkPlugin",
             .product(name: "Histogram", package: "package-histogram"),
         ],
-        path: "Benchmarks/Histogram"
+        path: "Benchmarks/Histogram",
+        plugins: [
+            "BenchmarkPlugin"
+        ]
     ),
 ]

--- a/Plugins/BenchmarkTool/BenchmarkTool+CreateBenchmark.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+CreateBenchmark.swift
@@ -35,9 +35,11 @@ extension BenchmarkTool {
                 name: "\(targetName)",
                 dependencies: [
                     .product(name: "Benchmark", package: "package-benchmark"),
-                    .product(name: "BenchmarkPlugin", package: "package-benchmark")
                 ],
-                path: "Benchmarks/\(targetName)"
+                path: "Benchmarks/\(targetName)",
+                plugins: [
+                    .product(name: "BenchmarkPlugin", package: "package-benchmark")
+                ]
             ),
         ]
         """

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-// swiftlint: disable file_length
+// swiftlint: disable file_length prefer_self_in_static_references
 
 /// Defines a benchmark
 public final class Benchmark: Codable, Hashable {
@@ -38,6 +38,8 @@ public final class Benchmark: Codable, Hashable {
         @_documentation(visibility: internal)
     #endif
     public typealias BenchmarkCustomMetricMeasurement = (BenchmarkMetric, Int) -> Void
+
+// swiftlint: enable prefer_self_in_static_references
 
     /// Alias for closures used to hook into setup / teardown
     public typealias BenchmarkHook = () async throws -> Void

--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -294,7 +294,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
             "(\(scaledTimeUnits.description)) *" : "(\(timeUnits.description)) *"
     }
 
-    public static func == (lhs: BenchmarkResult, rhs: BenchmarkResult) -> Bool {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
         guard lhs.metric == rhs.metric else {
             return false
         }
@@ -314,7 +314,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
         return true
     }
 
-    public static func < (lhs: BenchmarkResult, rhs: BenchmarkResult) -> Bool {
+    public static func < (lhs: Self, rhs: Self) -> Bool {
         let reversedComparison = lhs.metric.polarity == .prefersLarger
 
         guard lhs.metric == rhs.metric else {
@@ -353,13 +353,13 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
     }
 
     // swiftlint:disable function_body_length
-    public func betterResultsOrEqual(than otherResult: BenchmarkResult,
+    public func betterResultsOrEqual(than otherResult: Self,
                                      thresholds: BenchmarkThresholds = .default,
                                      name: String = "unknown name",
                                      target: String = "unknown target") -> (Bool, [ThresholdDeviation]) {
         var violationDescriptions: [ThresholdDeviation] = []
-        var rhs: BenchmarkResult
-        var lhs: BenchmarkResult
+        var rhs: Self
+        var lhs: Self
 
         lhs = self
         rhs = otherResult
@@ -372,7 +372,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
         func worseResult(_ metric: BenchmarkMetric,
                          _ lhs: Int,
                          _ rhs: Int,
-                         _ percentile: BenchmarkResult.Percentile,
+                         _ percentile: Self.Percentile,
                          _ thresholds: BenchmarkThresholds,
                          _ scalingFactor: Statistics.Units) -> (Bool, [ThresholdDeviation]) {
             let relativeDifference = rhs != 0 ? (100 - (100.0 * Double(lhs) / Double(rhs))) : 0.0
@@ -439,7 +439,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
                                              target: String) -> [ThresholdDeviation] {
         func worseResult(_ metric: BenchmarkMetric,
                          _ lhs: Int,
-                         _ percentile: BenchmarkResult.Percentile,
+                         _ percentile: Self.Percentile,
                          _ thresholds: BenchmarkThresholds,
                          _ scalingFactor: Statistics.Units) -> [ThresholdDeviation] {
             let reverseComparison = metric.polarity == .prefersLarger

--- a/Tests/BenchmarkTests/BenchmarkResultTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkResultTests.swift
@@ -119,10 +119,10 @@ final class BenchmarkResultTests: XCTestCase {
                                            thresholds: .default,
                                            statistics: firstStatistics)
 
-        XCTAssert(firstResult != secondResult)
+        XCTAssertNotEqual(firstResult, secondResult)
         XCTAssertFalse(firstResult > secondResult)
         XCTAssertFalse(firstResult < secondResult)
-        XCTAssertFalse(firstResult == secondResult)
+        XCTAssertNotEqual(firstResult, secondResult)
     }
 
     func testBenchmarkResultBetterOrEqualWithDefaultThresholds() throws {
@@ -362,7 +362,7 @@ final class BenchmarkResultTests: XCTestCase {
                                      thresholds: .default,
                                      statistics: firstStatistics)
 
-        XCTAssert(result.normalize(125_000_000) == result.scale(125_000_000_000))
+        XCTAssertEqual(result.normalize(125_000_000), result.scale(125_000_000_000))
 
         result = BenchmarkResult(metric: .cpuUser,
                                  timeUnits: .microseconds,
@@ -371,7 +371,7 @@ final class BenchmarkResultTests: XCTestCase {
                                  thresholds: .default,
                                  statistics: firstStatistics)
 
-        XCTAssert(result.normalize(125_000_000) == result.scale(125_000_000_000))
+        XCTAssertEqual(result.normalize(125_000_000), result.scale(125_000_000_000))
 
         result = BenchmarkResult(metric: .cpuUser,
                                  timeUnits: .nanoseconds,
@@ -380,7 +380,7 @@ final class BenchmarkResultTests: XCTestCase {
                                  thresholds: .default,
                                  statistics: firstStatistics)
 
-        XCTAssert(result.normalize(125_000_000) == result.scale(125_000_000_000))
+        XCTAssertEqual(result.normalize(125_000_000), result.scale(125_000_000_000))
     }
 
     func testBenchmarkResultEnumerations() throws {

--- a/Tests/BenchmarkTests/StatisticsTests.swift
+++ b/Tests/BenchmarkTests/StatisticsTests.swift
@@ -25,7 +25,7 @@ final class StatisticsTests: XCTestCase {
             stats.add(measurement)
         }
 
-        XCTAssert(Statistics.roundToDecimalplaces(123.4567898972239487234) == 123.46)
+        XCTAssertEqual(Statistics.roundToDecimalplaces(123.4567898972239487234), 123.46)
         XCTAssertEqual(stats.measurementCount, measurementCount * 2)
         XCTAssertEqual(stats.units(), .count)
         XCTAssertEqual(round(stats.histogram.mean), round(Double(measurementCount / 2)))


### PR DESCRIPTION
## Description

Fix benchmark init generation to add proper dependencies (as mentioned in (https://github.com/ordo-one/package-benchmark/pull/157)) - fix the local benchmark targets too.

## How Has This Been Tested?

Manual testing.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
