### PR TITLE
feat(patch): support some IO counters on macOS via proc_pid_rusage()

### DIFF
--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
@@ -183,10 +183,6 @@
                     return false
                 case .writeBytesLogical:
                     return false
-                case .readBytesPhysical:
-                    return true
-                case .writeBytesPhysical:
-                    return true
                 default:
                     return true
                 }

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
@@ -71,10 +71,10 @@
             }
 
             private func getIOStats() -> IOStats {
-                var rinfo = rusage_info_v2()
+                var rinfo = rusage_info_v6()
                 let result = withUnsafeMutablePointer(to: &rinfo) {
                     $0.withMemoryRebound(to: Optional<rusage_info_t>.self, capacity: 1) {
-                        proc_pid_rusage(getpid(), RUSAGE_INFO_V2, $0)
+                        proc_pid_rusage(getpid(), RUSAGE_INFO_V6, $0)
                     }
                 }
                 if result != 0 {

--- a/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
+++ b/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
@@ -91,4 +91,42 @@ final class OperatingSystemAndMallocTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(stopStats.retainCount - startStats.retainCount, 100)
         XCTAssertGreaterThanOrEqual(stopStats.releaseCount - startStats.releaseCount, 100)
     }
+
+    func testIOStatProducer() throws {
+        let statsProducer = OperatingSystemStatsProducer()
+
+        XCTAssertTrue(statsProducer.metricSupported(.readBytesPhysical))
+        XCTAssertTrue(statsProducer.metricSupported(.writeBytesPhysical))
+
+        let startStats = statsProducer.makeOperatingSystemStats()
+
+        let amplificationFactor = 1_000
+
+        let filename = "test-file"
+
+        let fd = open(filename, O_CREAT | O_TRUNC | O_WRONLY, S_IRWXU)
+        XCTAssertNotEqual(fd, -1, "open() failed: \(errno)")
+
+        var st = stat()
+        XCTAssertEqual(fstat(fd, &st), 0, "fstat() failed: \(errno)")
+
+        let buffer = (0 ..< st.st_blksize).map { _ in UInt8.random(in: 0 ... UInt8.max) }
+
+        for _ in (0 ..< amplificationFactor) {
+            buffer.withUnsafeBytes { buffer in
+                XCTAssertEqual(write(fd, buffer.baseAddress, buffer.count), buffer.count, "write() failed: \(errno)")
+            }
+            XCTAssertEqual(lseek(fd, 0, SEEK_SET), 0, "lseek() failed: \(errno)")
+        }
+
+        XCTAssertEqual(fsync(fd), 0, "fsync() failed: \(errno)")
+        XCTAssertEqual(close(fd), 0, "close() failed: \(errno)")
+        XCTAssertEqual(unlink(filename), 0, "unlink() failed: \(errno)")
+
+        let stopStats = statsProducer.makeOperatingSystemStats()
+
+        let writes = stopStats.writeBytesPhysical - startStats.writeBytesPhysical
+
+        XCTAssertEqual(writes, buffer.count)
+    }
 }


### PR DESCRIPTION
## Description

Support 2 IO counters on macOS: physical bytes read and written as reported by `proc_pid_rusage()` --https://opensource.apple.com/source/xnu/xnu-7195.141.2/bsd/sys/resource.h.auto.html
https://opensource.apple.com/source/xnu/xnu-7195.141.2/libsyscall/wrappers/libproc/libproc.h.auto.html

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
