### PR TITLE
chore(patch): [sc-2205] Stub out libproc.h on iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -142,7 +142,7 @@ var dependencies: [PackageDescription.Target.Dependency] = [
     .product(name: "SystemPackage", package: "swift-system"),
     .product(name: "DateTime", package: "package-datetime"),
     .product(name: "Progress", package: "Progress.swift"),
-    .byNameItem(name: "CDarwinOperatingSystemStats", condition: .when(platforms: [.macOS])),
+    .byNameItem(name: "CDarwinOperatingSystemStats", condition: .when(platforms: [.macOS, .iOS])),
     .byNameItem(name: "CLinuxOperatingSystemStats", condition: .when(platforms: [.linux])),
     .product(name: "Atomics", package: "swift-atomics"),
     "SwiftRuntimeHooks",

--- a/Platform/CDarwinOperatingSystemStats/include/CDarwinOperatingSystemStats.h
+++ b/Platform/CDarwinOperatingSystemStats/include/CDarwinOperatingSystemStats.h
@@ -13,6 +13,8 @@
 #ifndef CDarwinOperatingSystemStats_h
 #define CDarwinOperatingSystemStats_h
 
+#if __has_include(<libproc.h>)
 #include <libproc.h>
+#endif
 
 #endif /* CDarwinOperatingSystemStats_h */

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-// swiftlint: disable file_length prefer_self_in_static_references
+// swiftlint: disable file_length
 
 /// Defines a benchmark
 public final class Benchmark: Codable, Hashable {
@@ -38,8 +38,6 @@ public final class Benchmark: Codable, Hashable {
         @_documentation(visibility: internal)
     #endif
     public typealias BenchmarkCustomMetricMeasurement = (BenchmarkMetric, Int) -> Void
-
-// swiftlint: enable prefer_self_in_static_references
 
     /// Alias for closures used to hook into setup / teardown
     public typealias BenchmarkHook = () async throws -> Void

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
@@ -52,7 +52,7 @@ final class OperatingSystemStatsProducer {
         nsPerSchedulerTick = 1_000_000_000 / schedulerTicksPerSecond
     }
 
-#if !os(iOS)
+#if os(macOS)
     fileprivate
     func getProcInfo() -> proc_taskinfo {
         var procTaskInfo = proc_taskinfo()
@@ -68,7 +68,7 @@ final class OperatingSystemStatsProducer {
 #endif
 
     func startSampling(_: Int = 10_000) { // sample rate in microseconds
-#if !os(iOS)
+#if os(macOS)
         DispatchQueue.global(qos: .userInitiated).async {
             self.lock.lock()
             let rate = self.sampleRate
@@ -110,7 +110,7 @@ final class OperatingSystemStatsProducer {
     }
 
     func stopSampling() {
-#if !os(iOS)
+#if os(macOS)
         lock.withLock {
             runState = .shuttingDown
         }
@@ -119,7 +119,7 @@ final class OperatingSystemStatsProducer {
     }
 
     func makeOperatingSystemStats() -> OperatingSystemStats {
-#if !os(iOS)
+#if os(macOS)
         let procTaskInfo = getProcInfo()
         let userTime = Int(nsPerMachTick * Double(procTaskInfo.pti_total_user))
         let systemTime = Int(nsPerMachTick * Double(procTaskInfo.pti_total_system))
@@ -149,28 +149,12 @@ final class OperatingSystemStatsProducer {
 
         return stats
 #else
-        let stats = OperatingSystemStats(cpuUser: 0,
-                                         cpuSystem: 0,
-                                         cpuTotal: 0,
-                                         peakMemoryResident: 0,
-                                         peakMemoryVirtual: 0,
-                                         syscalls: 0,
-                                         contextSwitches: 0,
-                                         threads: 0,
-                                         threadsRunning: 0,
-                                         readSyscalls: 0,
-                                         writeSyscalls: 0,
-                                         readBytesLogical: 0,
-                                         writeBytesLogical: 0,
-                                         readBytesPhysical: 0,
-                                         writeBytesPhysical: 0)
-
-        return stats
+        return .init()
 #endif
     }
 
     func metricSupported(_ metric: BenchmarkMetric) -> Bool {
-#if !os(iOS)
+#if os(macOS)
         switch metric {
         case .readSyscalls:
             return false
@@ -188,7 +172,7 @@ final class OperatingSystemStatsProducer {
             return true
         }
 #else
-        // No metrics supported on iOS due to lack of libproc.h
+        // No metrics supported due to lack of libproc.h
         return false
 #endif
     }

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
@@ -149,11 +149,6 @@ final class OperatingSystemStatsProducer {
 
         return stats
 #else
-        lock.lock()
-        let threads = peakThreads
-        let threadsRunning = peakThreadsRunning
-        lock.unlock()
-
         let stats = OperatingSystemStats(cpuUser: 0,
                                          cpuSystem: 0,
                                          cpuTotal: 0,
@@ -161,8 +156,8 @@ final class OperatingSystemStatsProducer {
                                          peakMemoryVirtual: 0,
                                          syscalls: 0,
                                          contextSwitches: 0,
-                                         threads: threads,
-                                         threadsRunning: threadsRunning,
+                                         threads: 0,
+                                         threadsRunning: 0,
                                          readSyscalls: 0,
                                          writeSyscalls: 0,
                                          readBytesLogical: 0,
@@ -175,6 +170,7 @@ final class OperatingSystemStatsProducer {
     }
 
     func metricSupported(_ metric: BenchmarkMetric) -> Bool {
+#if !os(iOS)
         switch metric {
         case .readSyscalls:
             return false
@@ -191,6 +187,10 @@ final class OperatingSystemStatsProducer {
         default:
             return true
         }
+#else
+        // No metrics supported on iOS due to lack of libproc.h
+        return false
+#endif
     }
 }
 


### PR DESCRIPTION
## Description

Use `CDarwinOperatingSystemStats` on iOS but stub out all uses of `libproc.h`. Let `makeOperatingSystemStats()` return at least information about number of threads.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [ ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
