### PR TITLE
chore(patch): [sc-2205] Revert adding iOS target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,10 +8,7 @@ let disableJemalloc = ProcessInfo.processInfo.environment["BENCHMARK_DISABLE_JEM
 
 let package = Package(
     name: "Benchmark",
-    platforms: [
-        .macOS(.v13),
-        .iOS(.v16)
-    ],
+    platforms: [.macOS(.v13)],
     products: [
         .plugin(name: "BenchmarkCommandPlugin", targets: ["BenchmarkCommandPlugin"]),
         .plugin(name: "BenchmarkPlugin", targets: ["BenchmarkPlugin"]),
@@ -121,7 +118,7 @@ let package = Package(
 
 let macOSSPIBuild: Bool // Disables jemalloc for macOS SPI builds as the infrastructure doesn't have jemalloc there
 
-#if os(macOS) || os(iOS)
+#if os(macOS)
 if let spiBuildEnvironment = ProcessInfo.processInfo.environment["SPI_BUILD"], spiBuildEnvironment == "1" {
     macOSSPIBuild = true
     print("Building for SPI@macOS, disabling Jemalloc")


### PR DESCRIPTION
## Description

Reverts adding iOS target for now.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [ ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
