### PR TITLE
fix(patch): Provide better feedback when benchmark init hooks fails

### DIFF
--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -185,7 +185,7 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                                           \(error)
 
                                           If it is a filesystem permissioning error or if the benchmark uses networking, you may need
-                                          to give permissions or even disable SwiftPM:s sandbox environment and run the benchmark using:
+                                          to give permissions or even disable SwiftPM's sandbox environment and run the benchmark using:
 
                                           swift package --allow-writing-to-package-directory benchmark
                                           or


### PR DESCRIPTION
## Description

Provide better error description when setup fails.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
