### PR TITLE
feat(minor): Add support for CI detection of absolute threshold improvements + signposts for Instruments

### DIFF
--- a/Benchmarks/Basic/Basic+SetupTeardown.swift
+++ b/Benchmarks/Basic/Basic+SetupTeardown.swift
@@ -7,12 +7,11 @@
 
 import Benchmark
 
-func sharedSetup() {
-}
+func sharedSetup() {}
 
-//func sharedSetup() -> [Int] {
+// func sharedSetup() -> [Int] {
 //    [1, 2, 3]
-//}
+// }
 
 func sharedTeardown() {
 //    print("Shared teardown hook")
@@ -22,7 +21,6 @@ func testSetUpTearDown() {
 //    Benchmark.setup = { print("Global setup hook")}
 //    Benchmark.setup = { 123 }
 //    Benchmark.teardown = { print("Global teardown hook") }
-
 
     Benchmark("SetupTeardown",
               configuration: .init(setup: sharedSetup, teardown: sharedTeardown)) { _ in
@@ -37,7 +35,7 @@ func testSetUpTearDown() {
     }
 
     Benchmark("SetupTeardown3",
-              configuration: .init(setup: sharedSetup)) { benchmark in
+              configuration: .init(setup: sharedSetup)) { _ in
 //        let x = benchmark.setupState as! [Int]
 //        print("\(x)")
     } teardown: {
@@ -45,14 +43,14 @@ func testSetUpTearDown() {
     }
 
     Benchmark("SetupTeardown4",
-              configuration: .init(setup: sharedSetup)) { benchmark in
+              configuration: .init(setup: sharedSetup)) { _ in
 //        print("\(benchmark.setupState)")
     } setup: {
-  //      return 7
+        //      return 7
         //        print("Local setup hook")
     }
 
-    Benchmark("SetupTeardown5") { benchmark in
+    Benchmark("SetupTeardown5") { _ in
 //        print("\(benchmark.setupState)")
     }
 }

--- a/Benchmarks/Basic/Basic+SetupTeardown.swift
+++ b/Benchmarks/Basic/Basic+SetupTeardown.swift
@@ -50,14 +50,13 @@ func testSetUpTearDown() {
         //        print("Local setup hook")
     }
 
-    Benchmark("SetupTeardown5") { benchmark in
-  //              print("\(benchmark.setupState)")
+    Benchmark("SetupTeardown5") { _ in
+        //              print("\(benchmark.setupState)")
     }
 
-    Benchmark("SetupTeardown6") { benchmark, setupState in
+    Benchmark("SetupTeardown6") { _, _ in
 //        print("\(setupState)")
     } setup: {
         [1, 2, 3]
     }
-
 }

--- a/Benchmarks/Basic/Basic+SetupTeardown.swift
+++ b/Benchmarks/Basic/Basic+SetupTeardown.swift
@@ -18,9 +18,9 @@ func sharedTeardown() {
 }
 
 func testSetUpTearDown() {
-//    Benchmark.setup = { print("Global setup hook")}
-//    Benchmark.setup = { 123 }
-//    Benchmark.teardown = { print("Global teardown hook") }
+    //    Benchmark.setup = { print("Global setup hook")}
+//        Benchmark.setup = { 123 }
+    //    Benchmark.teardown = { print("Global teardown hook") }
 
     Benchmark("SetupTeardown",
               configuration: .init(setup: sharedSetup, teardown: sharedTeardown)) { _ in
@@ -36,21 +36,28 @@ func testSetUpTearDown() {
 
     Benchmark("SetupTeardown3",
               configuration: .init(setup: sharedSetup)) { _ in
-//        let x = benchmark.setupState as! [Int]
-//        print("\(x)")
+        //        let x = benchmark.setupState as! [Int]
+        //        print("\(x)")
     } teardown: {
         //        print("Local teardown hook")
     }
 
     Benchmark("SetupTeardown4",
               configuration: .init(setup: sharedSetup)) { _ in
-//        print("\(benchmark.setupState)")
+        //        print("\(benchmark.setupState)")
     } setup: {
         //      return 7
         //        print("Local setup hook")
     }
 
-    Benchmark("SetupTeardown5") { _ in
-//        print("\(benchmark.setupState)")
+    Benchmark("SetupTeardown5") { benchmark in
+  //              print("\(benchmark.setupState)")
     }
+
+    Benchmark("SetupTeardown6") { benchmark, setupState in
+//        print("\(setupState)")
+    } setup: {
+        [1, 2, 3]
+    }
+
 }

--- a/Benchmarks/Basic/Basic+SetupTeardown.swift
+++ b/Benchmarks/Basic/Basic+SetupTeardown.swift
@@ -8,23 +8,28 @@
 import Benchmark
 
 func sharedSetup() {
-//    print("Shared setup hook")
 }
+
+//func sharedSetup() -> [Int] {
+//    [1, 2, 3]
+//}
 
 func sharedTeardown() {
 //    print("Shared teardown hook")
 }
 
 func testSetUpTearDown() {
-//    Benchmark.setup = { print("Global setup hook") }
+//    Benchmark.setup = { print("Global setup hook")}
+//    Benchmark.setup = { 123 }
 //    Benchmark.teardown = { print("Global teardown hook") }
+
 
     Benchmark("SetupTeardown",
               configuration: .init(setup: sharedSetup, teardown: sharedTeardown)) { _ in
     } setup: {
-//        print("Local setup hook")
+        //        print("Local setup hook")
     } teardown: {
-//        print("Local teardown hook")
+        //        print("Local teardown hook")
     }
 
     Benchmark("SetupTeardown2",
@@ -32,14 +37,22 @@ func testSetUpTearDown() {
     }
 
     Benchmark("SetupTeardown3",
-              configuration: .init(setup: sharedSetup)) { _ in
+              configuration: .init(setup: sharedSetup)) { benchmark in
+//        let x = benchmark.setupState as! [Int]
+//        print("\(x)")
     } teardown: {
-//        print("Local teardown hook")
+        //        print("Local teardown hook")
     }
 
     Benchmark("SetupTeardown4",
-              configuration: .init(setup: sharedSetup)) { _ in
+              configuration: .init(setup: sharedSetup)) { benchmark in
+//        print("\(benchmark.setupState)")
     } setup: {
-//        print("Local setup hook")
+  //      return 7
+        //        print("Local setup hook")
+    }
+
+    Benchmark("SetupTeardown5") { benchmark in
+//        print("\(benchmark.setupState)")
     }
 }

--- a/Benchmarks/Basic/BenchmarkRunner+Basic.swift
+++ b/Benchmarks/Basic/BenchmarkRunner+Basic.swift
@@ -46,6 +46,12 @@ let benchmarks = {
               configuration: .init(metrics: [.wallClock, .throughput])) { _ in
     }
 
+    Benchmark("Noop", configuration: .init(metrics: [.wallClock, .mallocCountTotal])) { _ in
+    }
+
+    Benchmark("Noop2", configuration: .init(metrics: [.wallClock] + .arc)) { _ in
+    }
+
     Benchmark("Scaled metrics",
               configuration: .init(metrics: .all + [CustomMetrics.two, CustomMetrics.one],
                                    scalingFactor: .kilo)) { benchmark in

--- a/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
+++ b/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
@@ -45,8 +45,8 @@ let benchmarks = {
             blackHole(temporaryAllocation)
             free(temporaryAllocation)
             array.append(contentsOf: 1 ... 1_000)
+            blackHole(array)
         }
-        blackHole(array)
     }
 
     func concurrentWork(tasks: Int) async {
@@ -59,8 +59,7 @@ let benchmarks = {
         })
     }
 
-    Benchmark("Retain/release deviation",
-              configuration: .init(metrics: BenchmarkMetric.arc, maxDuration: .seconds(3))) { _ in
+    Benchmark("Retain/release deviation") { _ in
         await concurrentWork(tasks: 789)
     }
 }

--- a/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
+++ b/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
@@ -11,11 +11,17 @@ import Benchmark
 import Foundation
 
 let benchmarks = {
+    var thresholds: [BenchmarkMetric: BenchmarkThresholds]
+    let relative: BenchmarkThresholds.RelativeThresholds = [.p25: 25.0, .p50: 50.0, .p75: 75.0, .p90: 100.0, .p99: 101.0, .p100: 201.0]
+    let absolute: BenchmarkThresholds.AbsoluteThresholds = [.p75: 999, .p90: 1_000, .p99: 1_001, .p100: 2_001]
+    thresholds = [.mallocCountTotal: .init(relative: relative, absolute: absolute)]
+
     Benchmark.defaultConfiguration = .init(metrics: [.mallocCountTotal, .syscalls],
                                            warmupIterations: 1,
                                            scalingFactor: .kilo,
                                            maxDuration: .seconds(2),
-                                           maxIterations: .kilo(100))
+                                           maxIterations: .kilo(100),
+                                           thresholds: thresholds)
 
     Benchmark("P90Date") { benchmark in
         for _ in benchmark.scaledIterations {

--- a/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
+++ b/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
@@ -10,13 +10,21 @@
 import Benchmark
 import Foundation
 
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Glibc)
+    import Glibc
+#else
+    #error("Unsupported Platform")
+#endif
+
 let benchmarks = {
     var thresholds: [BenchmarkMetric: BenchmarkThresholds]
     let relative: BenchmarkThresholds.RelativeThresholds = [.p25: 25.0, .p50: 50.0, .p75: 75.0, .p90: 100.0, .p99: 101.0, .p100: 201.0]
     let absolute: BenchmarkThresholds.AbsoluteThresholds = [.p75: 999, .p90: 1_000, .p99: 1_001, .p100: 2_001]
     thresholds = [.mallocCountTotal: .init(relative: relative, absolute: absolute)]
 
-    Benchmark.defaultConfiguration = .init(metrics: [.mallocCountTotal, .syscalls],
+    Benchmark.defaultConfiguration = .init(metrics: [.mallocCountTotal, .syscalls] + .arc,
                                            warmupIterations: 1,
                                            scalingFactor: .kilo,
                                            maxDuration: .seconds(2),
@@ -30,10 +38,29 @@ let benchmarks = {
     }
 
     Benchmark("P90Malloc") { benchmark in
+        var array: [Int] = []
+
         for _ in benchmark.scaledIterations {
-            var array: [Int] = []
-            array.append(contentsOf: 0 ... 1_000)
-            blackHole(array)
+            var temporaryAllocation = malloc(1)
+            blackHole(temporaryAllocation)
+            free(temporaryAllocation)
+            array.append(contentsOf: 1 ... 1_000)
         }
+        blackHole(array)
+    }
+
+    func concurrentWork(tasks: Int) async {
+        _ = await withTaskGroup(of: Void.self, returning: Void.self, body: { taskGroup in
+            for _ in 0 ..< tasks {
+                taskGroup.addTask {}
+            }
+
+            for await _ in taskGroup {}
+        })
+    }
+
+    Benchmark("Retain/release deviation",
+              configuration: .init(metrics: BenchmarkMetric.arc, maxDuration: .seconds(3))) { _ in
+        await concurrentWork(tasks: 789)
     }
 }

--- a/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
+++ b/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
@@ -336,8 +336,10 @@ import PackagePlugin
                         case .genericFailure:
                             print("One or more benchmark suites crashed during runtime.")
                             throw MyError.benchmarkCrashed
-                        case .thresholdViolation:
-                            throw MyError.benchmarkThresholdDeviation
+                        case .thresholdRegression:
+                            throw MyError.benchmarkThresholdRegression
+                        case .thresholdImprovement:
+                            throw MyError.benchmarkThresholdImprovement
                         case .benchmarkJobFailed:
                             print("One benchmark job failed during runtime, continuing with remaining.")
                             break
@@ -357,7 +359,8 @@ import PackagePlugin
     }
 
     enum MyError: Error {
-        case benchmarkThresholdDeviation
+        case benchmarkThresholdRegression
+        case benchmarkThresholdImprovement
         case benchmarkCrashed
         case benchmarkUnexpectedReturnCode
         case invalidArgument

--- a/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
+++ b/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
@@ -223,9 +223,9 @@ import PackagePlugin
                 print("Only a single path for thresholds can be specified, got \(checkAbsoluteThresholdsPath.count).")
                 return
             }
-            args.append(contentsOf: ["--check-absolute-thresholds"])
+            args.append(contentsOf: ["--check-absolute"])
             if let path = checkAbsoluteThresholdsPath.first {
-                args.append(contentsOf: ["--check-absolute-thresholds-path", path])
+                args.append(contentsOf: ["--check-absolute-path", path])
             }
         }
 

--- a/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
+++ b/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
@@ -342,7 +342,6 @@ import PackagePlugin
                             throw MyError.benchmarkThresholdImprovement
                         case .benchmarkJobFailed:
                             print("One benchmark job failed during runtime, continuing with remaining.")
-                            break
                         }
                     } else {
                         print("One or more benchmarks returned an unexpected return code \(status)")

--- a/Plugins/BenchmarkCommandPlugin/BenchmarkPlugin+Help.swift
+++ b/Plugins/BenchmarkCommandPlugin/BenchmarkPlugin+Help.swift
@@ -53,7 +53,7 @@ let help =
     --path <path>           The path where exported data is stored, default is the current directory (".").
     --quiet                 Specifies that output should be suppressed (useful for if you just want to check return code)
     --scale                 Specifies that some of the text output should be scaled using the scalingFactor (denoted by '*' in output)
-    --check-absolute-thresholds
+    --check-absolute
                           Set to true if thresholds should be checked against an absolute reference point rather than delta between baselines.
                           This is used for CI workflows when you want to validate the thresholds vs. a persisted benchmark baseline
                           rather than comparing PR vs main or vs a current run. This is useful to cut down the build matrix needed
@@ -61,7 +61,7 @@ let help =
                           a specific check against a given absolute reference.).
                           If this is enabled, zero or one baselines should be specified for the check operation.
                           By default, thresholds are checked comparing two baselines, or a baseline and a benchmark run.
-    --check-absolute-thresholds-path <check-absolute-thresholds-path>
+    --check-absolute-path <check-absolute-path>
                           The path from which p90 thresholds will be loaded for absolute threshold checks.
                           This implicitly sets --check-absolute to true as well.
     --no-progress           Specifies that benchmark progress information should not be displayed

--- a/Plugins/BenchmarkCommandPlugin/Command+Helpers.swift
+++ b/Plugins/BenchmarkCommandPlugin/Command+Helpers.swift
@@ -60,6 +60,7 @@ enum BaselineOperation: String, CaseIterable {
 enum ExitCode: Int32 {
     case success = 0
     case genericFailure = 1
-    case thresholdViolation = 2
+    case thresholdRegression = 2
     case benchmarkJobFailed = 3
+    case thresholdImprovement = 4
 }

--- a/Plugins/BenchmarkHelpGenerator/BenchmarkHelpGenerator.swift
+++ b/Plugins/BenchmarkHelpGenerator/BenchmarkHelpGenerator.swift
@@ -120,14 +120,14 @@ struct Benchmark: AsyncParsableCommand {
         If this is enabled, zero or one baselines should be specified for the check operation.
         By default, thresholds are checked comparing two baselines, or a baseline and a benchmark run.
         """)
-    var checkAbsoluteThresholds = false
+    var checkAbsolute = false
 
     @Option(name: .long, help:
         """
         The path from which p90 thresholds will be loaded for absolute threshold checks.
         This implicitly sets --check-absolute to true as well.
         """)
-    var checkAbsoluteThresholdsPath: String?
+    var checkAbsolutePath: String?
 
     @Flag(name: .long, help: "Specifies that benchmark progress information should not be displayed")
     var noProgress: Int

--- a/Plugins/BenchmarkHelpGenerator/Command+Helpers.swift
+++ b/Plugins/BenchmarkHelpGenerator/Command+Helpers.swift
@@ -60,6 +60,7 @@ enum BaselineOperation: String, CaseIterable {
 enum ExitCode: Int32 {
     case success = 0
     case genericFailure = 1
-    case thresholdViolation = 2
+    case thresholdRegression = 2
     case benchmarkJobFailed = 3
+    case thresholdImprovement = 4
 }

--- a/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
@@ -24,7 +24,7 @@ import SystemPackage
 #endif
 
 struct BenchmarkMachine: Codable, Equatable {
-    internal init(hostname: String, processors: Int, processorType: String, memory: Int, kernelVersion: String) {
+    init(hostname: String, processors: Int, processorType: String, memory: Int, kernelVersion: String) {
         self.hostname = hostname
         self.processors = processors
         self.processorType = processorType
@@ -46,7 +46,7 @@ struct BenchmarkMachine: Codable, Equatable {
 }
 
 struct BenchmarkIdentifier: Codable, Hashable {
-    internal init(target: String, name: String) {
+    init(target: String, name: String) {
         self.target = target
         self.name = name
     }
@@ -79,7 +79,7 @@ struct BenchmarkBaseline: Codable {
         var metrics: BenchmarkResult
     }
 
-    internal init(baselineName: String, machine: BenchmarkMachine, results: [BenchmarkIdentifier: [BenchmarkResult]]) {
+    init(baselineName: String, machine: BenchmarkMachine, results: [BenchmarkIdentifier: [BenchmarkResult]]) {
         self.baselineName = baselineName
         self.machine = machine
         self.results = results
@@ -449,13 +449,13 @@ extension BenchmarkBaseline: Equatable {
         for (lhsBenchmarkIdentifier, lhsBenchmarkResults) in results {
             for lhsBenchmarkResult in lhsBenchmarkResults {
                 let thresholds = thresholdsForBenchmarks(benchmarks,
-                                              name: lhsBenchmarkIdentifier.name,
-                                              target: lhsBenchmarkIdentifier.target,
-                                              metric: lhsBenchmarkResult.metric)
+                                                         name: lhsBenchmarkIdentifier.name,
+                                                         target: lhsBenchmarkIdentifier.target,
+                                                         metric: lhsBenchmarkResult.metric)
 
                 let deviationResults = lhsBenchmarkResult.deviationsAgainstAbsoluteThresholds(thresholds,
-                                                                                       name: lhsBenchmarkIdentifier.name,
-                                                                                       target: lhsBenchmarkIdentifier.target)
+                                                                                              name: lhsBenchmarkIdentifier.name,
+                                                                                              target: lhsBenchmarkIdentifier.target)
                 allDeviationResults.append(deviationResults)
             }
         }

--- a/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
@@ -451,8 +451,8 @@ extension BenchmarkBaseline: Equatable {
         return (worseResult == false, allDeviationResults)
     }
 
-    public func failsAbsoluteThresholdChecks(benchmarks: [Benchmark]) -> [BenchmarkResult.ThresholdDeviation] {
-        var allDeviationResults: [BenchmarkResult.ThresholdDeviation] = []
+    public func failsAbsoluteThresholdChecks(benchmarks: [Benchmark]) -> BenchmarkResult.ThresholdComparisonResults {
+        var allDeviationResults = BenchmarkResult.ThresholdComparisonResults()
 
         for (lhsBenchmarkIdentifier, lhsBenchmarkResults) in results {
             for lhsBenchmarkResult in lhsBenchmarkResults {
@@ -464,7 +464,8 @@ extension BenchmarkBaseline: Equatable {
                 let deviationResults = lhsBenchmarkResult.failsAbsoluteThresholdChecks(thresholds: thresholds,
                                                                                        name: lhsBenchmarkIdentifier.name,
                                                                                        target: lhsBenchmarkIdentifier.target)
-                allDeviationResults.append(contentsOf: deviationResults)
+                allDeviationResults.improvements.append(contentsOf: deviationResults.improvements)
+                allDeviationResults.regressions.append(contentsOf: deviationResults.regressions)
             }
         }
 

--- a/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
@@ -424,8 +424,7 @@ extension BenchmarkBaseline: Equatable {
                                                                                          thresholds: thresholds,
                                                                                          name: lhsBenchmarkIdentifier.name,
                                                                                          target: lhsBenchmarkIdentifier.target)
-                        allDeviationResults.regressions.append(contentsOf: deviationResults.regressions)
-                        allDeviationResults.improvements.append(contentsOf: deviationResults.improvements)
+                        allDeviationResults.append(deviationResults)
                     } else {
                         if warningPrintedForMetric.contains(lhsBenchmarkResult.metric) == false {
                             print("`\(lhsBenchmarkResult.metric)` not found in both baselines, skipping it.")
@@ -457,8 +456,7 @@ extension BenchmarkBaseline: Equatable {
                 let deviationResults = lhsBenchmarkResult.deviationsAgainstAbsoluteThresholds(thresholds,
                                                                                        name: lhsBenchmarkIdentifier.name,
                                                                                        target: lhsBenchmarkIdentifier.target)
-                allDeviationResults.improvements.append(contentsOf: deviationResults.improvements)
-                allDeviationResults.regressions.append(contentsOf: deviationResults.regressions)
+                allDeviationResults.append(deviationResults)
             }
         }
 

--- a/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
@@ -225,7 +225,7 @@ extension BenchmarkTool {
                 let jsonEncoder = JSONEncoder()
                 jsonEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
 
-                var outputResults : [String : BenchmarkThresholds.AbsoluteThreshold] = [:]
+                var outputResults: [String: BenchmarkThresholds.AbsoluteThreshold] = [:]
                 results.forEach { values in
                     outputResults[values.metric.rawDescription] = Int(values.statistics.histogram.valueAtPercentile(90.0))
                 }

--- a/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
@@ -173,7 +173,7 @@ extension BenchmarkTool {
 
                     if deviationResults.regressions.isEmpty {
                         if deviationResults.improvements.isEmpty {
-                            print("Baseline '\(baselineName)' is WITHIN the defined absolute baseline thresholds. (--check-absolute)")
+                            print("Baseline '\(baselineName)' is EQUAL to the defined absolute baseline thresholds. (--check-absolute)")
                         } else {
                             prettyPrintAbsoluteDeviation(baselineName: baselineName,
                                                          deviationResults: deviationResults.improvements)

--- a/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
@@ -151,11 +151,11 @@ extension BenchmarkTool {
                             let thresholds = BenchmarkTool.makeBenchmarkThresholds(path: benchmarkPath,
                                                                                    moduleName: benchmark.target,
                                                                                    benchmarkName: benchmark.name)
-                            var transformed: [BenchmarkMetric : BenchmarkThresholds] = [:]
+                            var transformed: [BenchmarkMetric: BenchmarkThresholds] = [:]
                             if let thresholds {
                                 thresholds.forEach { key, value in
                                     if let metric = BenchmarkMetric(argument: key) {
-                                        let absoluteThreshold : BenchmarkThresholds.AbsoluteThresholds = [.p90 : value]
+                                        let absoluteThreshold: BenchmarkThresholds.AbsoluteThresholds = [.p90: value]
                                         transformed[metric] = BenchmarkThresholds(absolute: absoluteThreshold)
                                     }
                                 }

--- a/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
@@ -171,13 +171,21 @@ extension BenchmarkTool {
 
                     let deviationResults = currentBaseline.failsAbsoluteThresholdChecks(benchmarks: benchmarks)
 
-                    if deviationResults.isEmpty {
-                        print("Baseline '\(baselineName)' is BETTER (or equal) than the defined absolute baseline thresholds. (--check-absolute)")
+                    if deviationResults.regressions.isEmpty {
+                        if deviationResults.improvements.isEmpty {
+                            print("Baseline '\(baselineName)' is EQUAL to the defined absolute baseline thresholds. (--check-absolute)")
+                        } else {
+                            prettyPrintAbsoluteDeviation(baselineName: baselineName,
+                                                         deviationResults: deviationResults.improvements)
+
+                            failBenchmark("New baseline '\(baselineName)' is BETTER than the defined absolute baseline thresholds. (--check-absolute)",
+                                          exitCode: .thresholdImprovement)
+                        }
                     } else {
                         prettyPrintAbsoluteDeviation(baselineName: baselineName,
-                                                     deviationResults: deviationResults)
+                                                     deviationResults: deviationResults.regressions)
                         failBenchmark("New baseline '\(baselineName)' is WORSE than the defined absolute baseline thresholds. (--check-absolute)",
-                                      exitCode: .thresholdViolation)
+                                      exitCode: .thresholdRegression)
                     }
                 } else {
                     guard benchmarkBaselines.count == 2 else {
@@ -200,7 +208,7 @@ extension BenchmarkTool {
                                              comparingBaselineName: checkBaselineName,
                                              deviationResults: deviationResults)
                         failBenchmark("New baseline '\(checkBaselineName)' is WORSE than the '\(baselineName)' baseline thresholds.",
-                                      exitCode: .thresholdViolation)
+                                      exitCode: .thresholdRegression)
                     }
                 }
             case .read:

--- a/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
@@ -141,12 +141,12 @@ extension BenchmarkTool {
                 }
 
             case .check:
-                if checkAbsoluteThresholds {
+                if checkAbsolute {
                     guard benchmarkBaselines.count == 1 else {
                         print("Can only do absolute threshold violation checks for a single benchmark baseline, got: \(benchmarkBaselines.count) baselines.")
                         return
                     }
-                    if let benchmarkPath = checkAbsoluteThresholdsPath { // load statically defined threshods for .p90
+                    if let benchmarkPath = checkAbsolutePath { // load statically defined threshods for .p90
                         benchmarks.forEach { benchmark in
                             let thresholds = BenchmarkTool.makeBenchmarkThresholds(path: benchmarkPath,
                                                                                    moduleName: benchmark.target,

--- a/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
@@ -229,7 +229,7 @@ extension BenchmarkTool {
                     value.forEach { currentResult in
                         var result = currentResult
                         if let base = baselineComparison.first(where: { $0.metric == result.metric }) {
-                            let (hideResults, _) = result.betterResultsOrEqual(than: base, thresholds: result.thresholds ?? BenchmarkThresholds.none)
+                            let hideResults = result.deviationsComparedWith(base, thresholds: result.thresholds ?? BenchmarkThresholds.none).regressions.isEmpty
 
                             // We hide the markdown results if they are better than baseline to cut down noise
                             if format == .markdown {
@@ -371,14 +371,14 @@ extension BenchmarkTool {
         guard quiet == false else { return }
 
         let metrics = deviationResults.map(\.metric).unique()
-        // Get a unique set of all name/target pairs that have threshold violations, sorted lexically:
+        // Get a unique set of all name/target pairs that have threshold deviations, sorted lexically:
         let namesAndTargets = deviationResults.map { NameAndTarget(name: $0.name, target: $0.target) }
             .unique().sorted { ($0.target, $0.name) < ($1.target, $1.name) }
 
         namesAndTargets.forEach { nameAndTarget in
 
             printMarkdown("```")
-            "Threshold violations for \(nameAndTarget.name):\(nameAndTarget.target)".printAsHeader(addWhiteSpace: false)
+            "Threshold deviations for \(nameAndTarget.name):\(nameAndTarget.target)".printAsHeader(addWhiteSpace: false)
             printMarkdown("```")
 
             metrics.forEach { metric in
@@ -435,14 +435,14 @@ extension BenchmarkTool {
         guard quiet == false else { return }
 
         let metrics = deviationResults.map(\.metric).unique()
-        // Get a unique set of all name/target pairs that have threshold violations, sorted lexically:
+        // Get a unique set of all name/target pairs that have threshold deviations, sorted lexically:
         let namesAndTargets = deviationResults.map { NameAndTarget(name: $0.name, target: $0.target) }
             .unique().sorted { ($0.target, $0.name) < ($1.target, $1.name) }
 
         namesAndTargets.forEach { nameAndTarget in
 
             printMarkdown("```")
-            "Absolute threshold violations for \(nameAndTarget.name):\(nameAndTarget.target)".printAsHeader(addWhiteSpace: false)
+            "Absolute threshold deviations for \(nameAndTarget.name):\(nameAndTarget.target)".printAsHeader(addWhiteSpace: false)
             printMarkdown("```")
 
             metrics.forEach { metric in

--- a/Plugins/BenchmarkTool/BenchmarkTool+ReadP90AbsoluteThresholds.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+ReadP90AbsoluteThresholds.swift
@@ -32,7 +32,7 @@ extension BenchmarkTool {
     /// - Returns: A dictionary with static benchmark thresholds per metric or nil if the file could not be found or read
     static func makeBenchmarkThresholds(path: String,
                                         moduleName: String,
-                                        benchmarkName: String) -> [String : BenchmarkThresholds.AbsoluteThreshold]? {
+                                        benchmarkName: String) -> [String: BenchmarkThresholds.AbsoluteThreshold]? {
         var path = FilePath(path)
         if path.isAbsolute {
             path.append("\(moduleName).\(benchmarkName).p90.json")
@@ -43,7 +43,7 @@ extension BenchmarkTool {
             path = cwdPath
         }
 
-        var p90Thresholds: [String : BenchmarkThresholds.AbsoluteThreshold]?
+        var p90Thresholds: [String: BenchmarkThresholds.AbsoluteThreshold]?
 
         do {
             let fileDescriptor = try FileDescriptor.open(path, .readOnly, options: [], permissions: .ownerRead)
@@ -64,7 +64,7 @@ extension BenchmarkTool {
                             readBytes.append(contentsOf: nextBytes)
                         }
 
-                        p90Thresholds = try JSONDecoder().decode([String : BenchmarkThresholds.AbsoluteThreshold].self, from: Data(readBytes))
+                        p90Thresholds = try JSONDecoder().decode([String: BenchmarkThresholds.AbsoluteThreshold].self, from: Data(readBytes))
                     } catch {
                         print("Failed to read file at \(path) [\(error)] \(Errno(rawValue: errno).description)")
                     }

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -79,14 +79,14 @@ struct BenchmarkTool: AsyncParsableCommand {
         If this is enabled, zero or one baselines should be specified for the check operation.
         By default, thresholds are checked comparing two baselines, or a baseline and a benchmark run.
         """)
-    var checkAbsoluteThresholds = false
+    var checkAbsolute = false
 
     @Option(name: .long, help:
         """
         The path from which p90 thresholds will be loaded for absolute threshold checks.
         This implicitly sets --check-absolute to true as well.
         """)
-    var checkAbsoluteThresholdsPath: String?
+    var checkAbsolutePath: String?
 
     @Option(name: .long, help: "The named baseline(s) we should display, update, delete or compare with")
     var baseline: [String] = []
@@ -204,7 +204,7 @@ struct BenchmarkTool: AsyncParsableCommand {
         // Skip reading baselines for baseline operations not needing them
         if let operation = baselineOperation, [.delete, .list, .update].contains(operation) == false {
             try readBaselines()
-            if [.compare, .check].contains(operation), benchmarkBaselines.count < 1, checkAbsoluteThresholds == false {
+            if [.compare, .check].contains(operation), benchmarkBaselines.count < 1, checkAbsolute == false {
                 print("Failed to read at least one benchmark baseline for compare/check operations.")
                 return
             }
@@ -300,8 +300,8 @@ struct BenchmarkTool: AsyncParsableCommand {
                               "--output-fd", fromChild.writeEnd.rawValue.description,
                               "--quiet", noProgress.description]
 
-        if checkAbsoluteThresholds {
-            args.append("--check-absolute-thresholds")
+        if checkAbsolute {
+            args.append("--check-absolute")
         }
 
         inputFD = fromChild.readEnd.rawValue

--- a/Plugins/BenchmarkTool/Command+Helpers.swift
+++ b/Plugins/BenchmarkTool/Command+Helpers.swift
@@ -60,6 +60,7 @@ enum BaselineOperation: String, CaseIterable {
 enum ExitCode: Int32 {
     case success = 0
     case genericFailure = 1
-    case thresholdViolation = 2
+    case thresholdRegression = 2
     case benchmarkJobFailed = 3
+    case thresholdImprovement = 4
 }

--- a/Plugins/BenchmarkTool/FilePath+DirectoryView.swift
+++ b/Plugins/BenchmarkTool/FilePath+DirectoryView.swift
@@ -24,12 +24,12 @@ import SystemPackage
 public extension FilePath {
     /// `DirectoryView` provides an iteratable sequence of the contents of a directory referenced by a `FilePath`
     struct DirectoryView {
-        internal var directoryStreamPointer: DirectoryStreamPointer = nil
-        internal var path: FilePath
+        var directoryStreamPointer: DirectoryStreamPointer = nil
+        var path: FilePath
 
         /// Initializer
         /// - Parameter path: The file system path to provide directory entries for, should reference a directory
-        internal init(path pathName: FilePath) {
+        init(path pathName: FilePath) {
             path = pathName
             path.withPlatformString {
                 directoryStreamPointer = opendir($0)

--- a/Sources/Benchmark/ARCStats/ARCStats.swift
+++ b/Sources/Benchmark/ARCStats/ARCStats.swift
@@ -13,7 +13,8 @@
     @_documentation(visibility: internal)
 #endif
 
-internal struct ARCStats {
-    var retainCount: Int /// total number retains
-    var releaseCount: Int /// total number of releases
+struct ARCStats {
+    var objectAllocCount: Int = 0 /// total number allocations, implicit retain
+    var retainCount: Int = 0 /// total number retains
+    var releaseCount: Int = 0 /// total number of releases
 }

--- a/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
+++ b/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
@@ -9,12 +9,12 @@ extension Benchmark {
     @discardableResult
     convenience public init?<SetupResult>(_ name: String,
                                           configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
-                                          closure: @escaping (_ benchmark: Benchmark, inout SetupResult) -> Void,
+                                          closure: @escaping (_ benchmark: Benchmark, SetupResult) -> Void,
                                           setup: @escaping (() async throws -> SetupResult),
                                           teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration) { benchmark in
             var setupResult = benchmark.setupState! as! SetupResult
-            closure(benchmark, &setupResult)
+            closure(benchmark, setupResult)
         } setup: {
             try await setup()
         } teardown: {
@@ -32,12 +32,12 @@ extension Benchmark {
     @discardableResult
     convenience public init?<SetupResult>(_ name: String,
                  configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
-                 closure: @escaping (_ benchmark: Benchmark, inout SetupResult) async -> Void,
+                 closure: @escaping (_ benchmark: Benchmark, SetupResult) async -> Void,
                  setup: @escaping (() async throws -> SetupResult),
                  teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration) { benchmark in
             var setupResult = benchmark.setupState! as! SetupResult
-            await closure(benchmark, &setupResult)
+            await closure(benchmark, setupResult)
         } setup: {
             try await setup()
         } teardown: {
@@ -55,13 +55,13 @@ extension Benchmark {
     @discardableResult
     convenience public init?<SetupResult>(_ name: String,
                                           configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
-                                          closure: @escaping (_ benchmark: Benchmark, inout SetupResult) throws -> Void,
+                                          closure: @escaping (_ benchmark: Benchmark, SetupResult) throws -> Void,
                                           setup: (() async throws -> SetupResult)? = nil,
                                           teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration, closure: { benchmark in
             do {
                 var setupResult = benchmark.setupState! as! SetupResult
-                try closure(benchmark, &setupResult)
+                try closure(benchmark, setupResult)
             } catch {
                 benchmark.error("Benchmark \(name) failed with \(error)")
             }
@@ -78,13 +78,13 @@ extension Benchmark {
     @discardableResult
     public convenience init?<SetupResult>(_ name: String,
                              configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
-                             closure: @escaping (_ benchmark: Benchmark, inout SetupResult) async throws -> Void,
+                             closure: @escaping (_ benchmark: Benchmark, SetupResult) async throws -> Void,
                              setup: (() async throws -> SetupResult)? = nil,
                              teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration, closure: { benchmark in
             do {
                 var setupResult = benchmark.setupState! as! SetupResult
-                try await closure(benchmark, &setupResult)
+                try await closure(benchmark, setupResult)
             } catch {
                 benchmark.error("Benchmark \(name) failed with \(error)")
             }

--- a/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
+++ b/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
@@ -22,7 +22,8 @@ public extension Benchmark {
         }
     }
 
-    /// Definition of a Benchmark
+    
+/// Definition of an async Benchmark
     /// - Parameters:
     ///   - name: The name used for display purposes of the benchmark (also used for
     ///   matching when comparing to baselines)

--- a/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
+++ b/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
@@ -1,0 +1,93 @@
+extension Benchmark {
+    /// Definition of a Benchmark
+    /// - Parameters:
+    ///   - name: The name used for display purposes of the benchmark (also used for
+    ///   matching when comparing to baselines)
+    ///   - configuration: Defines the settings that should be used for this benchmark
+    ///   - closure: The actual benchmark closure that will be measured, this one takes one additional parameter
+    ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
+    @discardableResult
+    convenience public init?<SetupResult>(_ name: String,
+                                          configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
+                                          closure: @escaping (_ benchmark: Benchmark, inout SetupResult) -> Void,
+                                          setup: @escaping (() async throws -> SetupResult),
+                                          teardown: BenchmarkTeardownHook? = nil) {
+        self.init(name, configuration: configuration) { benchmark in
+            var setupResult = benchmark.setupState! as! SetupResult
+            closure(benchmark, &setupResult)
+        } setup: {
+            try await setup()
+        } teardown: {
+            try await teardown?()
+        }
+    }
+
+    /// Definition of a Benchmark
+    /// - Parameters:
+    ///   - name: The name used for display purposes of the benchmark (also used for
+    ///   matching when comparing to baselines)
+    ///   - configuration: Defines the settings that should be used for this benchmark
+    ///   - closure: The actual `async` benchmark closure that will be measured, this one takes one additional parameter
+    ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
+    @discardableResult
+    convenience public init?<SetupResult>(_ name: String,
+                 configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
+                 closure: @escaping (_ benchmark: Benchmark, inout SetupResult) async -> Void,
+                 setup: @escaping (() async throws -> SetupResult),
+                 teardown: BenchmarkTeardownHook? = nil) {
+        self.init(name, configuration: configuration) { benchmark in
+            var setupResult = benchmark.setupState! as! SetupResult
+            await closure(benchmark, &setupResult)
+        } setup: {
+            try await setup()
+        } teardown: {
+            try await teardown?()
+        }
+    }
+
+    /// Definition of a throwing Benchmark
+    /// - Parameters:
+    ///   - name: The name used for display purposes of the benchmark (also used for
+    ///   matching when comparing to baselines)
+    ///   - configuration: Defines the settings that should be used for this benchmark
+    ///   - closure: The actual throwing benchmark closure that will be measured, this one takes one additional parameter
+    ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
+    @discardableResult
+    convenience public init?<SetupResult>(_ name: String,
+                                          configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
+                                          closure: @escaping (_ benchmark: Benchmark, inout SetupResult) throws -> Void,
+                                          setup: (() async throws -> SetupResult)? = nil,
+                                          teardown: BenchmarkTeardownHook? = nil) {
+        self.init(name, configuration: configuration, closure: { benchmark in
+            do {
+                var setupResult = benchmark.setupState! as! SetupResult
+                try closure(benchmark, &setupResult)
+            } catch {
+                benchmark.error("Benchmark \(name) failed with \(error)")
+            }
+        }, setup: setup, teardown: teardown)
+    }
+
+    /// Definition of an async throwing Benchmark
+    /// - Parameters:
+    ///   - name: The name used for display purposes of the benchmark (also used for
+    ///   matching when comparing to baselines)
+    ///   - configuration: Defines the settings that should be used for this benchmark
+    ///   - closure: The actual async throwing benchmark closure that will be measured, this one takes one additional parameter
+    ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
+    @discardableResult
+    public convenience init?<SetupResult>(_ name: String,
+                             configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
+                             closure: @escaping (_ benchmark: Benchmark, inout SetupResult) async throws -> Void,
+                             setup: (() async throws -> SetupResult)? = nil,
+                             teardown: BenchmarkTeardownHook? = nil) {
+        self.init(name, configuration: configuration, closure: { benchmark in
+            do {
+                var setupResult = benchmark.setupState! as! SetupResult
+                try await closure(benchmark, &setupResult)
+            } catch {
+                benchmark.error("Benchmark \(name) failed with \(error)")
+            }
+        }, setup: setup, teardown: teardown)
+    }
+}

--- a/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
+++ b/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
@@ -22,7 +22,6 @@ public extension Benchmark {
         }
     }
 
-    
 /// Definition of an async Benchmark
     /// - Parameters:
     ///   - name: The name used for display purposes of the benchmark (also used for

--- a/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
+++ b/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
@@ -13,7 +13,7 @@ extension Benchmark {
                                           setup: @escaping (() async throws -> SetupResult),
                                           teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration) { benchmark in
-            var setupResult = benchmark.setupState! as! SetupResult
+            let setupResult = benchmark.setupState! as! SetupResult
             closure(benchmark, setupResult)
         } setup: {
             try await setup()
@@ -36,7 +36,7 @@ extension Benchmark {
                  setup: @escaping (() async throws -> SetupResult),
                  teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration) { benchmark in
-            var setupResult = benchmark.setupState! as! SetupResult
+            let setupResult = benchmark.setupState! as! SetupResult
             await closure(benchmark, setupResult)
         } setup: {
             try await setup()
@@ -60,7 +60,7 @@ extension Benchmark {
                                           teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration, closure: { benchmark in
             do {
-                var setupResult = benchmark.setupState! as! SetupResult
+                let setupResult = benchmark.setupState! as! SetupResult
                 try closure(benchmark, setupResult)
             } catch {
                 benchmark.error("Benchmark \(name) failed with \(error)")
@@ -83,7 +83,7 @@ extension Benchmark {
                              teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration, closure: { benchmark in
             do {
-                var setupResult = benchmark.setupState! as! SetupResult
+                let setupResult = benchmark.setupState! as! SetupResult
                 try await closure(benchmark, setupResult)
             } catch {
                 benchmark.error("Benchmark \(name) failed with \(error)")

--- a/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
+++ b/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
@@ -1,4 +1,4 @@
-extension Benchmark {
+public extension Benchmark {
     /// Definition of a Benchmark
     /// - Parameters:
     ///   - name: The name used for display purposes of the benchmark (also used for
@@ -7,13 +7,13 @@ extension Benchmark {
     ///   - closure: The actual benchmark closure that will be measured, this one takes one additional parameter
     ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
     @discardableResult
-    convenience public init?<SetupResult>(_ name: String,
-                                          configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
-                                          closure: @escaping (_ benchmark: Benchmark, SetupResult) -> Void,
-                                          setup: @escaping (() async throws -> SetupResult),
-                                          teardown: BenchmarkTeardownHook? = nil) {
+    convenience init?<SetupResult>(_ name: String,
+                                   configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
+                                   closure: @escaping (_ benchmark: Benchmark, SetupResult) -> Void,
+                                   setup: @escaping (() async throws -> SetupResult),
+                                   teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration) { benchmark in
-            let setupResult = benchmark.setupState! as! SetupResult
+            let setupResult = benchmark.setupState! as! SetupResult // swiftlint:disable:this force_cast
             closure(benchmark, setupResult)
         } setup: {
             try await setup()
@@ -30,13 +30,13 @@ extension Benchmark {
     ///   - closure: The actual `async` benchmark closure that will be measured, this one takes one additional parameter
     ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
     @discardableResult
-    convenience public init?<SetupResult>(_ name: String,
-                 configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
-                 closure: @escaping (_ benchmark: Benchmark, SetupResult) async -> Void,
-                 setup: @escaping (() async throws -> SetupResult),
-                 teardown: BenchmarkTeardownHook? = nil) {
+    convenience init?<SetupResult>(_ name: String,
+                                   configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
+                                   closure: @escaping (_ benchmark: Benchmark, SetupResult) async -> Void,
+                                   setup: @escaping (() async throws -> SetupResult),
+                                   teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration) { benchmark in
-            let setupResult = benchmark.setupState! as! SetupResult
+            let setupResult = benchmark.setupState! as! SetupResult // swiftlint:disable:this force_cast
             await closure(benchmark, setupResult)
         } setup: {
             try await setup()
@@ -53,14 +53,14 @@ extension Benchmark {
     ///   - closure: The actual throwing benchmark closure that will be measured, this one takes one additional parameter
     ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
     @discardableResult
-    convenience public init?<SetupResult>(_ name: String,
-                                          configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
-                                          closure: @escaping (_ benchmark: Benchmark, SetupResult) throws -> Void,
-                                          setup: (() async throws -> SetupResult)? = nil,
-                                          teardown: BenchmarkTeardownHook? = nil) {
+    convenience init?<SetupResult>(_ name: String,
+                                   configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
+                                   closure: @escaping (_ benchmark: Benchmark, SetupResult) throws -> Void,
+                                   setup: (() async throws -> SetupResult)? = nil,
+                                   teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration, closure: { benchmark in
             do {
-                let setupResult = benchmark.setupState! as! SetupResult
+                let setupResult = benchmark.setupState! as! SetupResult // swiftlint:disable:this force_cast
                 try closure(benchmark, setupResult)
             } catch {
                 benchmark.error("Benchmark \(name) failed with \(error)")
@@ -76,14 +76,14 @@ extension Benchmark {
     ///   - closure: The actual async throwing benchmark closure that will be measured, this one takes one additional parameter
     ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
     @discardableResult
-    public convenience init?<SetupResult>(_ name: String,
-                             configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
-                             closure: @escaping (_ benchmark: Benchmark, SetupResult) async throws -> Void,
-                             setup: (() async throws -> SetupResult)? = nil,
-                             teardown: BenchmarkTeardownHook? = nil) {
+    convenience init?<SetupResult>(_ name: String,
+                                   configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
+                                   closure: @escaping (_ benchmark: Benchmark, SetupResult) async throws -> Void,
+                                   setup: (() async throws -> SetupResult)? = nil,
+                                   teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration, closure: { benchmark in
             do {
-                let setupResult = benchmark.setupState! as! SetupResult
+                let setupResult = benchmark.setupState! as! SetupResult // swiftlint:disable:this force_cast
                 try await closure(benchmark, setupResult)
             } catch {
                 benchmark.error("Benchmark \(name) failed with \(error)")

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-// swiftlint: disable file_length prefer_self_in_static_references
+// swiftlint: disable file_length
 
 /// Defines a benchmark
 public final class Benchmark: Codable, Hashable {
@@ -348,7 +348,6 @@ public final class Benchmark: Codable, Hashable {
         }
     }
 }
-// swiftlint:enable prefer_self_in_static_references
 
 public extension Benchmark {
     /// The configuration settings for running a benchmark.

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-// swiftlint: disable file_length
+// swiftlint: disable file_length prefer_self_in_static_references
 
 /// Defines a benchmark
 public final class Benchmark: Codable, Hashable {
@@ -127,7 +127,7 @@ public final class Benchmark: Codable, Hashable {
                                                                   skip: false,
                                                                   thresholds: nil)
 
-    internal static var testSkipBenchmarkRegistrations = false // true in test to avoid bench registration fail
+    static var testSkipBenchmarkRegistrations = false // true in test to avoid bench registration fail
     var measurementCompleted = false // Keep track so we skip multiple 'end of measurement'
 
     enum CodingKeys: String, CodingKey {
@@ -245,7 +245,7 @@ public final class Benchmark: Codable, Hashable {
     }
 
     // Shared between sync/async actual benchmark registration
-    internal func benchmarkRegistration() {
+    func benchmarkRegistration() {
         if Self.testSkipBenchmarkRegistrations == false {
             guard Self.benchmarks.contains(self) == false else {
                 fatalError("Duplicate registration of benchmark '\(name)', name must be unique.")
@@ -314,7 +314,7 @@ public final class Benchmark: Codable, Hashable {
 
     // https://forums.swift.org/t/actually-waiting-for-a-task/56230
     // Async closures can possibly show false memory leaks possibly due to Swift runtime allocations
-    internal func runAsync() {
+    func runAsync() {
         guard let asyncClosure else {
             fatalError("Tried to runAsync on benchmark instance without any async closure set")
         }
@@ -348,6 +348,7 @@ public final class Benchmark: Codable, Hashable {
         }
     }
 }
+// swiftlint:enable prefer_self_in_static_references
 
 public extension Benchmark {
     /// The configuration settings for running a benchmark.

--- a/Sources/Benchmark/BenchmarkExecutor+Extensions.swift
+++ b/Sources/Benchmark/BenchmarkExecutor+Extensions.swift
@@ -70,7 +70,7 @@ extension BenchmarkExecutor {
 extension BenchmarkExecutor {
     func arcStatsProducerNeeded(_ metric: BenchmarkMetric) -> Bool {
         switch metric {
-        case .retainCount, .releaseCount, .retainReleaseDelta:
+        case .objectAllocCount, .retainCount, .releaseCount, .retainReleaseDelta:
             return true
         default:
             return false

--- a/Sources/Benchmark/BenchmarkExecutor.swift
+++ b/Sources/Benchmark/BenchmarkExecutor.swift
@@ -43,10 +43,10 @@ internal final class BenchmarkExecutor {
         let logHandler = OSLog(subsystem: "one.ordo.benchmark", category: .pointsOfInterest)
         let signPost = OSSignposter(logHandle: logHandler)
         let signpostID = OSSignpostID(log: logHandler)
-        var interval: OSSignpostIntervalState?
+        var warmupInterval: OSSignpostIntervalState?
 
         if benchmark.configuration.warmupIterations > 0 {
-            interval = signPost.beginInterval("Benchmark", id: signpostID, "\(benchmark.name) warmup")
+            warmupInterval = signPost.beginInterval("Benchmark", id: signpostID, "\(benchmark.name) warmup")
         }
 #endif
 
@@ -56,8 +56,8 @@ internal final class BenchmarkExecutor {
         }
 
 #if canImport(OSLog)
-        if let interval, benchmark.configuration.warmupIterations > 0 {
-            signPost.endInterval("Benchmark", interval, "\(benchmark.configuration.warmupIterations)")
+        if let warmupInterval {
+            signPost.endInterval("Benchmark", warmupInterval, "\(benchmark.configuration.warmupIterations)")
         }
 #endif
 

--- a/Sources/Benchmark/BenchmarkExecutor.swift
+++ b/Sources/Benchmark/BenchmarkExecutor.swift
@@ -102,16 +102,16 @@ internal final class BenchmarkExecutor {
         // NB this code may be called twice if the user calls startMeasurement() manually and should
         // then reset to a new starting state.
         benchmark.measurementPreSynchronization = {
-            if mallocStatsRequested {
-                startMallocStats = self.mallocStatsProducer.makeMallocStats()
-            }
-
             if operatingSystemStatsRequested {
                 startOperatingSystemStats = self.operatingSystemStatsProducer.makeOperatingSystemStats()
             }
 
             if arcStatsRequested {
                 startARCStats = self.arcStatsProducer.makeARCStats()
+            }
+
+            if mallocStatsRequested {
+                startMallocStats = self.mallocStatsProducer.makeMallocStats()
             }
 
             startTime = BenchmarkClock.now // must be last in closure
@@ -122,16 +122,16 @@ internal final class BenchmarkExecutor {
         benchmark.measurementPostSynchronization = {
             stopTime = BenchmarkClock.now // must be first in closure
 
+            if mallocStatsRequested {
+                stopMallocStats = self.mallocStatsProducer.makeMallocStats()
+            }
+
             if arcStatsRequested {
                 stopARCStats = self.arcStatsProducer.makeARCStats()
             }
 
             if operatingSystemStatsRequested {
                 stopOperatingSystemStats = self.operatingSystemStatsProducer.makeOperatingSystemStats()
-            }
-
-            if mallocStatsRequested {
-                stopMallocStats = self.mallocStatsProducer.makeMallocStats()
             }
 
             var delta = 0

--- a/Sources/Benchmark/BenchmarkMetric+Defaults.swift
+++ b/Sources/Benchmark/BenchmarkMetric+Defaults.swift
@@ -49,7 +49,8 @@ public extension BenchmarkMetric {
 
     /// A collection of ARC metrics
     static var arc: [BenchmarkMetric] {
-        [.retainCount,
+        [.objectAllocCount,
+         .retainCount,
          .releaseCount,
          .retainReleaseDelta]
     }
@@ -98,6 +99,7 @@ public extension BenchmarkMetric {
          .readBytesPhysical,
          .writeBytesPhysical,
          .allocatedResidentMemory,
+         .objectAllocCount,
          .retainCount,
          .releaseCount,
          .retainReleaseDelta]

--- a/Sources/Benchmark/BenchmarkMetric.swift
+++ b/Sources/Benchmark/BenchmarkMetric.swift
@@ -58,6 +58,8 @@ public enum BenchmarkMetric: Hashable, Equatable, Codable, CustomStringConvertib
     case readBytesPhysical
     /// The number of bytes physicall written to a block device (i.e. disk) -- Linux only
     case writeBytesPhysical
+    /// Number of object allocations (implicit retain of one) (ARC)
+    case objectAllocCount
     /// Number of retains (ARC)
     case retainCount
     /// Number of releases (ARC)
@@ -126,7 +128,7 @@ public extension BenchmarkMetric {
             return true
         case .writeSyscalls, .writeBytesLogical, .writeBytesPhysical:
             return true
-        case .retainCount, .releaseCount, .retainReleaseDelta:
+        case .objectAllocCount, .retainCount, .releaseCount, .retainReleaseDelta:
             return true
         case let .custom(_, _, useScaleFactor):
             return useScaleFactor
@@ -193,12 +195,14 @@ public extension BenchmarkMetric {
             return "Bytes (read physical)"
         case .writeBytesPhysical:
             return "Bytes (write physical)"
+        case .objectAllocCount:
+            return "Object allocs"
         case .retainCount:
             return "Retains"
         case .releaseCount:
             return "Releases"
         case .retainReleaseDelta:
-            return "Retain / Release Δ"
+            return "(Alloc + Retain) - Release Δ"
         case .delta:
             return "Δ"
         case .deltaPercentage:
@@ -259,6 +263,8 @@ public extension BenchmarkMetric {
             return "readBytesPhysical"
         case .writeBytesPhysical:
             return "writeBytesPhysical"
+        case .objectAllocCount:
+            return "objectAllocCount"
         case .retainCount:
             return "retainCount"
         case .releaseCount:
@@ -327,6 +333,8 @@ public extension BenchmarkMetric {
             self = BenchmarkMetric.readBytesPhysical
         case "writeBytesPhysical":
             self = BenchmarkMetric.writeBytesPhysical
+        case "objectAllocCount":
+            self = BenchmarkMetric.objectAllocCount
         case "retainCount":
             self = BenchmarkMetric.retainCount
         case "releaseCount":

--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -200,7 +200,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
     }
 
     // from SO to avoid Foundation/Numerics
-    internal func pow<T: BinaryInteger>(_ base: T, _ power: T) -> T {
+    func pow<T: BinaryInteger>(_ base: T, _ power: T) -> T {
         func expBySq(_ y: T, _ x: T, _ n: T) -> T {
             precondition(n >= 0)
             if n == 0 {
@@ -217,7 +217,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
         return expBySq(1, base, power)
     }
 
-    internal var remainingScalingFactor: BenchmarkScalingFactor {
+    var remainingScalingFactor: BenchmarkScalingFactor {
         guard statistics.timeUnits == .automatic else {
             return scalingFactor
         }
@@ -362,8 +362,8 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
         public var improvements: [ThresholdDeviation] = []
 
         public mutating func append(_ otherDeviations: Self) {
-            self.improvements.append(contentsOf: otherDeviations.improvements)
-            self.regressions.append(contentsOf: otherDeviations.regressions)
+            improvements.append(contentsOf: otherDeviations.improvements)
+            regressions.append(contentsOf: otherDeviations.regressions)
         }
     }
 
@@ -390,7 +390,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
             let absoluteDifference = (reverseComparison ? -1 : 1) * (lhs - rhs)
             let relativeDifference = (reverseComparison ? 1 : -1) * (rhs != 0 ? (100 - (100.0 * Double(lhs) / Double(rhs))) : 0.0)
 
-            if let threshold = thresholds.relative[percentile], !(-threshold...threshold).contains(relativeDifference) {
+            if let threshold = thresholds.relative[percentile], !(-threshold ... threshold).contains(relativeDifference) {
                 let deviation = ThresholdDeviation(name: name,
                                                    target: target,
                                                    metric: metric,

--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -408,7 +408,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
                 }
             }
 
-            if let threshold = thresholds.absolute[percentile], abs(absoluteDifference) > threshold {
+            if let threshold = thresholds.absolute[percentile], !(-threshold ... threshold).contains(absoluteDifference) {
                 let deviation = ThresholdDeviation(name: name,
                                                    target: target,
                                                    metric: metric,

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -70,7 +70,7 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
         If this is enabled, zero or one baselines should be specified for the check operation.
         By default, thresholds are checked comparing two baselines, or a baseline and a benchmark run.
         """)
-    var checkAbsoluteThresholds = false
+    var checkAbsolute = false
 
     @Flag(name: .shortAndLong, help: "True if we should run the benchmarks for all metrics.")
     var allMetrics = false
@@ -87,7 +87,7 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
     public static func setupBenchmarkRunner(registerBenchmarks: () -> Void) async {
         do {
             var command = Self.parseOrExit()
-            Benchmark.checkAbsoluteThresholds = command.checkAbsoluteThresholds
+            Benchmark.checkAbsoluteThresholds = command.checkAbsolute
             registerBenchmarks()
             try await command.run()
         } catch {

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -168,15 +168,28 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                     benchmark.target = benchmarkToRun.target
 
                     do {
-                        try await Benchmark.startupHook?()
-                        try await Benchmark.setup?()
+                        var setupState = try await Benchmark.startupHook?()
+                        if let setupState {
+                            benchmark.setupState = setupState
+                        }
+                        
+                        setupState = try await Benchmark.setup?()
+                        if let setupState {
+                            benchmark.setupState = setupState
+                        }
 
                         if let setup = benchmark.configuration.setup {
-                            try await setup()
+                            setupState = try await setup()
+                            if let setupState {
+                                benchmark.setupState = setupState
+                            }
                         }
 
                         if let setup = benchmark.setup {
-                            try await setup()
+                            setupState = try await setup()
+                            if let setupState {
+                                benchmark.setupState = setupState
+                            }
                         }
                     } catch {
                         let description = """

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -172,7 +172,7 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                         if let setupState {
                             benchmark.setupState = setupState
                         }
-                        
+
                         setupState = try await Benchmark.setup?()
                         if let setupState {
                             benchmark.setupState = setupState

--- a/Sources/Benchmark/Documentation.docc/ComparingBenchmarksCI.md
+++ b/Sources/Benchmark/Documentation.docc/ComparingBenchmarksCI.md
@@ -33,6 +33,8 @@ These baselines can then be checked with:
 swift package benchmark baseline check --check-absolute-path /relative/or/absolute/path/to/Thresholds
 ```
 
+The absolute check will have an exit code of 0 if the check is exactly equal, but will return with exit code 2 if there we any regressions or exit code 4 if there were only improvements.
+
 ### Example GitHub CI workflow comparing against a baseline
 
 The following GitHub workflow provides an example of comparing any pull request against the `main` branch of your repository, failing on a comparison regression.

--- a/Sources/Benchmark/Documentation.docc/ComparingBenchmarksCI.md
+++ b/Sources/Benchmark/Documentation.docc/ComparingBenchmarksCI.md
@@ -33,7 +33,7 @@ These baselines can then be checked with:
 swift package benchmark baseline check --check-absolute-path /relative/or/absolute/path/to/Thresholds
 ```
 
-The absolute check will have an exit code of 0 if the check is exactly equal, but will return with exit code 2 if there we any regressions or exit code 4 if there were only improvements.
+The absolute check will have an exit code of 0 if the check is exactly equal, but will return with exit code 2 if there were any regressions or exit code 4 if there were only improvements.
 
 ### Example GitHub CI workflow comparing against a baseline
 

--- a/Sources/Benchmark/Documentation.docc/RunningBenchmarks.md
+++ b/Sources/Benchmark/Documentation.docc/RunningBenchmarks.md
@@ -90,7 +90,7 @@ Benchmark targets matching the regexp filter that should be skipped
 --path <path>           The path where exported data is stored, default is the current directory ("."). 
 --quiet                 Specifies that output should be suppressed (useful for if you just want to check return code)
 --scale                 Specifies that some of the text output should be scaled using the scalingFactor (denoted by '*' in output)
---check-absolute-thresholds
+--check-absolute
 Set to true if thresholds should be checked against an absolute reference point rather than delta between baselines.
 This is used for CI workflows when you want to validate the thresholds vs. a persisted benchmark baseline
 rather than comparing PR vs main or vs a current run. This is useful to cut down the build matrix needed
@@ -98,7 +98,7 @@ for those wanting to validate performance of e.g. toolchains or OS:s as well (or
 a specific check against a given absolute reference.).
 If this is enabled, zero or one baselines should be specified for the check operation.
 By default, thresholds are checked comparing two baselines, or a baseline and a benchmark run.
---check-absolute-thresholds-path <check-absolute-thresholds-path>
+--check-absolute-path <check-absolute-path>
 The path from which p90 thresholds will be loaded for absolute threshold checks.
 This implicitly sets --check-absolute to true as well.
 --no-progress           Specifies that benchmark progress information should not be displayed

--- a/Sources/Benchmark/Documentation.docc/WritingBenchmarks.md
+++ b/Sources/Benchmark/Documentation.docc/WritingBenchmarks.md
@@ -334,6 +334,35 @@ let benchmarks = {
 }
 ```
 
+Also, the setup can return an optional value of Any type, that can subsequently be accessed by the 
+benchmark in the standard benchmark execution closure through the ``Benchmark/Benchmark/setupState`` property.
+This is useful for benchmarks that need to set up some computed state that is then reused for each benchmark
+iteration loop. This can be done for all setup closures, like this:
+
+```swift
+import Benchmark
+
+func setupFunction() -> [Int] {
+    [1, 2, 3]
+}
+
+let benchmarks = {
+
+  Benchmark.setup = { 
+    print("global setup closure, used for all benchmarks") 
+    return 4711 // possible to return here
+  }
+
+  Benchmark("Minimal benchmark",
+  configuration: .init(setup: setupFunction)) { benchmark in
+    if let state = benchmark.setupState as? [Int] {
+    }
+  } setup: {
+    return "test" // or here
+  } 
+}
+```
+Only the most specific (and last) return value will be set.
 
 ### Async vs Sync
 

--- a/Sources/Benchmark/Documentation.docc/WritingBenchmarks.md
+++ b/Sources/Benchmark/Documentation.docc/WritingBenchmarks.md
@@ -334,10 +334,30 @@ let benchmarks = {
 }
 ```
 
-Also, the setup can return an optional value of Any type, that can subsequently be accessed by the 
-benchmark in the standard benchmark execution closure through the ``Benchmark/Benchmark/setupState`` property.
+Also, the setup can return an optional value of any type, that can subsequently be accessed by the 
+benchmark in the standard benchmark execution closure through a second closure parameter.
+
 This is useful for benchmarks that need to set up some computed state that is then reused for each benchmark
-iteration loop. This can be done for all setup closures, like this:
+iteration loop. 
+
+```swift
+import Benchmark
+
+let benchmarks = {
+
+Benchmark("Minimal benchmark") { benchmark, setupState in
+print("Array of ints: \(setupState")
+} setup: {
+[1, 2, 3]
+} 
+}
+```
+
+It's also possible to return an optional value of Any type, that can subsequently be accessed by the 
+benchmark in the standard benchmark execution closure through the ``Benchmark/Benchmark/setupState`` property,
+this will then need to be case appropriately in the benchmark.
+
+This can be done for all setup closures, like this:
 
 ```swift
 import Benchmark
@@ -362,6 +382,7 @@ let benchmarks = {
   } 
 }
 ```
+
 Only the most specific (and last) return value will be set.
 
 ### Async vs Sync

--- a/Sources/Benchmark/MallocStats/MallocStats.swift
+++ b/Sources/Benchmark/MallocStats/MallocStats.swift
@@ -12,7 +12,7 @@
 #if swift(>=5.8)
     @_documentation(visibility: internal)
 #endif
-internal struct MallocStats {
+struct MallocStats {
     var mallocCountTotal: Int = 0 /// total number of mallocs done
     var mallocCountSmall: Int = 0 /// number of small mallocs (as defined by jemalloc)
     var mallocCountLarge: Int = 0 /// number of large mallocs (as defined by jemalloc)

--- a/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
+++ b/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
@@ -22,23 +22,37 @@ import ExtrasJSON
 //        @_documentation(visibility: internal)
 //    #endif
     final class MallocStatsProducer {
-        var threadCacheMIB: [size_t]
-        var epochMIB: [size_t]
-//    var smallNMallocMIB: [size_t]
-//    var largeNMallocMIB: [size_t]
-//    var smallNDallocMIB: [size_t]
-//    var largeNDallocMIB: [size_t]
-//    var smallAlloctedMIB: [size_t]
-//    var largeAllocatedMIB: [size_t]
-        var totalAllocatedMIB: [size_t]
-        var smallNRequestsMIB: [size_t]
-        var largeNRequestsMIB: [size_t]
-//    var smallNFillsMIB: [size_t]
-//    var largeNFillsMIB: [size_t]
+        // Basically just set up a number of cached MIB structures for
+        // more efficient queries later of malloc statistics.
+        static var threadCacheMIB = setupMIB(name: "thread.tcache.flush")
+        static var epochMIB = setupMIB(name: "epoch")
+        static var totalAllocatedMIB: [size_t] = setupMIB(name: "stats.resident")
+        static var smallNRequestsMIB: [size_t] = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.nrequests")
+        static var largeNRequestsMIB: [size_t] = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.nrequests")
+//    var smallNMallocMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.nmalloc")
+//    var largeNMallocMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.nmalloc")
+//    var smallNDallocMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.ndalloc")
+//    var largeNDallocMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.ndalloc")
+//    var smallAlloctedMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.allocated")
+//    var largeAllocatedMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.allocated")
+//    var smallNFillsMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.nfills")
+//    var largeNFillsMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.nfills")
+
+        static func setupMIB(name: String) -> [size_t] {
+            precondition(!name.split(separator: ".").isEmpty, "setupMIB with 0 count")
+            var mib = [size_t](repeating: 0, count: name.split(separator: ".").count)
+            var mibSize = mib.count
+            mib.withUnsafeMutableBufferPointer { pointer in
+                let result = mallctlnametomib(name, pointer.baseAddress, &mibSize)
+                if result != 0 {
+                    print("mallctlnametomib \(name) returned \(result)")
+                }
+            }
+            return mib
+        }
 
         // Update jemalloc internal statistics, this is the magic incantation to do it
-        @discardableResult
-        func updateEpoch() -> Int {
+        static func updateEpoch() {
             var allocated = 0
             var size = MemoryLayout<Int>.size
             var epoch = 0
@@ -56,43 +70,11 @@ import ExtrasJSON
             if result != 0 {
                 print("mallctlbymib epochMIB returned \(result)")
             }
-
-            return epoch
-        }
-
-        // Basically just set up a number of cached MIB structures for
-        // more efficient queries later of malloc statistics.
-        init() {
-            func setupMIB(name: String) -> [size_t] {
-                precondition(!name.split(separator: ".").isEmpty, "setupMIB with 0 count")
-                var mib = [size_t](repeating: 0, count: name.split(separator: ".").count)
-                var mibSize = mib.count
-                mib.withUnsafeMutableBufferPointer { pointer in
-                    let result = mallctlnametomib(name, pointer.baseAddress, &mibSize)
-                    if result != 0 {
-                        print("mallctlnametomib \(name) returned \(result)")
-                    }
-                }
-                return mib
-            }
-
-            epochMIB = setupMIB(name: "epoch")
-            threadCacheMIB = setupMIB(name: "thread.tcache.flush")
-            smallNRequestsMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.nrequests")
-            largeNRequestsMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.nrequests")
-            totalAllocatedMIB = setupMIB(name: "stats.resident")
-//        smallNMallocMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.nmalloc")
-//        largeNMallocMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.nmalloc")
-//        smallNDallocMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.ndalloc")
-//        largeNDallocMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.ndalloc")
-//        smallAlloctedMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.allocated")
-//        largeAllocatedMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.allocated")
-//        smallNFillsMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.nfills")
-//        largeNFillsMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.nfills")
+//            return epoch
         }
 
         // Read the actual stats using a cached MIB as the key
-        func readStats(_ mib: [Int]) -> Int {
+        static func readStats(_ mib: [Int]) -> Int {
             var allocated = 0
             var size = MemoryLayout<Int>.size
 
@@ -103,7 +85,7 @@ import ExtrasJSON
             return 0
         }
 
-        func makeMallocStats() -> MallocStats {
+        static func makeMallocStats() -> MallocStats {
             updateEpoch()
             let allocationsCountSmall = readStats(smallNRequestsMIB)
             let allocationsCountLarge = readStats(largeNRequestsMIB)
@@ -129,7 +111,7 @@ import ExtrasJSON
 
         // Parsed stats for convenience, this is a heavy and slow operation not suitable for
         // being called within benchmark iterations
-        func jemallocStatistics() -> Jemalloc? {
+        static func jemallocStatistics() -> Jemalloc? {
             // C style callback needs to use a class instance as a data carrier as we can't
             // capture state in a c-style closure, thus the dance with from/to Opaque.
             typealias CallbackType = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Void
@@ -152,7 +134,7 @@ import ExtrasJSON
 
         // Full JSON with stats, this is a heavy and slow operation not suitable for
         // being called within benchmark iterations
-        func jsonStatistics() -> String {
+        static func jsonStatistics() -> String {
             // C style callback needs to use a class instance as a data carrier as we can't
             // capture state in a c-style closure, thus the dance with from/to Opaque.
             typealias CallbackType = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Void
@@ -172,8 +154,8 @@ import ExtrasJSON
 #else
 
     // stub if no jemalloc available
-    final class MallocStatsProducer {
-        func makeMallocStats() -> MallocStats {
+    enum MallocStatsProducer {
+        static func makeMallocStats() -> MallocStats {
             MallocStats(mallocCountTotal: 0,
                         mallocCountSmall: 0,
                         mallocCountLarge: 0,

--- a/Sources/Benchmark/NIOLock.swift
+++ b/Sources/Benchmark/NIOLock.swift
@@ -33,25 +33,25 @@
 /// `SRWLOCK` type.
 struct NIOLock {
     @usableFromInline
-    internal let _storage: _Storage
+    let _storage: _Storage
 
     #if os(Windows)
         @usableFromInline
-        internal typealias LockPrimitive = SRWLOCK
+        typealias LockPrimitive = SRWLOCK
     #else
         @usableFromInline
-        internal typealias LockPrimitive = pthread_mutex_t
+        typealias LockPrimitive = pthread_mutex_t
     #endif
 
     @usableFromInline
-    internal final class _Storage {
+    final class _Storage {
         // TODO: We should tail-allocate the pthread_t/SRWLock.
         @usableFromInline
-        internal let mutex: UnsafeMutablePointer<LockPrimitive> =
+        let mutex: UnsafeMutablePointer<LockPrimitive> =
             UnsafeMutablePointer.allocate(capacity: 1)
 
         /// Create a new lock.
-        internal init() {
+        init() {
             #if os(Windows)
                 InitializeSRWLock(mutex)
             #else
@@ -63,7 +63,7 @@ struct NIOLock {
             #endif
         }
 
-        internal func lock() {
+        func lock() {
             #if os(Windows)
                 AcquireSRWLockExclusive(mutex)
             #else
@@ -72,7 +72,7 @@ struct NIOLock {
             #endif
         }
 
-        internal func unlock() {
+        func unlock() {
             #if os(Windows)
                 ReleaseSRWLockExclusive(mutex)
             #else
@@ -81,7 +81,7 @@ struct NIOLock {
             #endif
         }
 
-        internal func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
+        func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
             try body(mutex)
         }
 
@@ -117,7 +117,7 @@ struct NIOLock {
         _storage.unlock()
     }
 
-    internal func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
+    func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
         try _storage.withLockPrimitive(body)
     }
 }

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStats.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStats.swift
@@ -9,7 +9,7 @@
 //
 
 /// The  stats that the OperatingSystemStatsProducer can provide
-internal struct OperatingSystemStats {
+struct OperatingSystemStats {
     /// CPU user space time spent for running the test
     var cpuUser: Int = 0
     /// CPU system time spent for running the test

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
@@ -24,6 +24,7 @@
         var peakThreads: Int = 0
         var sampleRate: Int = 10_000
         var runState: RunState = .running
+        var metrics: Set<BenchmarkMetric>?
 
         enum RunState {
             case running
@@ -90,6 +91,10 @@
             stats.peakMemoryResident *= pageSize
 
             return stats
+        }
+
+        func configureMetrics(_ metrics: Set<BenchmarkMetric>) {
+            self.metrics = metrics
         }
 
         func makeOperatingSystemStats() -> OperatingSystemStats {

--- a/Sources/Benchmark/Statistics.swift
+++ b/Sources/Benchmark/Statistics.swift
@@ -75,9 +75,9 @@ public final class Statistics: Codable {
         }
     }
 
-    internal var _cachedPercentiles: [Int] = []
-    internal var _cacheUnits: Statistics.Units = .automatic
-    internal var _cachedPercentilesHistogramCount: UInt64 = 0
+    var _cachedPercentiles: [Int] = []
+    var _cacheUnits: Statistics.Units = .automatic
+    var _cachedPercentilesHistogramCount: UInt64 = 0
 
     public func percentiles(for percentilesToCalculate: [Double] = defaultPercentilesToCalculate) -> [Int] {
         if percentilesToCalculate == Self.defaultPercentilesToCalculate {

--- a/Sources/SwiftRuntimeHooks/include/SwiftRuntimeHooks.h
+++ b/Sources/SwiftRuntimeHooks/include/SwiftRuntimeHooks.h
@@ -3,6 +3,7 @@
 
 typedef void (*swift_runtime_hook_t)(const void *, void *);
 
+void swift_runtime_set_alloc_object_hook(swift_runtime_hook_t hook, void * context);
 void swift_runtime_set_retain_hook(swift_runtime_hook_t hook, void * context);
 void swift_runtime_set_release_hook(swift_runtime_hook_t hook, void * context);
 

--- a/Sources/SwiftRuntimeHooks/shims.c
+++ b/Sources/SwiftRuntimeHooks/shims.c
@@ -4,9 +4,16 @@
 #include "SwiftRuntimeHooks.h"
 
 typedef struct HeapObject_s HeapObject;
+typedef struct HeapMetadata_s HeapMetadata;
+
+extern HeapObject * (*_swift_allocObject)(HeapMetadata const *metadata,
+                                          size_t requiredSize,
+                                          size_t requiredAlignmentMask);
 
 extern HeapObject * (*_swift_retain)(HeapObject*);
 extern HeapObject * (*_swift_release)(HeapObject*);
+
+extern HeapObject * (*_swift_tryRetain)(HeapObject*);
 
 // unclear if the following two needs hooking and they don't seem to be called on Apple Silicon
 extern HeapObject * (*_swift_retain_n)(HeapObject *object, uint32_t n);
@@ -14,18 +21,57 @@ extern HeapObject * (*_swift_release_n)(HeapObject *object, uint32_t n);
 
 struct hook_data_s {
     HeapObject * (*orig)(HeapObject*);
+    HeapObject * (*origTry)(HeapObject*);
     HeapObject * (*orig_n)(HeapObject*, uint32_t);
+    swift_runtime_hook_t hook;
+    void * context;
+};
+
+struct hook_data_alloc_s {
+    HeapObject * (*orig)(HeapMetadata const *, size_t, size_t);
     swift_runtime_hook_t hook;
     void * context;
 };
 
 /*===========================================================================*/
 
-static struct hook_data_s _swift_retain_hook_data = {NULL, NULL, NULL, NULL};
+static struct hook_data_alloc_s _swift_alloc_object_hook_data = {NULL, NULL, NULL};
+
+static HeapObject * _swift_alloc_object_hook(HeapMetadata const *metadata,
+                                             size_t requiredSize,
+                                             size_t requiredAlignmentMask) {
+    HeapObject * ret = (*_swift_alloc_object_hook_data.orig)(metadata, requiredSize, requiredAlignmentMask);
+    (*_swift_alloc_object_hook_data.hook)(ret, _swift_alloc_object_hook_data.context);
+    return ret;
+}
+
+void swift_runtime_set_alloc_object_hook(swift_runtime_hook_t hook, void * context) {
+    if (hook == NULL) {
+        _swift_allocObject = _swift_alloc_object_hook_data.orig;
+        struct hook_data_alloc_s hook_data = {NULL, NULL, NULL};
+        _swift_alloc_object_hook_data = hook_data;
+    } else {
+        struct hook_data_alloc_s hook_data = {_swift_allocObject, hook, context};
+        _swift_alloc_object_hook_data = hook_data;
+        _swift_allocObject = _swift_alloc_object_hook;
+    }
+}
+/*===========================================================================*/
+
+static struct hook_data_s _swift_retain_hook_data = {NULL, NULL, NULL, NULL, NULL};
 
 static HeapObject * _swift_retain_hook(HeapObject * heapObject) {
     HeapObject * ret = (*_swift_retain_hook_data.orig)(heapObject);
     (*_swift_retain_hook_data.hook)(heapObject, _swift_retain_hook_data.context);
+    return ret;
+}
+
+// This doesn't seem to be called for Apple Silicon at least, but keeping it here
+static HeapObject * _swift_tryRetain_hook(HeapObject * heapObject) {
+    HeapObject * ret = (*_swift_retain_hook_data.origTry)(heapObject);
+    if (ret != NULL) {
+        (*_swift_retain_hook_data.hook)(heapObject, _swift_retain_hook_data.context);
+    }
     return ret;
 }
 
@@ -42,20 +88,22 @@ static HeapObject * _swift_retain_n_hook(HeapObject * heapObject, uint32_t n) {
 void swift_runtime_set_retain_hook(swift_runtime_hook_t hook, void * context) {
     if (hook == NULL) {
         _swift_retain = _swift_retain_hook_data.orig;
+        _swift_tryRetain = _swift_retain_hook_data.origTry;
         _swift_retain_n = _swift_retain_hook_data.orig_n;
-        struct hook_data_s hook_data = {NULL, NULL, NULL, NULL};
+        struct hook_data_s hook_data = {NULL, NULL, NULL, NULL, NULL};
         _swift_retain_hook_data = hook_data;
     } else {
-        struct hook_data_s hook_data = {_swift_retain, _swift_retain_n, hook, context};
+        struct hook_data_s hook_data = {_swift_retain, _swift_tryRetain, _swift_retain_n, hook, context};
         _swift_retain_hook_data = hook_data;
         _swift_retain = _swift_retain_hook;
+        _swift_tryRetain = _swift_tryRetain_hook;
         _swift_retain_n = _swift_retain_n_hook;
     }
 }
 
 /*===========================================================================*/
 
-static struct hook_data_s _swift_release_hook_data = {NULL, NULL, NULL, NULL};
+static struct hook_data_s _swift_release_hook_data = {NULL, NULL, NULL, NULL, NULL};
 
 static HeapObject * _swift_release_hook(HeapObject * heapObject) {
     HeapObject * ret = (*_swift_release_hook_data.orig)(heapObject);
@@ -77,10 +125,10 @@ void swift_runtime_set_release_hook(swift_runtime_hook_t hook, void * context) {
     if (hook == NULL) {
         _swift_release = _swift_release_hook_data.orig;
         _swift_release_n = _swift_release_hook_data.orig_n;
-        struct hook_data_s hook_data = {NULL, NULL, NULL, NULL};
+        struct hook_data_s hook_data = {NULL, NULL, NULL, NULL, NULL};
         _swift_release_hook_data = hook_data;
     } else {
-        struct hook_data_s hook_data = {_swift_release, _swift_release_n, hook, context};
+        struct hook_data_s hook_data = {_swift_release, NULL, _swift_release_n, hook, context};
         _swift_release_hook_data = hook_data;
         _swift_release = _swift_release_hook;
         _swift_release_n = _swift_release_n_hook;

--- a/Tests/BenchmarkTests/BenchmarkMetricsTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkMetricsTests.swift
@@ -35,6 +35,7 @@ final class BenchmarkMetricsTests: XCTestCase {
         .writeBytesLogical,
         .readBytesPhysical,
         .writeBytesPhysical,
+        .objectAllocCount,
         .retainCount,
         .releaseCount,
         .retainReleaseDelta,
@@ -65,6 +66,7 @@ final class BenchmarkMetricsTests: XCTestCase {
         "writeBytesLogical",
         "readBytesPhysical",
         "writeBytesPhysical",
+        "objectAllocCount",
         "retainCount",
         "releaseCount",
         "retainReleaseDelta"

--- a/Tests/BenchmarkTests/BenchmarkResultTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkResultTests.swift
@@ -275,6 +275,14 @@ final class BenchmarkResultTests: XCTestCase {
         thirdStatistics.add(1_501)
         thirdStatistics.add(1_501)
 
+        let fourthStatistics = Statistics()
+        fourthStatistics.add(1_499)
+        fourthStatistics.add(1_500)
+        fourthStatistics.add(1_501)
+        fourthStatistics.add(1_501)
+        fourthStatistics.add(1_501)
+        fourthStatistics.add(1_501)
+
         let absolute: BenchmarkThresholds.AbsoluteThresholds = [.p0: 1,
                                                                 .p25: 1,
                                                                 .p50: 1,
@@ -314,6 +322,13 @@ final class BenchmarkResultTests: XCTestCase {
                                           thresholds: .default,
                                           statistics: thirdStatistics)
 
+        let fourthResult = BenchmarkResult(metric: .cpuUser,
+                                           timeUnits: .nanoseconds,
+                                           scalingFactor: .one,
+                                           warmupIterations: 0,
+                                           thresholds: .default,
+                                           statistics: fourthStatistics)
+
         var (betterOrEqual, failures) = secondResult.betterResultsOrEqual(than: firstResult,
                                                                           thresholds: absoluteThresholds)
         XCTAssertFalse(betterOrEqual)
@@ -325,10 +340,17 @@ final class BenchmarkResultTests: XCTestCase {
         XCTAssert(failures.isEmpty)
 
         Benchmark.checkAbsoluteThresholds = true
-        failures = thirdResult.failsAbsoluteThresholdChecks(thresholds: absoluteThresholdsTwo,
-                                                            name: "test",
-                                                            target: "test")
-        XCTAssert(failures.count > 4)
+        let results = thirdResult.failsAbsoluteThresholdChecks(thresholds: absoluteThresholdsTwo,
+                                                               name: "test",
+                                                               target: "test")
+        XCTAssert(results.regressions.count > 4)
+
+        Benchmark.checkAbsoluteThresholds = true
+        let mixedResults = fourthResult.failsAbsoluteThresholdChecks(thresholds: absoluteThresholdsTwo,
+                                                                     name: "test",
+                                                                     target: "test")
+        XCTAssert(mixedResults.regressions.count == 4)
+        XCTAssert(mixedResults.improvements.count == 1)
     }
 
     func testBenchmarkResultDescriptions() throws {

--- a/Tests/BenchmarkTests/BenchmarkResultTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkResultTests.swift
@@ -349,8 +349,8 @@ final class BenchmarkResultTests: XCTestCase {
         let mixedResults = fourthResult.failsAbsoluteThresholdChecks(thresholds: absoluteThresholdsTwo,
                                                                      name: "test",
                                                                      target: "test")
-        XCTAssert(mixedResults.regressions.count == 4)
-        XCTAssert(mixedResults.improvements.count == 1)
+        XCTAssertEqual(mixedResults.regressions.count, 4)
+        XCTAssertEqual(mixedResults.improvements.count, 1)
     }
 
     func testBenchmarkResultDescriptions() throws {

--- a/Tests/BenchmarkTests/BenchmarkResultTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkResultTests.swift
@@ -158,8 +158,7 @@ final class BenchmarkResultTests: XCTestCase {
                                            thresholds: .default,
                                            statistics: secondStatistics)
 
-        let (betterOrEqual, _) = secondResult.betterResultsOrEqual(than: firstResult)
-        XCTAssert(betterOrEqual)
+        XCTAssert(secondResult.deviationsComparedWith(firstResult).regressions.isEmpty)
     }
 
     func testBenchmarkResultBetterOrEqualWithCustomThresholds() throws {
@@ -224,28 +223,28 @@ final class BenchmarkResultTests: XCTestCase {
                                            thresholds: .default,
                                            statistics: secondStatistics)
 
-        var (betterOrEqual, _) = secondResult.betterResultsOrEqual(than: firstResult, thresholds: bothThresholds)
+        var betterOrEqual = secondResult.deviationsComparedWith(firstResult, thresholds: bothThresholds).regressions.isEmpty
         XCTAssertFalse(betterOrEqual)
 
-        (betterOrEqual, _) = secondResult.betterResultsOrEqual(than: firstResult, thresholds: relativeRelaxedThresholds)
+        betterOrEqual = secondResult.deviationsComparedWith(firstResult, thresholds: relativeRelaxedThresholds).regressions.isEmpty
         XCTAssert(betterOrEqual)
 
-        (betterOrEqual, _) = secondResult.betterResultsOrEqual(than: firstResult, thresholds: relativeThresholds)
+        betterOrEqual = secondResult.deviationsComparedWith(firstResult, thresholds: relativeThresholds).regressions.isEmpty
         XCTAssertFalse(betterOrEqual)
 
-        (betterOrEqual, _) = secondResult.betterResultsOrEqual(than: firstResult, thresholds: absoluteThresholds)
+        betterOrEqual = secondResult.deviationsComparedWith(firstResult, thresholds: absoluteThresholds).regressions.isEmpty
         XCTAssertFalse(betterOrEqual)
 
-        (betterOrEqual, _) = firstResult.betterResultsOrEqual(than: secondResult, thresholds: bothThresholds)
+        betterOrEqual = firstResult.deviationsComparedWith(secondResult, thresholds: bothThresholds).regressions.isEmpty
         XCTAssert(betterOrEqual)
 
-        (betterOrEqual, _) = firstResult.betterResultsOrEqual(than: secondResult, thresholds: relativeRelaxedThresholds)
+        betterOrEqual = firstResult.deviationsComparedWith(secondResult, thresholds: relativeRelaxedThresholds).regressions.isEmpty
         XCTAssert(betterOrEqual)
 
-        (betterOrEqual, _) = firstResult.betterResultsOrEqual(than: secondResult, thresholds: relativeThresholds)
+        betterOrEqual = firstResult.deviationsComparedWith(secondResult, thresholds: relativeThresholds).regressions.isEmpty
         XCTAssert(betterOrEqual)
 
-        (betterOrEqual, _) = firstResult.betterResultsOrEqual(than: secondResult, thresholds: absoluteThresholds)
+        betterOrEqual = firstResult.deviationsComparedWith(secondResult, thresholds: absoluteThresholds).regressions.isEmpty
         XCTAssert(betterOrEqual)
     }
 
@@ -329,28 +328,22 @@ final class BenchmarkResultTests: XCTestCase {
                                            thresholds: .default,
                                            statistics: fourthStatistics)
 
-        var (betterOrEqual, failures) = secondResult.betterResultsOrEqual(than: firstResult,
-                                                                          thresholds: absoluteThresholds)
-        XCTAssertFalse(betterOrEqual)
-        XCTAssertFalse(failures.isEmpty, "Failures: \(failures)")
+        var deviations = secondResult.deviationsComparedWith(firstResult,
+                                                             thresholds: absoluteThresholds)
+        XCTAssertFalse(deviations.regressions.isEmpty, "Regressions: \(deviations.regressions)")
 
-        (betterOrEqual, failures) = firstResult.betterResultsOrEqual(than: secondResult,
-                                                                     thresholds: absoluteThresholds)
-        XCTAssert(betterOrEqual)
-        XCTAssert(failures.isEmpty)
+        deviations = firstResult.deviationsComparedWith(secondResult,
+                                                        thresholds: absoluteThresholds)
+        XCTAssert(deviations.regressions.isEmpty)
 
         Benchmark.checkAbsoluteThresholds = true
-        let results = thirdResult.failsAbsoluteThresholdChecks(thresholds: absoluteThresholdsTwo,
-                                                               name: "test",
-                                                               target: "test")
-        XCTAssert(results.regressions.count > 4)
+        deviations = thirdResult.deviationsAgainstAbsoluteThresholds(absoluteThresholdsTwo)
+        XCTAssert(deviations.regressions.count > 4)
 
         Benchmark.checkAbsoluteThresholds = true
-        let mixedResults = fourthResult.failsAbsoluteThresholdChecks(thresholds: absoluteThresholdsTwo,
-                                                                     name: "test",
-                                                                     target: "test")
-        XCTAssertEqual(mixedResults.regressions.count, 4)
-        XCTAssertEqual(mixedResults.improvements.count, 1)
+        deviations = fourthResult.deviationsAgainstAbsoluteThresholds(absoluteThresholdsTwo)
+        XCTAssertEqual(deviations.regressions.count, 4)
+        XCTAssertEqual(deviations.improvements.count, 1)
     }
 
     func testBenchmarkResultDescriptions() throws {

--- a/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
@@ -16,12 +16,12 @@ final class BenchmarkRunnerTests: XCTestCase, BenchmarkRunnerReadWrite {
     private var writeCount: Int = 0
 
     // swiftlint:disable test_case_accessibility
-    internal func write(_: BenchmarkCommandReply) throws {
+    func write(_: BenchmarkCommandReply) throws {
         writeCount += 1
 //        print("write \(reply)")
     }
 
-    internal func read() throws -> BenchmarkCommandRequest {
+    func read() throws -> BenchmarkCommandRequest {
         //      print("read request")
         Benchmark.testSkipBenchmarkRegistrations = true
         let benchmark = Benchmark("Minimal benchmark") { _ in

--- a/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
+++ b/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
@@ -56,14 +56,13 @@ final class OperatingSystemAndMallocTests: XCTestCase {
 
     #if canImport(jemalloc)
         func testMallocProducerLeaks() throws {
-            let mallocStatsProducer = MallocStatsProducer()
-            let startMallocStats = mallocStatsProducer.makeMallocStats()
+            let startMallocStats = MallocStatsProducer.makeMallocStats()
 
             for outerloop in 1 ... 100 {
                 blackHole(malloc(outerloop * 1_024))
             }
 
-            let stopMallocStats = mallocStatsProducer.makeMallocStats()
+            let stopMallocStats = MallocStatsProducer.makeMallocStats()
 
             XCTAssertGreaterThanOrEqual(stopMallocStats.mallocCountTotal - startMallocStats.mallocCountTotal, 100)
             XCTAssertGreaterThanOrEqual(stopMallocStats.allocatedResidentMemory - startMallocStats.allocatedResidentMemory,
@@ -72,12 +71,10 @@ final class OperatingSystemAndMallocTests: XCTestCase {
     #endif
 
     func testARCStatsProducer() throws {
-        let statsProducer = ARCStatsProducer()
-
         let array = [3]
-        statsProducer.hook()
+        ARCStatsProducer.hook()
 
-        let startStats = statsProducer.makeARCStats()
+        let startStats = ARCStatsProducer.makeARCStats()
 
         for outerloop in 1 ... 100 {
             var arrayCopy = array
@@ -86,8 +83,9 @@ final class OperatingSystemAndMallocTests: XCTestCase {
             blackHole(arrayCopy)
         }
 
-        let stopStats = statsProducer.makeARCStats()
+        let stopStats = ARCStatsProducer.makeARCStats()
 
+        XCTAssertGreaterThanOrEqual(stopStats.objectAllocCount - startStats.objectAllocCount, 100)
         XCTAssertGreaterThanOrEqual(stopStats.retainCount - startStats.retainCount, 100)
         XCTAssertGreaterThanOrEqual(stopStats.releaseCount - startStats.releaseCount, 100)
     }
@@ -97,6 +95,8 @@ final class OperatingSystemAndMallocTests: XCTestCase {
 
         XCTAssertTrue(statsProducer.metricSupported(.readBytesPhysical))
         XCTAssertTrue(statsProducer.metricSupported(.writeBytesPhysical))
+
+        statsProducer.configureMetrics([.readBytesPhysical, .writeBytesPhysical])
 
         let startStats = statsProducer.makeOperatingSystemStats()
 
@@ -112,7 +112,7 @@ final class OperatingSystemAndMallocTests: XCTestCase {
 
         var buffer = (0 ..< stat.st_blksize).map { _ in UInt8.random(in: 0 ... UInt8.max) }
 
-        for _ in (0 ..< amplificationFactor) {
+        for _ in 0 ..< amplificationFactor {
             buffer.withUnsafeBytes { buffer in
                 XCTAssertEqual(write(fildes, buffer.baseAddress, buffer.count), buffer.count, "write() failed: \(errno)")
             }

--- a/Thresholds/P90AbsoluteThresholdsBenchmark.P90Date.p90.json
+++ b/Thresholds/P90AbsoluteThresholdsBenchmark.P90Date.p90.json
@@ -1,4 +1,4 @@
 {
-  "syscalls" : 1,
+  "syscalls" : 2,
   "mallocCountTotal" : 0
 }

--- a/Thresholds/P90AbsoluteThresholdsBenchmark.P90Malloc.p90.json
+++ b/Thresholds/P90AbsoluteThresholdsBenchmark.P90Malloc.p90.json
@@ -1,4 +1,4 @@
 {
-  "syscalls" : 1,
-  "mallocCountTotal" : 999
+  "syscalls" : 2,
+  "mallocCountTotal" : 1000
 }


### PR DESCRIPTION
## Description

Its desirable to be able to signal from CI if a threshold has been improved too and not only regressed, so we now return exit code 0 only for exact equal checks and 2 for regressions and 4 for improvements.

Added support for signposts (https://github.com/ordo-one/package-benchmark/issues/183):

Added new objectAllocCount ARC stat counter and fixed the delta calculation to take initial refcount into account.

Also added support for returning setupState from the benchmark setup hooks, to allow access to state that can be reused per benchmark iteration.
 
<img width="1505" alt="image" src="https://github.com/ordo-one/package-benchmark/assets/8501048/aab42385-65a2-4617-970b-b777ebb6ed00">

## How Has This Been Tested?

Manually tested + added unit test.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
