### PR TITLE
Sort benchmarks in lexical order so that run order is consistent with output order

### DIFF
--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -240,6 +240,8 @@ struct BenchmarkTool: AsyncParsableCommand {
 
         var benchmarkResults: BenchmarkResults = [:]
 
+        benchmarks.sort { ($0.target, $0.name) < ($1.target, $1.name) }
+
         // run each benchmark for the target as a separate process
         try benchmarks.forEach { benchmark in
             if try shouldIncludeBenchmark(benchmark.name) {


### PR DESCRIPTION
## Description

Currently the run order is random while the output is lexically sorted, this PR makes both sorted.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
