### PR TITLE
feat(minor): Improve metric api ergonomics (#175)

### DIFF
--- a/Benchmarks/Basic/Basic+SetupTeardown.swift
+++ b/Benchmarks/Basic/Basic+SetupTeardown.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Joakim Hassila on 2023-04-21.
 //

--- a/Benchmarks/Basic/BenchmarkRunner+Basic.swift
+++ b/Benchmarks/Basic/BenchmarkRunner+Basic.swift
@@ -24,9 +24,9 @@ let benchmarks = {
                                                                 .p99: .milliseconds(3),
                                                                 .p100: .milliseconds(1)]
 
-        thresholds = [.wallClock : .init(absolute: absolute)]
+        thresholds = [.wallClock: .init(absolute: absolute)]
     } else {
-        thresholds = [.wallClock : .relaxed]
+        thresholds = [.wallClock: .relaxed]
     }
 
     Benchmark.defaultConfiguration = .init(warmupIterations: 0,

--- a/Benchmarks/Basic/BenchmarkRunner+Basic.swift
+++ b/Benchmarks/Basic/BenchmarkRunner+Basic.swift
@@ -24,9 +24,9 @@ let benchmarks = {
                                                                 .p99: .milliseconds(3),
                                                                 .p100: .milliseconds(1)]
 
-        thresholds = [BenchmarkMetric.wallClock: BenchmarkThresholds(absolute: absolute)]
+        thresholds = [.wallClock : .init(absolute: absolute)]
     } else {
-        thresholds = [BenchmarkMetric.wallClock: BenchmarkThresholds.relaxed]
+        thresholds = [.wallClock : .relaxed]
     }
 
     Benchmark.defaultConfiguration = .init(warmupIterations: 0,
@@ -47,7 +47,7 @@ let benchmarks = {
     }
 
     Benchmark("Scaled metrics",
-              configuration: .init(metrics: BenchmarkMetric.all + [CustomMetrics.two, CustomMetrics.one],
+              configuration: .init(metrics: .all + [CustomMetrics.two, CustomMetrics.one],
                                    scalingFactor: .kilo)) { benchmark in
         for _ in benchmark.scaledIterations {
             blackHole(Int.random(in: benchmark.scaledIterations))
@@ -57,7 +57,7 @@ let benchmarks = {
     }
 
     Benchmark("All metrics",
-              configuration: .init(metrics: BenchmarkMetric.all, skip: true)) { _ in
+              configuration: .init(metrics: .all, skip: true)) { _ in
     }
 
     let stats = Statistics(numberOfSignificantDigits: .four)
@@ -68,7 +68,7 @@ let benchmarks = {
     }
 
     Benchmark("Statistics",
-              configuration: .init(metrics: BenchmarkMetric.arc + [.wallClock],
+              configuration: .init(metrics: .arc + [.wallClock],
                                    scalingFactor: .kilo, maxDuration: .seconds(1))) { benchmark in
         for _ in benchmark.scaledIterations {
             blackHole(stats.percentiles())

--- a/Benchmarks/DateTime/DateTime.swift
+++ b/Benchmarks/DateTime/DateTime.swift
@@ -11,7 +11,7 @@ import Benchmark
 import DateTime
 
 let benchmarks = {
-    Benchmark.defaultConfiguration = .init(metrics: [.throughput, .wallClock] + BenchmarkMetric.arc,
+    Benchmark.defaultConfiguration = .init(metrics: [.throughput, .wallClock] + .arc,
                                            warmupIterations: 10,
                                            scalingFactor: .kilo,
                                            maxDuration: .seconds(1),

--- a/Benchmarks/Histogram/Histogram.swift
+++ b/Benchmarks/Histogram/Histogram.swift
@@ -11,7 +11,7 @@ import Benchmark
 import Histogram
 
 let benchmarks = {
-    let metrics = [.wallClock, .throughput] + BenchmarkMetric.memory + BenchmarkMetric.arc
+    let metrics = [.wallClock, .throughput] + .memory + .arc
     Benchmark.defaultConfiguration = .init(metrics: metrics,
                                            scalingFactor: .mega,
                                            maxDuration: .seconds(1),

--- a/Package.swift
+++ b/Package.swift
@@ -122,14 +122,14 @@ let package = Package(
 let macOSSPIBuild: Bool // Disables jemalloc for macOS SPI builds as the infrastructure doesn't have jemalloc there
 
 #if os(macOS) || os(iOS)
-if let spiBuildEnvironment = ProcessInfo.processInfo.environment["SPI_BUILD"], spiBuildEnvironment == "1" {
-    macOSSPIBuild = true
-    print("Building for SPI@macOS, disabling Jemalloc")
-} else {
-    macOSSPIBuild = false
-}
+    if let spiBuildEnvironment = ProcessInfo.processInfo.environment["SPI_BUILD"], spiBuildEnvironment == "1" {
+        macOSSPIBuild = true
+        print("Building for SPI@macOS, disabling Jemalloc")
+    } else {
+        macOSSPIBuild = false
+    }
 #else
-macOSSPIBuild = false
+    macOSSPIBuild = false
 #endif
 
 // Add Benchmark target dynamically

--- a/Plugins/BenchmarkTool/BenchmarkTool+CreateBenchmark.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+CreateBenchmark.swift
@@ -11,11 +11,11 @@
 import SystemPackage
 
 #if canImport(Darwin)
-import Darwin
+    import Darwin
 #elseif canImport(Glibc)
-import Glibc
+    import Glibc
 #else
-#error("Unsupported Platform")
+    #error("Unsupported Platform")
 #endif
 
 extension BenchmarkTool {

--- a/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
@@ -57,9 +57,9 @@ extension BenchmarkTool {
         outputPath.append(csvFile.components)
 
         print("Writing output to \(outputPath)")
-        
+
         printFailedBenchmarks()
-        
+
         do {
             let fd = try FileDescriptor.open(
                 outputPath, .writeOnly, options: [.truncate, .create], permissions: .ownerReadWrite
@@ -112,7 +112,7 @@ extension BenchmarkTool {
         outputPath.append(jsonFile.components)
 
         print("Writing output to \(outputPath)")
-        
+
         printFailedBenchmarks()
 
         do {
@@ -221,7 +221,7 @@ extension BenchmarkTool {
             }
         }
     }
-    
+
     func printFailedBenchmarks() {
         if !failedBenchmarkList.isEmpty {
             print("The following benchmarks failed: \n")

--- a/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
@@ -62,7 +62,7 @@ extension BenchmarkTool {
                 break outerloop
             case let .error(description):
                 failBenchmark(description, exitCode: .benchmarkJobFailed, "\(target)/\(benchmark.name)")
-                
+
                 benchmarkResults[BenchmarkIdentifier(target: target, name: benchmark.name)] = []
                 break outerloop
             default:

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -118,10 +118,6 @@ struct BenchmarkTool: AsyncParsableCommand {
 
         // check what failed and react accordingly
         switch exitCode {
-        case .genericFailure:
-            exitBenchmark(exitCode: exitCode)
-        case .thresholdViolation:
-            exitBenchmark(exitCode: exitCode)
         case .benchmarkJobFailed:
             if let failedBenchmark {
                 failedBenchmarkList.append(failedBenchmark)

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -107,7 +107,7 @@ struct BenchmarkTool: AsyncParsableCommand {
     var benchmarkBaselines: [BenchmarkBaseline] = [] // The baselines read from disk, merged + current run if needed
     var comparisonBaseline: BenchmarkBaseline?
     var checkBaseline: BenchmarkBaseline?
-    
+
     var failedBenchmarkList: [String] = []
 
     mutating func failBenchmark(_ reason: String? = nil, exitCode: ExitCode = .genericFailure, _ failedBenchmark: String? = nil) {
@@ -115,22 +115,22 @@ struct BenchmarkTool: AsyncParsableCommand {
             print(reason)
             print("")
         }
-        
+
         // check what failed and react accordingly
         switch exitCode {
-            case .genericFailure:
-                exitBenchmark(exitCode: exitCode)
-            case .thresholdViolation:
-                exitBenchmark(exitCode: exitCode)
-            case .benchmarkJobFailed:
-                if let failedBenchmark {
-                    failedBenchmarkList.append(failedBenchmark)
-                }
-            default:
-                exitBenchmark(exitCode: exitCode)
+        case .genericFailure:
+            exitBenchmark(exitCode: exitCode)
+        case .thresholdViolation:
+            exitBenchmark(exitCode: exitCode)
+        case .benchmarkJobFailed:
+            if let failedBenchmark {
+                failedBenchmarkList.append(failedBenchmark)
+            }
+        default:
+            exitBenchmark(exitCode: exitCode)
         }
     }
-    
+
     func exitBenchmark(exitCode: ExitCode) {
         #if canImport(Darwin)
             Darwin.exit(exitCode.rawValue)
@@ -138,7 +138,6 @@ struct BenchmarkTool: AsyncParsableCommand {
             Glibc.exit(exitCode.rawValue)
         #endif
     }
-    
 
     func printChildRunError(error: Int32, benchmarkExecutablePath: String) {
         print("Failed to run '\(command)' for \(benchmarkExecutablePath), error code [\(error)]")
@@ -314,7 +313,6 @@ struct BenchmarkTool: AsyncParsableCommand {
                 switch benchmarkCommand {
                 case .`init`:
                     fatalError("Should never come here")
-                    break
                 case .query:
                     try queryBenchmarks(benchmarkPath) // Get all available benchmarks first
                 case .list:
@@ -347,7 +345,7 @@ struct BenchmarkTool: AsyncParsableCommand {
 
         return benchmarkResults
     }
-    
+
     struct FailedBenchmark: Codable {
         let benchmarkName: String
         let failureReason: String

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-// swiftlint: disable file_length prefer_self_in_static_references
+// swiftlint: disable file_length
 
 /// Defines a benchmark
 public final class Benchmark: Codable, Hashable {
@@ -410,8 +410,6 @@ public extension Benchmark {
         // swiftlint:enable nesting
     }
 }
-
-// swiftlint:enable prefer_self_in_static_references
 
 // This is an additional convenience duplicating the free standing function blackHole() for those cases where
 // another module happens to define it, as we have a type clash between module name and type name and otherwise

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-// swiftlint: disable file_length
+// swiftlint: disable file_length prefer_self_in_static_references
 
 /// Defines a benchmark
 public final class Benchmark: Codable, Hashable {
@@ -410,6 +410,8 @@ public extension Benchmark {
         // swiftlint:enable nesting
     }
 }
+
+// swiftlint:enable prefer_self_in_static_references
 
 // This is an additional convenience duplicating the free standing function blackHole() for those cases where
 // another module happens to define it, as we have a type clash between module name and type name and otherwise

--- a/Sources/Benchmark/BenchmarkExecutor+Extensions.swift
+++ b/Sources/Benchmark/BenchmarkExecutor+Extensions.swift
@@ -77,4 +77,5 @@ extension BenchmarkExecutor {
         }
     }
 }
+
 // swiftlint:enable cyclomatic_complexity

--- a/Sources/Benchmark/BenchmarkInternals.swift
+++ b/Sources/Benchmark/BenchmarkInternals.swift
@@ -36,4 +36,5 @@ public enum BenchmarkCommandReply: Codable {
     case end // end of query for list/result
     case error(_ description: String) // error while performing operation (e.g. 'run')
 }
+
 // swiftlint:enable all

--- a/Sources/Benchmark/BenchmarkMetric+Defaults.swift
+++ b/Sources/Benchmark/BenchmarkMetric+Defaults.swift
@@ -13,6 +13,9 @@ public extension BenchmarkMetric {
     /// The default collection of metrics used for a benchmark.
     ///
     /// The defaults include ``wallClock``, ``cpuTotal``, ``mallocCountTotal``, ``throughput``, and ``peakMemoryResident``.
+    ///
+    /// There is also an convenience extension on Array defined such that you can write just `.default` rather than `BenchmarkMetric.default`
+    ///
     static var `default`: [BenchmarkMetric] {
         [.wallClock,
          .cpuTotal,
@@ -100,3 +103,44 @@ public extension BenchmarkMetric {
          .retainReleaseDelta]
     }
 }
+
+// Nicer convenience extension for Array so one can write `.extended` instead of `BenchmarkMetric.extended`
+public extension Array where Element == BenchmarkMetric {
+    /// The default collection of metrics used for a benchmark.
+    ///
+    /// The defaults include ``wallClock``, ``cpuTotal``, ``mallocCountTotal``, ``throughput``, and ``peakMemoryResident``.
+    static var `default`: [BenchmarkMetric] {
+        BenchmarkMetric.default
+    }
+
+    /// A collection of extended system benchmarks.
+    static var extended: [BenchmarkMetric] {
+        BenchmarkMetric.extended
+    }
+
+    /// A collection of memory benchmarks.
+    static var memory: [BenchmarkMetric] {
+        BenchmarkMetric.memory
+    }
+
+    /// A collection of ARC metrics
+    static var arc: [BenchmarkMetric] {
+        BenchmarkMetric.arc
+    }
+
+    /// A collection of system benchmarks.
+    static var system: [BenchmarkMetric] {
+        BenchmarkMetric.system
+    }
+
+    /// A collection of disk benchmarks.
+    static var disk: [BenchmarkMetric] {
+        BenchmarkMetric.disk
+    }
+
+    /// A collection of all benchmarks supported by this library.
+    static var all: [BenchmarkMetric] {
+        BenchmarkMetric.all
+    }
+}
+

--- a/Sources/Benchmark/BenchmarkMetric+Defaults.swift
+++ b/Sources/Benchmark/BenchmarkMetric+Defaults.swift
@@ -105,7 +105,7 @@ public extension BenchmarkMetric {
 }
 
 // Nicer convenience extension for Array so one can write `.extended` instead of `BenchmarkMetric.extended`
-public extension Array where Element == BenchmarkMetric {
+public extension [BenchmarkMetric] {
     /// The default collection of metrics used for a benchmark.
     ///
     /// The defaults include ``wallClock``, ``cpuTotal``, ``mallocCountTotal``, ``throughput``, and ``peakMemoryResident``.
@@ -143,4 +143,3 @@ public extension Array where Element == BenchmarkMetric {
         BenchmarkMetric.all
     }
 }
-

--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -531,4 +531,5 @@ public extension BenchmarkTimeUnits {
         }
     }
 }
+
 // swiftlint:enable file_length identifier_name function_parameter_count function_body_length type_body_length

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -180,17 +180,17 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                         }
                     } catch {
                         let description = """
-                                          Benchmark.setup or local benchmark setup failed:
+                        Benchmark.setup or local benchmark setup failed:
 
-                                          \(error)
+                        \(error)
 
-                                          If it is a filesystem permissioning error or if the benchmark uses networking, you may need
-                                          to give permissions or even disable SwiftPM's sandbox environment and run the benchmark using:
+                        If it is a filesystem permissioning error or if the benchmark uses networking, you may need
+                        to give permissions or even disable SwiftPM's sandbox environment and run the benchmark using:
 
-                                          swift package --allow-writing-to-package-directory benchmark
-                                          or
-                                          swift package --disable-sandbox benchmark
-                                          """
+                        swift package --allow-writing-to-package-directory benchmark
+                        or
+                        swift package --disable-sandbox benchmark
+                        """
 
                         try channel.write(.error(description))
                         return

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -162,7 +162,7 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                     }
 
                     if debug, allMetrics {
-                        benchmark.configuration.metrics = BenchmarkMetric.all
+                        benchmark.configuration.metrics = .all
                     }
 
                     benchmark.target = benchmarkToRun.target

--- a/Sources/Benchmark/BenchmarkThresholds+Defaults.swift
+++ b/Sources/Benchmark/BenchmarkThresholds+Defaults.swift
@@ -92,4 +92,5 @@ public extension BenchmarkThresholds {
         BenchmarkThresholds()
     }
 }
+
 // swiftlint:enable discouraged_none_name

--- a/Sources/Benchmark/Blackhole.swift
+++ b/Sources/Benchmark/Blackhole.swift
@@ -33,6 +33,6 @@
 public func blackHole(_: some Any) {}
 
 @inline(never)
-public func identity<T>(_ x: T) -> T {
-    return x
+public func identity<T>(_ value: T) -> T {
+    value
 }

--- a/Sources/Benchmark/Blackhole.swift
+++ b/Sources/Benchmark/Blackhole.swift
@@ -31,3 +31,8 @@
 /// ```
 @inline(never)
 public func blackHole(_: some Any) {}
+
+@inline(never)
+public func identity<T>(_ x: T) -> T {
+    return x
+}

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
@@ -10,172 +10,172 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 
-import CDarwinOperatingSystemStats
-import Darwin
-import Dispatch
+    import CDarwinOperatingSystemStats
+    import Darwin
+    import Dispatch
 
-final class OperatingSystemStatsProducer {
-    var nsPerMachTick: Double
-    var nsPerSchedulerTick: Int
+    final class OperatingSystemStatsProducer {
+        var nsPerMachTick: Double
+        var nsPerSchedulerTick: Int
 
-    let lock = NIOLock()
-    let semaphore = DispatchSemaphore(value: 0)
-    var peakThreads: Int = 0
-    var peakThreadsRunning: Int = 0
-    var runState: RunState = .running
-    var sampleRate: Int = 10_000
+        let lock = NIOLock()
+        let semaphore = DispatchSemaphore(value: 0)
+        var peakThreads: Int = 0
+        var peakThreadsRunning: Int = 0
+        var runState: RunState = .running
+        var sampleRate: Int = 10_000
 
-    enum RunState {
-        case running
-        case shuttingDown
-        case done
-    }
-
-    internal
-    final class CallbackDataCarrier<T> {
-        init(_ data: T) {
-            self.data = data
+        enum RunState {
+            case running
+            case shuttingDown
+            case done
         }
 
-        var data: T
-    }
-
-    init() {
-        var info = mach_timebase_info_data_t()
-
-        mach_timebase_info(&info)
-
-        nsPerMachTick = Double(info.numer) / Double(info.denom)
-
-        let schedulerTicksPerSecond = sysconf(_SC_CLK_TCK)
-
-        nsPerSchedulerTick = 1_000_000_000 / schedulerTicksPerSecond
-    }
-
-#if os(macOS)
-    fileprivate
-    func getProcInfo() -> proc_taskinfo {
-        var procTaskInfo = proc_taskinfo()
-        let procTaskInfoSize = MemoryLayout<proc_taskinfo>.size
-
-        let result = proc_pidinfo(getpid(), PROC_PIDTASKINFO, 0, &procTaskInfo, Int32(procTaskInfoSize))
-
-        if result != procTaskInfoSize {
-            fatalError("proc_pidinfo returned an error \(errno)")
-        }
-        return procTaskInfo
-    }
-#endif
-
-    func startSampling(_: Int = 10_000) { // sample rate in microseconds
-#if os(macOS)
-        DispatchQueue.global(qos: .userInitiated).async {
-            self.lock.lock()
-            let rate = self.sampleRate
-            self.peakThreads = 0
-            self.peakThreadsRunning = 0
-            self.runState = .running
-            self.lock.unlock()
-
-            while true {
-                let procTaskInfo = self.getProcInfo()
-
-                self.lock.lock()
-                if procTaskInfo.pti_threadnum > self.peakThreads {
-                    self.peakThreads = Int(procTaskInfo.pti_threadnum)
-                }
-
-                if procTaskInfo.pti_numrunning > self.peakThreadsRunning {
-                    self.peakThreadsRunning = Int(procTaskInfo.pti_numrunning)
-                }
-
-                if self.runState == .shuttingDown {
-                    self.runState = .done
-                    self.semaphore.signal()
-                }
-
-                let quit = self.runState
-                self.lock.unlock()
-
-                if quit == .done {
-                    return
-                }
-
-                usleep(UInt32.random(in: UInt32(Double(rate) * 0.9) ... UInt32(Double(rate) * 1.1)))
+        internal
+        final class CallbackDataCarrier<T> {
+            init(_ data: T) {
+                self.data = data
             }
+
+            var data: T
         }
-        // We'll sleep just a little bit to let the sampler thread get going so we don't get 0 samples
-        usleep(1_000)
-#endif
-    }
 
-    func stopSampling() {
-#if os(macOS)
-        lock.withLock {
-            runState = .shuttingDown
+        init() {
+            var info = mach_timebase_info_data_t()
+
+            mach_timebase_info(&info)
+
+            nsPerMachTick = Double(info.numer) / Double(info.denom)
+
+            let schedulerTicksPerSecond = sysconf(_SC_CLK_TCK)
+
+            nsPerSchedulerTick = 1_000_000_000 / schedulerTicksPerSecond
         }
-        semaphore.wait()
-#endif
-    }
 
-    func makeOperatingSystemStats() -> OperatingSystemStats {
-#if os(macOS)
-        let procTaskInfo = getProcInfo()
-        let userTime = Int(nsPerMachTick * Double(procTaskInfo.pti_total_user))
-        let systemTime = Int(nsPerMachTick * Double(procTaskInfo.pti_total_system))
-        let totalTime = userTime + systemTime
+        #if os(macOS)
+            fileprivate
+            func getProcInfo() -> proc_taskinfo {
+                var procTaskInfo = proc_taskinfo()
+                let procTaskInfoSize = MemoryLayout<proc_taskinfo>.size
 
-        lock.lock()
-        let threads = peakThreads
-        let threadsRunning = peakThreadsRunning
-        lock.unlock()
+                let result = proc_pidinfo(getpid(), PROC_PIDTASKINFO, 0, &procTaskInfo, Int32(procTaskInfoSize))
 
-        let stats = OperatingSystemStats(cpuUser: userTime,
-                                         cpuSystem: systemTime,
-                                         cpuTotal: totalTime,
-                                         peakMemoryResident: Int(procTaskInfo.pti_resident_size),
-                                         peakMemoryVirtual: Int(procTaskInfo.pti_virtual_size),
-                                         syscalls: Int(procTaskInfo.pti_syscalls_unix) +
-                                         Int(procTaskInfo.pti_syscalls_mach),
-                                         contextSwitches: Int(procTaskInfo.pti_csw),
-                                         threads: threads,
-                                         threadsRunning: threadsRunning,
-                                         readSyscalls: 0,
-                                         writeSyscalls: 0,
-                                         readBytesLogical: 0,
-                                         writeBytesLogical: 0,
-                                         readBytesPhysical: 0,
-                                         writeBytesPhysical: 0)
+                if result != procTaskInfoSize {
+                    fatalError("proc_pidinfo returned an error \(errno)")
+                }
+                return procTaskInfo
+            }
+        #endif
 
-        return stats
-#else
-        return .init()
-#endif
-    }
+        func startSampling(_: Int = 10_000) { // sample rate in microseconds
+            #if os(macOS)
+                DispatchQueue.global(qos: .userInitiated).async {
+                    self.lock.lock()
+                    let rate = self.sampleRate
+                    self.peakThreads = 0
+                    self.peakThreadsRunning = 0
+                    self.runState = .running
+                    self.lock.unlock()
 
-    func metricSupported(_ metric: BenchmarkMetric) -> Bool {
-#if os(macOS)
-        switch metric {
-        case .readSyscalls:
-            return false
-        case .writeSyscalls:
-            return false
-        case .readBytesLogical:
-            return false
-        case .writeBytesLogical:
-            return false
-        case .readBytesPhysical:
-            return false
-        case .writeBytesPhysical:
-            return false
-        default:
-            return true
+                    while true {
+                        let procTaskInfo = self.getProcInfo()
+
+                        self.lock.lock()
+                        if procTaskInfo.pti_threadnum > self.peakThreads {
+                            self.peakThreads = Int(procTaskInfo.pti_threadnum)
+                        }
+
+                        if procTaskInfo.pti_numrunning > self.peakThreadsRunning {
+                            self.peakThreadsRunning = Int(procTaskInfo.pti_numrunning)
+                        }
+
+                        if self.runState == .shuttingDown {
+                            self.runState = .done
+                            self.semaphore.signal()
+                        }
+
+                        let quit = self.runState
+                        self.lock.unlock()
+
+                        if quit == .done {
+                            return
+                        }
+
+                        usleep(UInt32.random(in: UInt32(Double(rate) * 0.9) ... UInt32(Double(rate) * 1.1)))
+                    }
+                }
+                // We'll sleep just a little bit to let the sampler thread get going so we don't get 0 samples
+                usleep(1_000)
+            #endif
         }
-#else
-        // No metrics supported due to lack of libproc.h
-        return false
-#endif
+
+        func stopSampling() {
+            #if os(macOS)
+                lock.withLock {
+                    runState = .shuttingDown
+                }
+                semaphore.wait()
+            #endif
+        }
+
+        func makeOperatingSystemStats() -> OperatingSystemStats {
+            #if os(macOS)
+                let procTaskInfo = getProcInfo()
+                let userTime = Int(nsPerMachTick * Double(procTaskInfo.pti_total_user))
+                let systemTime = Int(nsPerMachTick * Double(procTaskInfo.pti_total_system))
+                let totalTime = userTime + systemTime
+
+                lock.lock()
+                let threads = peakThreads
+                let threadsRunning = peakThreadsRunning
+                lock.unlock()
+
+                let stats = OperatingSystemStats(cpuUser: userTime,
+                                                 cpuSystem: systemTime,
+                                                 cpuTotal: totalTime,
+                                                 peakMemoryResident: Int(procTaskInfo.pti_resident_size),
+                                                 peakMemoryVirtual: Int(procTaskInfo.pti_virtual_size),
+                                                 syscalls: Int(procTaskInfo.pti_syscalls_unix) +
+                                                     Int(procTaskInfo.pti_syscalls_mach),
+                                                 contextSwitches: Int(procTaskInfo.pti_csw),
+                                                 threads: threads,
+                                                 threadsRunning: threadsRunning,
+                                                 readSyscalls: 0,
+                                                 writeSyscalls: 0,
+                                                 readBytesLogical: 0,
+                                                 writeBytesLogical: 0,
+                                                 readBytesPhysical: 0,
+                                                 writeBytesPhysical: 0)
+
+                return stats
+            #else
+                return .init()
+            #endif
+        }
+
+        func metricSupported(_ metric: BenchmarkMetric) -> Bool {
+            #if os(macOS)
+                switch metric {
+                case .readSyscalls:
+                    return false
+                case .writeSyscalls:
+                    return false
+                case .readBytesLogical:
+                    return false
+                case .writeBytesLogical:
+                    return false
+                case .readBytesPhysical:
+                    return false
+                case .writeBytesPhysical:
+                    return false
+                default:
+                    return true
+                }
+            #else
+                // No metrics supported due to lack of libproc.h
+                return false
+            #endif
+        }
     }
-}
 
 #endif

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
@@ -10,168 +10,168 @@
 
 #if os(Linux)
 
-import CLinuxOperatingSystemStats
-import Dispatch
-import Glibc
-import SystemPackage
+    import CLinuxOperatingSystemStats
+    import Dispatch
+    import Glibc
+    import SystemPackage
 
-final class OperatingSystemStatsProducer {
-    var nsPerSchedulerTick: Int
-    var pageSize: Int
+    final class OperatingSystemStatsProducer {
+        var nsPerSchedulerTick: Int
+        var pageSize: Int
 
-    let lock = NIOLock()
-    let semaphore = DispatchSemaphore(value: 0)
-    var peakThreads: Int = 0
-    var sampleRate: Int = 10_000
-    var runState: RunState = .running
+        let lock = NIOLock()
+        let semaphore = DispatchSemaphore(value: 0)
+        var peakThreads: Int = 0
+        var sampleRate: Int = 10_000
+        var runState: RunState = .running
 
-    enum RunState {
-        case running
-        case shuttingDown
-        case done
-    }
+        enum RunState {
+            case running
+            case shuttingDown
+            case done
+        }
 
-    init() {
-        let schedulerTicksPerSecond = sysconf(Int32(_SC_CLK_TCK))
+        init() {
+            let schedulerTicksPerSecond = sysconf(Int32(_SC_CLK_TCK))
 
-        nsPerSchedulerTick = 1_000_000_000 / schedulerTicksPerSecond
-        pageSize = sysconf(Int32(_SC_PAGESIZE))
-    }
+            nsPerSchedulerTick = 1_000_000_000 / schedulerTicksPerSecond
+            pageSize = sysconf(Int32(_SC_PAGESIZE))
+        }
 
-    deinit {}
+        deinit {}
 
-    // We should cache the open file(s) and just read from file offset 0 to reduce overhead
-    func read(path: FilePath) -> String {
-        var string = ""
+        // We should cache the open file(s) and just read from file offset 0 to reduce overhead
+        func read(path: FilePath) -> String {
+            var string = ""
 
-        do {
-            let fileDescriptor = try FileDescriptor.open(path, .readOnly, options: [], permissions: .ownerRead)
             do {
-                try fileDescriptor.closeAfter {
-                    do {
-                        let fileData = try [UInt8](unsafeUninitializedCapacity: 1_024) { buf, count in
-                            count = try fileDescriptor.read(into: UnsafeMutableRawBufferPointer(buf))
-                        }
+                let fileDescriptor = try FileDescriptor.open(path, .readOnly, options: [], permissions: .ownerRead)
+                do {
+                    try fileDescriptor.closeAfter {
+                        do {
+                            let fileData = try [UInt8](unsafeUninitializedCapacity: 1_024) { buf, count in
+                                count = try fileDescriptor.read(into: UnsafeMutableRawBufferPointer(buf))
+                            }
 
-                        fileData.withUnsafeBufferPointer {
-                            string = String(cString: $0.baseAddress!)
+                            fileData.withUnsafeBufferPointer {
+                                string = String(cString: $0.baseAddress!)
+                            }
+                        } catch {
+                            print("Failed to open file for reading \(path)")
                         }
-                    } catch {
-                        print("Failed to open file for reading \(path)")
                     }
+                } catch {
+                    print("Failed to close fileDescriptor for \(path) after reading.")
                 }
             } catch {
-                print("Failed to close fileDescriptor for \(path) after reading.")
+                if errno != ENOENT { // file not found is ok, e.g. when no baselines exist
+                    print("Failed to open file \(path), errno = [\(errno)]")
+                }
             }
-        } catch {
-            if errno != ENOENT { // file not found is ok, e.g. when no baselines exist
-                print("Failed to open file \(path), errno = [\(errno)]")
+
+            return string
+        }
+
+        func readIOStats() -> ioStats {
+            let stats = read(path: FilePath("/proc/self/io"))
+            var ioStats: ioStats = .init()
+            CLinuxIOStats(stats, &ioStats)
+            return ioStats
+        }
+
+        func readProcessStats() -> processStats {
+            let statsRead = read(path: FilePath("/proc/self/stat"))
+
+            var stats: processStats = .init()
+            CLinuxProcessStats(statsRead, &stats)
+            stats.cpuUser *= nsPerSchedulerTick
+            stats.cpuSystem *= nsPerSchedulerTick
+            stats.cpuTotal *= nsPerSchedulerTick
+            stats.peakMemoryResident *= pageSize
+
+            return stats
+        }
+
+        func makeOperatingSystemStats() -> OperatingSystemStats {
+            let ioStats = readIOStats()
+            let processStats = readProcessStats()
+
+            return OperatingSystemStats(cpuUser: Int(processStats.cpuUser),
+                                        cpuSystem: Int(processStats.cpuSystem),
+                                        cpuTotal: Int(processStats.cpuTotal),
+                                        peakMemoryResident: Int(processStats.peakMemoryResident),
+                                        peakMemoryVirtual: Int(processStats.peakMemoryVirtual),
+                                        syscalls: 0,
+                                        contextSwitches: 0,
+                                        threads: Int(processStats.threads),
+                                        threadsRunning: 0, // we can go dig in /proc/self/task/ later if want this
+                                        readSyscalls: Int(ioStats.readSyscalls),
+                                        writeSyscalls: Int(ioStats.writeSyscalls),
+                                        readBytesLogical: Int(ioStats.readBytesLogical),
+                                        writeBytesLogical: Int(ioStats.writeBytesLogical),
+                                        readBytesPhysical: Int(ioStats.readBytesPhysical),
+                                        writeBytesPhysical: Int(ioStats.writeBytesPhysical))
+        }
+
+        func metricSupported(_ metric: BenchmarkMetric) -> Bool {
+            switch metric {
+            case .syscalls:
+                return false
+            case .contextSwitches:
+                return false
+            case .threadsRunning:
+                return false
+            default:
+                return true
             }
         }
 
-        return string
-    }
-
-    func readIOStats() -> ioStats {
-        let stats = read(path: FilePath("/proc/self/io"))
-        var ioStats: ioStats = .init()
-        CLinuxIOStats(stats, &ioStats)
-        return ioStats
-    }
-
-    func readProcessStats() -> processStats {
-        let statsRead = read(path: FilePath("/proc/self/stat"))
-
-        var stats: processStats = .init()
-        CLinuxProcessStats(statsRead, &stats)
-        stats.cpuUser *= nsPerSchedulerTick
-        stats.cpuSystem *= nsPerSchedulerTick
-        stats.cpuTotal *= nsPerSchedulerTick
-        stats.peakMemoryResident *= pageSize
-
-        return stats
-    }
-
-    func makeOperatingSystemStats() -> OperatingSystemStats {
-        let ioStats = readIOStats()
-        let processStats = readProcessStats()
-
-        return OperatingSystemStats(cpuUser: Int(processStats.cpuUser),
-                                    cpuSystem: Int(processStats.cpuSystem),
-                                    cpuTotal: Int(processStats.cpuTotal),
-                                    peakMemoryResident: Int(processStats.peakMemoryResident),
-                                    peakMemoryVirtual: Int(processStats.peakMemoryVirtual),
-                                    syscalls: 0,
-                                    contextSwitches: 0,
-                                    threads: Int(processStats.threads),
-                                    threadsRunning: 0, // we can go dig in /proc/self/task/ later if want this
-                                    readSyscalls: Int(ioStats.readSyscalls),
-                                    writeSyscalls: Int(ioStats.writeSyscalls),
-                                    readBytesLogical: Int(ioStats.readBytesLogical),
-                                    writeBytesLogical: Int(ioStats.writeBytesLogical),
-                                    readBytesPhysical: Int(ioStats.readBytesPhysical),
-                                    writeBytesPhysical: Int(ioStats.writeBytesPhysical))
-    }
-
-    func metricSupported(_ metric: BenchmarkMetric) -> Bool {
-        switch metric {
-        case .syscalls:
-            return false
-        case .contextSwitches:
-            return false
-        case .threadsRunning:
-            return false
-        default:
-            return true
-        }
-    }
-
-    func startSampling(_: Int = 10_000) { // sample rate in microseconds
-        DispatchQueue.global(qos: .userInitiated).async {
-            self.lock.lock()
-
-            let rate = self.sampleRate
-            self.peakThreads = 0
-            self.runState = .running
-
-            self.lock.unlock()
-
-            while true {
-                let processStats = self.readProcessStats()
-
+        func startSampling(_: Int = 10_000) { // sample rate in microseconds
+            DispatchQueue.global(qos: .userInitiated).async {
                 self.lock.lock()
 
-                if processStats.threads > self.peakThreads {
-                    self.peakThreads = processStats.threads
-                }
-
-                if self.runState == .shuttingDown {
-                    self.runState = .done
-                    self.semaphore.signal()
-                }
-
-                let quit = self.runState
+                let rate = self.sampleRate
+                self.peakThreads = 0
+                self.runState = .running
 
                 self.lock.unlock()
 
-                if quit == .done {
-                    return
+                while true {
+                    let processStats = self.readProcessStats()
+
+                    self.lock.lock()
+
+                    if processStats.threads > self.peakThreads {
+                        self.peakThreads = processStats.threads
+                    }
+
+                    if self.runState == .shuttingDown {
+                        self.runState = .done
+                        self.semaphore.signal()
+                    }
+
+                    let quit = self.runState
+
+                    self.lock.unlock()
+
+                    if quit == .done {
+                        return
+                    }
+
+                    usleep(UInt32.random(in: UInt32(Double(rate) * 0.9) ... UInt32(Double(rate) * 1.1)))
                 }
-
-                usleep(UInt32.random(in: UInt32(Double(rate) * 0.9) ... UInt32(Double(rate) * 1.1)))
             }
+            // We'll sleep just a little bit to let the sampler thread get going so we try to avoid 0 samples
+            usleep(1_000)
         }
-        // We'll sleep just a little bit to let the sampler thread get going so we try to avoid 0 samples
-        usleep(1_000)
-    }
 
-    func stopSampling() {
-        lock.lock()
-        runState = .shuttingDown
-        lock.unlock()
+        func stopSampling() {
+            lock.lock()
+            runState = .shuttingDown
+            lock.unlock()
 
-        semaphore.wait()
+            semaphore.wait()
+        }
     }
-}
 
 #endif

--- a/Tests/BenchmarkTests/BenchmarkTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkTests.swift
@@ -61,7 +61,7 @@ final class BenchmarkTests: XCTestCase {
     func testBenchmarkRunMoreParameters() throws {
         let benchmark = Benchmark("testBenchmarkRunMoreParameters benchmark",
                                   configuration: .init(
-                                      metrics: BenchmarkMetric.all,
+                                        metrics: .all,
                                       timeUnits: .milliseconds,
                                       warmupIterations: 0,
                                       scalingFactor: .mega

--- a/Tests/BenchmarkTests/BenchmarkTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkTests.swift
@@ -61,7 +61,7 @@ final class BenchmarkTests: XCTestCase {
     func testBenchmarkRunMoreParameters() throws {
         let benchmark = Benchmark("testBenchmarkRunMoreParameters benchmark",
                                   configuration: .init(
-                                        metrics: .all,
+                                      metrics: .all,
                                       timeUnits: .milliseconds,
                                       warmupIterations: 0,
                                       scalingFactor: .mega


### PR DESCRIPTION
## Description

Improves ergonomics of benchmark metric selection to allow writing `.all` instead of `BenchmarkMetric.all`

## How Has This Been Tested?

Manual tests.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [] I have added unit and/or integration tests that prove my fix is effective or that my feature works
