### PR TITLE
fix: Add objectAllocationCount to ARC statistics

### DIFF
--- a/Benchmarks/Basic/Basic+SetupTeardown.swift
+++ b/Benchmarks/Basic/Basic+SetupTeardown.swift
@@ -50,14 +50,13 @@ func testSetUpTearDown() {
         //        print("Local setup hook")
     }
 
-    Benchmark("SetupTeardown5") { benchmark in
-  //              print("\(benchmark.setupState)")
+    Benchmark("SetupTeardown5") { _ in
+        //              print("\(benchmark.setupState)")
     }
 
-    Benchmark("SetupTeardown6") { benchmark, setupState in
+    Benchmark("SetupTeardown6") { _, _ in
 //        print("\(setupState)")
     } setup: {
         [1, 2, 3]
     }
-
 }

--- a/Benchmarks/Basic/BenchmarkRunner+Basic.swift
+++ b/Benchmarks/Basic/BenchmarkRunner+Basic.swift
@@ -46,10 +46,10 @@ let benchmarks = {
               configuration: .init(metrics: [.wallClock, .throughput])) { _ in
     }
 
-    Benchmark("Noop", configuration: .init(metrics: [.mallocCountTotal])) { _ in
+    Benchmark("Noop", configuration: .init(metrics: [.wallClock, .mallocCountTotal])) { _ in
     }
 
-    Benchmark("Noop2", configuration: .init(metrics: .arc)) { _ in
+    Benchmark("Noop2", configuration: .init(metrics: [.wallClock] + .arc)) { _ in
     }
 
     Benchmark("Scaled metrics",

--- a/Benchmarks/Basic/BenchmarkRunner+Basic.swift
+++ b/Benchmarks/Basic/BenchmarkRunner+Basic.swift
@@ -46,6 +46,12 @@ let benchmarks = {
               configuration: .init(metrics: [.wallClock, .throughput])) { _ in
     }
 
+    Benchmark("Noop", configuration: .init(metrics: [.mallocCountTotal])) { _ in
+    }
+
+    Benchmark("Noop2", configuration: .init(metrics: .arc)) { _ in
+    }
+
     Benchmark("Scaled metrics",
               configuration: .init(metrics: .all + [CustomMetrics.two, CustomMetrics.one],
                                    scalingFactor: .kilo)) { benchmark in

--- a/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
+++ b/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
@@ -41,9 +41,9 @@ let benchmarks = {
         var array: [Int] = []
 
         for _ in benchmark.scaledIterations {
-//            var x = malloc(1)
-//            blackHole(x)
-//            free(x)
+            var x = malloc(1)
+            blackHole(x)
+            free(x)
             array.append(contentsOf: 1 ... 1000)
         }
         blackHole(array)

--- a/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
+++ b/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
@@ -11,11 +11,11 @@ import Benchmark
 import Foundation
 
 #if canImport(Darwin)
-import Darwin
+    import Darwin
 #elseif canImport(Glibc)
-import Glibc
+    import Glibc
 #else
-#error("Unsupported Platform")
+    #error("Unsupported Platform")
 #endif
 
 let benchmarks = {
@@ -41,10 +41,10 @@ let benchmarks = {
         var array: [Int] = []
 
         for _ in benchmark.scaledIterations {
-            var x = malloc(1)
-            blackHole(x)
-            free(x)
-            array.append(contentsOf: 1 ... 1000)
+            var temporaryAllocation = malloc(1)
+            blackHole(temporaryAllocation)
+            free(temporaryAllocation)
+            array.append(contentsOf: 1 ... 1_000)
         }
         blackHole(array)
     }
@@ -52,8 +52,7 @@ let benchmarks = {
     func concurrentWork(tasks: Int) async {
         _ = await withTaskGroup(of: Void.self, returning: Void.self, body: { taskGroup in
             for _ in 0 ..< tasks {
-                taskGroup.addTask {
-                }
+                taskGroup.addTask {}
             }
 
             for await _ in taskGroup {}
@@ -64,5 +63,4 @@ let benchmarks = {
               configuration: .init(metrics: BenchmarkMetric.arc, maxDuration: .seconds(3))) { _ in
         await concurrentWork(tasks: 789)
     }
-
 }

--- a/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
+++ b/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
@@ -10,13 +10,21 @@
 import Benchmark
 import Foundation
 
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#else
+#error("Unsupported Platform")
+#endif
+
 let benchmarks = {
     var thresholds: [BenchmarkMetric: BenchmarkThresholds]
     let relative: BenchmarkThresholds.RelativeThresholds = [.p25: 25.0, .p50: 50.0, .p75: 75.0, .p90: 100.0, .p99: 101.0, .p100: 201.0]
     let absolute: BenchmarkThresholds.AbsoluteThresholds = [.p75: 999, .p90: 1_000, .p99: 1_001, .p100: 2_001]
     thresholds = [.mallocCountTotal: .init(relative: relative, absolute: absolute)]
 
-    Benchmark.defaultConfiguration = .init(metrics: [.mallocCountTotal, .syscalls],
+    Benchmark.defaultConfiguration = .init(metrics: [.mallocCountTotal, .syscalls] + .arc,
                                            warmupIterations: 1,
                                            scalingFactor: .kilo,
                                            maxDuration: .seconds(2),
@@ -30,10 +38,31 @@ let benchmarks = {
     }
 
     Benchmark("P90Malloc") { benchmark in
+        var array: [Int] = []
+
         for _ in benchmark.scaledIterations {
-            var array: [Int] = []
-            array.append(contentsOf: 0 ... 1_000)
-            blackHole(array)
+//            var x = malloc(1)
+//            blackHole(x)
+//            free(x)
+            array.append(contentsOf: 1 ... 1000)
         }
+        blackHole(array)
     }
+
+    func concurrentWork(tasks: Int) async {
+        _ = await withTaskGroup(of: Void.self, returning: Void.self, body: { taskGroup in
+            for _ in 0 ..< tasks {
+                taskGroup.addTask {
+                }
+            }
+
+            for await _ in taskGroup {}
+        })
+    }
+
+    Benchmark("Retain/release deviation",
+              configuration: .init(metrics: BenchmarkMetric.arc, maxDuration: .seconds(3))) { _ in
+        await concurrentWork(tasks: 789)
+    }
+
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -19,15 +19,6 @@
       }
     },
     {
-      "identity" : "package-jemalloc",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/package-jemalloc",
-      "state" : {
-        "revision" : "e8a5db026963f5bfeac842d9d3f2cc8cde323b49",
-        "version" : "1.0.0"
-      }
-    },
-    {
       "identity" : "progress.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ordo-one/Progress.swift",

--- a/Package.resolved
+++ b/Package.resolved
@@ -19,6 +19,15 @@
       }
     },
     {
+      "identity" : "package-jemalloc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ordo-one/package-jemalloc",
+      "state" : {
+        "revision" : "e8a5db026963f5bfeac842d9d3f2cc8cde323b49",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "progress.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ordo-one/Progress.swift",

--- a/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
+++ b/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
@@ -342,7 +342,6 @@ import PackagePlugin
                             throw MyError.benchmarkThresholdImprovement
                         case .benchmarkJobFailed:
                             print("One benchmark job failed during runtime, continuing with remaining.")
-                            break
                         }
                     } else {
                         print("One or more benchmarks returned an unexpected return code \(status)")

--- a/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
@@ -24,7 +24,7 @@ import SystemPackage
 #endif
 
 struct BenchmarkMachine: Codable, Equatable {
-    internal init(hostname: String, processors: Int, processorType: String, memory: Int, kernelVersion: String) {
+    init(hostname: String, processors: Int, processorType: String, memory: Int, kernelVersion: String) {
         self.hostname = hostname
         self.processors = processors
         self.processorType = processorType
@@ -46,7 +46,7 @@ struct BenchmarkMachine: Codable, Equatable {
 }
 
 struct BenchmarkIdentifier: Codable, Hashable {
-    internal init(target: String, name: String) {
+    init(target: String, name: String) {
         self.target = target
         self.name = name
     }
@@ -79,7 +79,7 @@ struct BenchmarkBaseline: Codable {
         var metrics: BenchmarkResult
     }
 
-    internal init(baselineName: String, machine: BenchmarkMachine, results: [BenchmarkIdentifier: [BenchmarkResult]]) {
+    init(baselineName: String, machine: BenchmarkMachine, results: [BenchmarkIdentifier: [BenchmarkResult]]) {
         self.baselineName = baselineName
         self.machine = machine
         self.results = results
@@ -449,13 +449,13 @@ extension BenchmarkBaseline: Equatable {
         for (lhsBenchmarkIdentifier, lhsBenchmarkResults) in results {
             for lhsBenchmarkResult in lhsBenchmarkResults {
                 let thresholds = thresholdsForBenchmarks(benchmarks,
-                                              name: lhsBenchmarkIdentifier.name,
-                                              target: lhsBenchmarkIdentifier.target,
-                                              metric: lhsBenchmarkResult.metric)
+                                                         name: lhsBenchmarkIdentifier.name,
+                                                         target: lhsBenchmarkIdentifier.target,
+                                                         metric: lhsBenchmarkResult.metric)
 
                 let deviationResults = lhsBenchmarkResult.deviationsAgainstAbsoluteThresholds(thresholds,
-                                                                                       name: lhsBenchmarkIdentifier.name,
-                                                                                       target: lhsBenchmarkIdentifier.target)
+                                                                                              name: lhsBenchmarkIdentifier.name,
+                                                                                              target: lhsBenchmarkIdentifier.target)
                 allDeviationResults.append(deviationResults)
             }
         }

--- a/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
@@ -225,7 +225,7 @@ extension BenchmarkTool {
                 let jsonEncoder = JSONEncoder()
                 jsonEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
 
-                var outputResults : [String : BenchmarkThresholds.AbsoluteThreshold] = [:]
+                var outputResults: [String: BenchmarkThresholds.AbsoluteThreshold] = [:]
                 results.forEach { values in
                     outputResults[values.metric.rawDescription] = Int(values.statistics.histogram.valueAtPercentile(90.0))
                 }

--- a/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
@@ -151,11 +151,11 @@ extension BenchmarkTool {
                             let thresholds = BenchmarkTool.makeBenchmarkThresholds(path: benchmarkPath,
                                                                                    moduleName: benchmark.target,
                                                                                    benchmarkName: benchmark.name)
-                            var transformed: [BenchmarkMetric : BenchmarkThresholds] = [:]
+                            var transformed: [BenchmarkMetric: BenchmarkThresholds] = [:]
                             if let thresholds {
                                 thresholds.forEach { key, value in
                                     if let metric = BenchmarkMetric(argument: key) {
-                                        let absoluteThreshold : BenchmarkThresholds.AbsoluteThresholds = [.p90 : value]
+                                        let absoluteThreshold: BenchmarkThresholds.AbsoluteThresholds = [.p90: value]
                                         transformed[metric] = BenchmarkThresholds(absolute: absoluteThreshold)
                                     }
                                 }

--- a/Plugins/BenchmarkTool/BenchmarkTool+ReadP90AbsoluteThresholds.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+ReadP90AbsoluteThresholds.swift
@@ -32,7 +32,7 @@ extension BenchmarkTool {
     /// - Returns: A dictionary with static benchmark thresholds per metric or nil if the file could not be found or read
     static func makeBenchmarkThresholds(path: String,
                                         moduleName: String,
-                                        benchmarkName: String) -> [String : BenchmarkThresholds.AbsoluteThreshold]? {
+                                        benchmarkName: String) -> [String: BenchmarkThresholds.AbsoluteThreshold]? {
         var path = FilePath(path)
         if path.isAbsolute {
             path.append("\(moduleName).\(benchmarkName).p90.json")
@@ -43,7 +43,7 @@ extension BenchmarkTool {
             path = cwdPath
         }
 
-        var p90Thresholds: [String : BenchmarkThresholds.AbsoluteThreshold]?
+        var p90Thresholds: [String: BenchmarkThresholds.AbsoluteThreshold]?
 
         do {
             let fileDescriptor = try FileDescriptor.open(path, .readOnly, options: [], permissions: .ownerRead)
@@ -64,7 +64,7 @@ extension BenchmarkTool {
                             readBytes.append(contentsOf: nextBytes)
                         }
 
-                        p90Thresholds = try JSONDecoder().decode([String : BenchmarkThresholds.AbsoluteThreshold].self, from: Data(readBytes))
+                        p90Thresholds = try JSONDecoder().decode([String: BenchmarkThresholds.AbsoluteThreshold].self, from: Data(readBytes))
                     } catch {
                         print("Failed to read file at \(path) [\(error)] \(Errno(rawValue: errno).description)")
                     }

--- a/Plugins/BenchmarkTool/FilePath+DirectoryView.swift
+++ b/Plugins/BenchmarkTool/FilePath+DirectoryView.swift
@@ -24,12 +24,12 @@ import SystemPackage
 public extension FilePath {
     /// `DirectoryView` provides an iteratable sequence of the contents of a directory referenced by a `FilePath`
     struct DirectoryView {
-        internal var directoryStreamPointer: DirectoryStreamPointer = nil
-        internal var path: FilePath
+        var directoryStreamPointer: DirectoryStreamPointer = nil
+        var path: FilePath
 
         /// Initializer
         /// - Parameter path: The file system path to provide directory entries for, should reference a directory
-        internal init(path pathName: FilePath) {
+        init(path pathName: FilePath) {
             path = pathName
             path.withPlatformString {
                 directoryStreamPointer = opendir($0)

--- a/Sources/Benchmark/ARCStats/ARCStats.swift
+++ b/Sources/Benchmark/ARCStats/ARCStats.swift
@@ -13,7 +13,7 @@
     @_documentation(visibility: internal)
 #endif
 
-internal struct ARCStats {
+struct ARCStats {
     var objectAllocCount: Int = 0 /// total number allocations, implicit retain
     var retainCount: Int = 0 /// total number retains
     var releaseCount: Int = 0 /// total number of releases

--- a/Sources/Benchmark/ARCStats/ARCStats.swift
+++ b/Sources/Benchmark/ARCStats/ARCStats.swift
@@ -14,7 +14,7 @@
 #endif
 
 internal struct ARCStats {
-    var objectAllocCount: Int /// total number allocations, implicit retain
-    var retainCount: Int /// total number retains
-    var releaseCount: Int /// total number of releases
+    var objectAllocCount: Int = 0 /// total number allocations, implicit retain
+    var retainCount: Int = 0 /// total number retains
+    var releaseCount: Int = 0 /// total number of releases
 }

--- a/Sources/Benchmark/ARCStats/ARCStats.swift
+++ b/Sources/Benchmark/ARCStats/ARCStats.swift
@@ -14,6 +14,7 @@
 #endif
 
 internal struct ARCStats {
+    var objectAllocCount: Int /// total number allocations, implicit retain
     var retainCount: Int /// total number retains
     var releaseCount: Int /// total number of releases
 }

--- a/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
+++ b/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
@@ -1,4 +1,4 @@
-extension Benchmark {
+public extension Benchmark {
     /// Definition of a Benchmark
     /// - Parameters:
     ///   - name: The name used for display purposes of the benchmark (also used for
@@ -7,13 +7,13 @@ extension Benchmark {
     ///   - closure: The actual benchmark closure that will be measured, this one takes one additional parameter
     ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
     @discardableResult
-    convenience public init?<SetupResult>(_ name: String,
-                                          configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
-                                          closure: @escaping (_ benchmark: Benchmark, SetupResult) -> Void,
-                                          setup: @escaping (() async throws -> SetupResult),
-                                          teardown: BenchmarkTeardownHook? = nil) {
+    convenience init?<SetupResult>(_ name: String,
+                                   configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
+                                   closure: @escaping (_ benchmark: Benchmark, SetupResult) -> Void,
+                                   setup: @escaping (() async throws -> SetupResult),
+                                   teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration) { benchmark in
-            let setupResult = benchmark.setupState! as! SetupResult
+            let setupResult = benchmark.setupState! as! SetupResult // swiftlint:disable:this force_cast
             closure(benchmark, setupResult)
         } setup: {
             try await setup()
@@ -30,13 +30,13 @@ extension Benchmark {
     ///   - closure: The actual `async` benchmark closure that will be measured, this one takes one additional parameter
     ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
     @discardableResult
-    convenience public init?<SetupResult>(_ name: String,
-                 configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
-                 closure: @escaping (_ benchmark: Benchmark, SetupResult) async -> Void,
-                 setup: @escaping (() async throws -> SetupResult),
-                 teardown: BenchmarkTeardownHook? = nil) {
+    convenience init?<SetupResult>(_ name: String,
+                                   configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
+                                   closure: @escaping (_ benchmark: Benchmark, SetupResult) async -> Void,
+                                   setup: @escaping (() async throws -> SetupResult),
+                                   teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration) { benchmark in
-            let setupResult = benchmark.setupState! as! SetupResult
+            let setupResult = benchmark.setupState! as! SetupResult // swiftlint:disable:this force_cast
             await closure(benchmark, setupResult)
         } setup: {
             try await setup()
@@ -53,14 +53,14 @@ extension Benchmark {
     ///   - closure: The actual throwing benchmark closure that will be measured, this one takes one additional parameter
     ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
     @discardableResult
-    convenience public init?<SetupResult>(_ name: String,
-                                          configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
-                                          closure: @escaping (_ benchmark: Benchmark, SetupResult) throws -> Void,
-                                          setup: (() async throws -> SetupResult)? = nil,
-                                          teardown: BenchmarkTeardownHook? = nil) {
+    convenience init?<SetupResult>(_ name: String,
+                                   configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
+                                   closure: @escaping (_ benchmark: Benchmark, SetupResult) throws -> Void,
+                                   setup: (() async throws -> SetupResult)? = nil,
+                                   teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration, closure: { benchmark in
             do {
-                let setupResult = benchmark.setupState! as! SetupResult
+                let setupResult = benchmark.setupState! as! SetupResult // swiftlint:disable:this force_cast
                 try closure(benchmark, setupResult)
             } catch {
                 benchmark.error("Benchmark \(name) failed with \(error)")
@@ -76,14 +76,14 @@ extension Benchmark {
     ///   - closure: The actual async throwing benchmark closure that will be measured, this one takes one additional parameter
     ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
     @discardableResult
-    public convenience init?<SetupResult>(_ name: String,
-                             configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
-                             closure: @escaping (_ benchmark: Benchmark, SetupResult) async throws -> Void,
-                             setup: (() async throws -> SetupResult)? = nil,
-                             teardown: BenchmarkTeardownHook? = nil) {
+    convenience init?<SetupResult>(_ name: String,
+                                   configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
+                                   closure: @escaping (_ benchmark: Benchmark, SetupResult) async throws -> Void,
+                                   setup: (() async throws -> SetupResult)? = nil,
+                                   teardown: BenchmarkTeardownHook? = nil) {
         self.init(name, configuration: configuration, closure: { benchmark in
             do {
-                let setupResult = benchmark.setupState! as! SetupResult
+                let setupResult = benchmark.setupState! as! SetupResult // swiftlint:disable:this force_cast
                 try await closure(benchmark, setupResult)
             } catch {
                 benchmark.error("Benchmark \(name) failed with \(error)")

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -338,7 +338,6 @@ public final class Benchmark: Codable, Hashable {
     #if swift(>=5.8)
         @_documentation(visibility: internal)
     #endif
-    @inline(__always)
     public func run() {
         if let closure {
             startMeasurement()

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -338,6 +338,7 @@ public final class Benchmark: Codable, Hashable {
     #if swift(>=5.8)
         @_documentation(visibility: internal)
     #endif
+    @inline(__always)
     public func run() {
         if let closure {
             startMeasurement()

--- a/Sources/Benchmark/BenchmarkExecutor+Extensions.swift
+++ b/Sources/Benchmark/BenchmarkExecutor+Extensions.swift
@@ -70,7 +70,7 @@ extension BenchmarkExecutor {
 extension BenchmarkExecutor {
     func arcStatsProducerNeeded(_ metric: BenchmarkMetric) -> Bool {
         switch metric {
-        case .retainCount, .releaseCount, .retainReleaseDelta:
+        case .objectAllocCount, .retainCount, .releaseCount, .retainReleaseDelta:
             return true
         default:
             return false

--- a/Sources/Benchmark/BenchmarkExecutor.swift
+++ b/Sources/Benchmark/BenchmarkExecutor.swift
@@ -12,11 +12,11 @@ import DateTime
 import Progress
 
 #if canImport(OSLog)
-import OSLog
+    import OSLog
 #endif
 
-internal final class BenchmarkExecutor {
-    internal init(quiet: Bool = false) {
+final class BenchmarkExecutor {
+    init(quiet: Bool = false) {
         self.quiet = quiet
     }
 
@@ -37,27 +37,27 @@ internal final class BenchmarkExecutor {
 
         // optionally run a few warmup iterations by default to clean out outliers due to cacheing etc.
 
-#if canImport(OSLog)
-        let logHandler = OSLog(subsystem: "one.ordo.benchmark", category: .pointsOfInterest)
-        let signPost = OSSignposter(logHandle: logHandler)
-        let signpostID = OSSignpostID(log: logHandler)
-        var warmupInterval: OSSignpostIntervalState?
+        #if canImport(OSLog)
+            let logHandler = OSLog(subsystem: "one.ordo.benchmark", category: .pointsOfInterest)
+            let signPost = OSSignposter(logHandle: logHandler)
+            let signpostID = OSSignpostID(log: logHandler)
+            var warmupInterval: OSSignpostIntervalState?
 
-        if benchmark.configuration.warmupIterations > 0 {
-            warmupInterval = signPost.beginInterval("Benchmark", id: signpostID, "\(benchmark.name) warmup")
-        }
-#endif
+            if benchmark.configuration.warmupIterations > 0 {
+                warmupInterval = signPost.beginInterval("Benchmark", id: signpostID, "\(benchmark.name) warmup")
+            }
+        #endif
 
         for iterations in 0 ..< benchmark.configuration.warmupIterations {
             benchmark.currentIteration = iterations
             benchmark.run()
         }
 
-#if canImport(OSLog)
-        if let warmupInterval {
-            signPost.endInterval("Benchmark", warmupInterval, "\(benchmark.configuration.warmupIterations)")
-        }
-#endif
+        #if canImport(OSLog)
+            if let warmupInterval {
+                signPost.endInterval("Benchmark", warmupInterval, "\(benchmark.configuration.warmupIterations)")
+            }
+        #endif
 
         // Could make an array with raw value indexing on enum for
         // performance if needed instead of dictionary
@@ -85,7 +85,7 @@ internal final class BenchmarkExecutor {
                 mallocStatsRequested = true
             }
 
-            if operatingSystemsStatsProducerNeeded(metric) && operatingSystemStatsProducer.metricSupported(metric) {
+            if operatingSystemsStatsProducerNeeded(metric), operatingSystemStatsProducer.metricSupported(metric) {
                 operatingSystemMetricsRequested.insert(metric)
                 operatingSystemStatsRequested = true
             }
@@ -286,9 +286,9 @@ internal final class BenchmarkExecutor {
             ARCStatsProducer.hook()
         }
 
-#if canImport(OSLog)
-        let benchmarkInterval = signPost.beginInterval("Benchmark", id: signpostID, "\(benchmark.name)")
-#endif
+        #if canImport(OSLog)
+            let benchmarkInterval = signPost.beginInterval("Benchmark", id: signpostID, "\(benchmark.name)")
+        #endif
 
         // Run the benchmark at a minimum the desired iterations/runtime --
 
@@ -328,9 +328,9 @@ internal final class BenchmarkExecutor {
             }
         }
 
-#if canImport(OSLog)
-        signPost.endInterval("Benchmark", benchmarkInterval, "\(iterations)")
-#endif
+        #if canImport(OSLog)
+            signPost.endInterval("Benchmark", benchmarkInterval, "\(iterations)")
+        #endif
 
         if arcStatsRequested {
             ARCStatsProducer.unhook()

--- a/Sources/Benchmark/BenchmarkMetric+Defaults.swift
+++ b/Sources/Benchmark/BenchmarkMetric+Defaults.swift
@@ -49,7 +49,8 @@ public extension BenchmarkMetric {
 
     /// A collection of ARC metrics
     static var arc: [BenchmarkMetric] {
-        [.retainCount,
+        [.objectAllocCount,
+         .retainCount,
          .releaseCount,
          .retainReleaseDelta]
     }
@@ -98,6 +99,7 @@ public extension BenchmarkMetric {
          .readBytesPhysical,
          .writeBytesPhysical,
          .allocatedResidentMemory,
+         .objectAllocCount,
          .retainCount,
          .releaseCount,
          .retainReleaseDelta]

--- a/Sources/Benchmark/BenchmarkMetric.swift
+++ b/Sources/Benchmark/BenchmarkMetric.swift
@@ -58,6 +58,8 @@ public enum BenchmarkMetric: Hashable, Equatable, Codable, CustomStringConvertib
     case readBytesPhysical
     /// The number of bytes physicall written to a block device (i.e. disk) -- Linux only
     case writeBytesPhysical
+    /// Number of object allocations (implicit retain of one) (ARC)
+    case objectAllocCount
     /// Number of retains (ARC)
     case retainCount
     /// Number of releases (ARC)
@@ -126,7 +128,7 @@ public extension BenchmarkMetric {
             return true
         case .writeSyscalls, .writeBytesLogical, .writeBytesPhysical:
             return true
-        case .retainCount, .releaseCount, .retainReleaseDelta:
+        case .objectAllocCount, .retainCount, .releaseCount, .retainReleaseDelta:
             return true
         case let .custom(_, _, useScaleFactor):
             return useScaleFactor
@@ -193,12 +195,14 @@ public extension BenchmarkMetric {
             return "Bytes (read physical)"
         case .writeBytesPhysical:
             return "Bytes (write physical)"
+        case .objectAllocCount:
+            return "Object allocs"
         case .retainCount:
             return "Retains"
         case .releaseCount:
             return "Releases"
         case .retainReleaseDelta:
-            return "Retain / Release Δ"
+            return "(Alloc + Retain) - Release Δ"
         case .delta:
             return "Δ"
         case .deltaPercentage:
@@ -259,6 +263,8 @@ public extension BenchmarkMetric {
             return "readBytesPhysical"
         case .writeBytesPhysical:
             return "writeBytesPhysical"
+        case .objectAllocCount:
+            return "objectAllocCount"
         case .retainCount:
             return "retainCount"
         case .releaseCount:
@@ -327,6 +333,8 @@ public extension BenchmarkMetric {
             self = BenchmarkMetric.readBytesPhysical
         case "writeBytesPhysical":
             self = BenchmarkMetric.writeBytesPhysical
+        case "objectAllocCount":
+            self = BenchmarkMetric.objectAllocCount
         case "retainCount":
             self = BenchmarkMetric.retainCount
         case "releaseCount":

--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -200,7 +200,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
     }
 
     // from SO to avoid Foundation/Numerics
-    internal func pow<T: BinaryInteger>(_ base: T, _ power: T) -> T {
+    func pow<T: BinaryInteger>(_ base: T, _ power: T) -> T {
         func expBySq(_ y: T, _ x: T, _ n: T) -> T {
             precondition(n >= 0)
             if n == 0 {
@@ -217,7 +217,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
         return expBySq(1, base, power)
     }
 
-    internal var remainingScalingFactor: BenchmarkScalingFactor {
+    var remainingScalingFactor: BenchmarkScalingFactor {
         guard statistics.timeUnits == .automatic else {
             return scalingFactor
         }
@@ -362,8 +362,8 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
         public var improvements: [ThresholdDeviation] = []
 
         public mutating func append(_ otherDeviations: Self) {
-            self.improvements.append(contentsOf: otherDeviations.improvements)
-            self.regressions.append(contentsOf: otherDeviations.regressions)
+            improvements.append(contentsOf: otherDeviations.improvements)
+            regressions.append(contentsOf: otherDeviations.regressions)
         }
     }
 
@@ -390,7 +390,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
             let absoluteDifference = (reverseComparison ? -1 : 1) * (lhs - rhs)
             let relativeDifference = (reverseComparison ? 1 : -1) * (rhs != 0 ? (100 - (100.0 * Double(lhs) / Double(rhs))) : 0.0)
 
-            if let threshold = thresholds.relative[percentile], !(-threshold...threshold).contains(relativeDifference) {
+            if let threshold = thresholds.relative[percentile], !(-threshold ... threshold).contains(relativeDifference) {
                 let deviation = ThresholdDeviation(name: name,
                                                    target: target,
                                                    metric: metric,

--- a/Sources/Benchmark/MallocStats/MallocStats.swift
+++ b/Sources/Benchmark/MallocStats/MallocStats.swift
@@ -12,7 +12,7 @@
 #if swift(>=5.8)
     @_documentation(visibility: internal)
 #endif
-internal struct MallocStats {
+struct MallocStats {
     var mallocCountTotal: Int = 0 /// total number of mallocs done
     var mallocCountSmall: Int = 0 /// number of small mallocs (as defined by jemalloc)
     var mallocCountLarge: Int = 0 /// number of large mallocs (as defined by jemalloc)

--- a/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
+++ b/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
@@ -111,7 +111,7 @@ import ExtrasJSON
 
         // Parsed stats for convenience, this is a heavy and slow operation not suitable for
         // being called within benchmark iterations
-        func jemallocStatistics() -> Jemalloc? {
+        static func jemallocStatistics() -> Jemalloc? {
             // C style callback needs to use a class instance as a data carrier as we can't
             // capture state in a c-style closure, thus the dance with from/to Opaque.
             typealias CallbackType = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Void
@@ -134,7 +134,7 @@ import ExtrasJSON
 
         // Full JSON with stats, this is a heavy and slow operation not suitable for
         // being called within benchmark iterations
-        func jsonStatistics() -> String {
+        static func jsonStatistics() -> String {
             // C style callback needs to use a class instance as a data carrier as we can't
             // capture state in a c-style closure, thus the dance with from/to Opaque.
             typealias CallbackType = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Void
@@ -155,7 +155,7 @@ import ExtrasJSON
 
     // stub if no jemalloc available
     final class MallocStatsProducer {
-        func makeMallocStats() -> MallocStats {
+        static func makeMallocStats() -> MallocStats {
             MallocStats(mallocCountTotal: 0,
                         mallocCountSmall: 0,
                         mallocCountLarge: 0,

--- a/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
+++ b/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
@@ -154,7 +154,7 @@ import ExtrasJSON
 #else
 
     // stub if no jemalloc available
-    final class MallocStatsProducer {
+    enum MallocStatsProducer {
         static func makeMallocStats() -> MallocStats {
             MallocStats(mallocCountTotal: 0,
                         mallocCountSmall: 0,

--- a/Sources/Benchmark/NIOLock.swift
+++ b/Sources/Benchmark/NIOLock.swift
@@ -33,25 +33,25 @@
 /// `SRWLOCK` type.
 struct NIOLock {
     @usableFromInline
-    internal let _storage: _Storage
+    let _storage: _Storage
 
     #if os(Windows)
         @usableFromInline
-        internal typealias LockPrimitive = SRWLOCK
+        typealias LockPrimitive = SRWLOCK
     #else
         @usableFromInline
-        internal typealias LockPrimitive = pthread_mutex_t
+        typealias LockPrimitive = pthread_mutex_t
     #endif
 
     @usableFromInline
-    internal final class _Storage {
+    final class _Storage {
         // TODO: We should tail-allocate the pthread_t/SRWLock.
         @usableFromInline
-        internal let mutex: UnsafeMutablePointer<LockPrimitive> =
+        let mutex: UnsafeMutablePointer<LockPrimitive> =
             UnsafeMutablePointer.allocate(capacity: 1)
 
         /// Create a new lock.
-        internal init() {
+        init() {
             #if os(Windows)
                 InitializeSRWLock(mutex)
             #else
@@ -63,7 +63,7 @@ struct NIOLock {
             #endif
         }
 
-        internal func lock() {
+        func lock() {
             #if os(Windows)
                 AcquireSRWLockExclusive(mutex)
             #else
@@ -72,7 +72,7 @@ struct NIOLock {
             #endif
         }
 
-        internal func unlock() {
+        func unlock() {
             #if os(Windows)
                 ReleaseSRWLockExclusive(mutex)
             #else
@@ -81,7 +81,7 @@ struct NIOLock {
             #endif
         }
 
-        internal func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
+        func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
             try body(mutex)
         }
 
@@ -117,7 +117,7 @@ struct NIOLock {
         _storage.unlock()
     }
 
-    internal func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
+    func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
         try _storage.withLockPrimitive(body)
     }
 }

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStats.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStats.swift
@@ -9,7 +9,7 @@
 //
 
 /// The  stats that the OperatingSystemStatsProducer can provide
-internal struct OperatingSystemStats {
+struct OperatingSystemStats {
     /// CPU user space time spent for running the test
     var cpuUser: Int = 0
     /// CPU system time spent for running the test

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
@@ -24,7 +24,7 @@
         var peakThreadsRunning: Int = 0
         var runState: RunState = .running
         var sampleRate: Int = 10_000
-        var metrics:Set<BenchmarkMetric>?
+        var metrics: Set<BenchmarkMetric>?
 
         enum RunState {
             case running
@@ -75,7 +75,7 @@
             private func getIOStats() -> IOStats {
                 var rinfo = rusage_info_v6()
                 let result = withUnsafeMutablePointer(to: &rinfo) {
-                    $0.withMemoryRebound(to: Optional<rusage_info_t>.self, capacity: 1) {
+                    $0.withMemoryRebound(to: rusage_info_t?.self, capacity: 1) {
                         proc_pid_rusage(getpid(), RUSAGE_INFO_V6, $0)
                     }
                 }
@@ -137,7 +137,7 @@
             #endif
         }
 
-        func configureMetrics(_ metrics:Set<BenchmarkMetric>) {
+        func configureMetrics(_ metrics: Set<BenchmarkMetric>) {
             self.metrics = metrics
         }
 

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
@@ -24,6 +24,7 @@
         var peakThreadsRunning: Int = 0
         var runState: RunState = .running
         var sampleRate: Int = 10_000
+        var metrics:Set<BenchmarkMetric>?
 
         enum RunState {
             case running
@@ -67,7 +68,8 @@
             }
 
             struct IOStats {
-                var bytesRead, bytesWritten: UInt64
+                var bytesRead: UInt64 = 0
+                var bytesWritten: UInt64 = 0
             }
 
             private func getIOStats() -> IOStats {
@@ -135,19 +137,34 @@
             #endif
         }
 
+        func configureMetrics(_ metrics:Set<BenchmarkMetric>) {
+            self.metrics = metrics
+        }
+
         func makeOperatingSystemStats() -> OperatingSystemStats {
             #if os(macOS)
+                guard let metrics else {
+                    return .init()
+                }
+
                 let procTaskInfo = getProcInfo()
                 let userTime = Int(nsPerMachTick * Double(procTaskInfo.pti_total_user))
                 let systemTime = Int(nsPerMachTick * Double(procTaskInfo.pti_total_system))
                 let totalTime = userTime + systemTime
+                var threads = 0
+                var threadsRunning = 0
 
-                lock.lock()
-                let threads = peakThreads
-                let threadsRunning = peakThreadsRunning
-                lock.unlock()
+                if metrics.contains(.threads) || metrics.contains(.threadsRunning) {
+                    lock.lock()
+                    threads = peakThreads
+                    threadsRunning = peakThreadsRunning
+                    lock.unlock()
+                }
+                var ioStats = IOStats()
 
-                let ioStats = getIOStats()
+                if metrics.contains(.writeBytesPhysical) || metrics.contains(.writeBytesPhysical) {
+                    ioStats = getIOStats()
+                }
 
                 let stats = OperatingSystemStats(cpuUser: userTime,
                                                  cpuSystem: systemTime,

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
@@ -24,6 +24,7 @@
         var peakThreads: Int = 0
         var sampleRate: Int = 10_000
         var runState: RunState = .running
+        var metrics:Set<BenchmarkMetric>?
 
         enum RunState {
             case running
@@ -90,6 +91,10 @@
             stats.peakMemoryResident *= pageSize
 
             return stats
+        }
+
+        func configureMetrics(_ metrics:Set<BenchmarkMetric>) {
+            self.metrics = metrics
         }
 
         func makeOperatingSystemStats() -> OperatingSystemStats {

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
@@ -24,7 +24,7 @@
         var peakThreads: Int = 0
         var sampleRate: Int = 10_000
         var runState: RunState = .running
-        var metrics:Set<BenchmarkMetric>?
+        var metrics: Set<BenchmarkMetric>?
 
         enum RunState {
             case running
@@ -93,7 +93,7 @@
             return stats
         }
 
-        func configureMetrics(_ metrics:Set<BenchmarkMetric>) {
+        func configureMetrics(_ metrics: Set<BenchmarkMetric>) {
             self.metrics = metrics
         }
 

--- a/Sources/Benchmark/Statistics.swift
+++ b/Sources/Benchmark/Statistics.swift
@@ -75,9 +75,9 @@ public final class Statistics: Codable {
         }
     }
 
-    internal var _cachedPercentiles: [Int] = []
-    internal var _cacheUnits: Statistics.Units = .automatic
-    internal var _cachedPercentilesHistogramCount: UInt64 = 0
+    var _cachedPercentiles: [Int] = []
+    var _cacheUnits: Statistics.Units = .automatic
+    var _cachedPercentilesHistogramCount: UInt64 = 0
 
     public func percentiles(for percentilesToCalculate: [Double] = defaultPercentilesToCalculate) -> [Int] {
         if percentilesToCalculate == Self.defaultPercentilesToCalculate {

--- a/Sources/SwiftRuntimeHooks/include/SwiftRuntimeHooks.h
+++ b/Sources/SwiftRuntimeHooks/include/SwiftRuntimeHooks.h
@@ -3,6 +3,7 @@
 
 typedef void (*swift_runtime_hook_t)(const void *, void *);
 
+void swift_runtime_set_alloc_object_hook(swift_runtime_hook_t hook, void * context);
 void swift_runtime_set_retain_hook(swift_runtime_hook_t hook, void * context);
 void swift_runtime_set_release_hook(swift_runtime_hook_t hook, void * context);
 

--- a/Tests/BenchmarkTests/BenchmarkMetricsTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkMetricsTests.swift
@@ -66,6 +66,7 @@ final class BenchmarkMetricsTests: XCTestCase {
         "writeBytesLogical",
         "readBytesPhysical",
         "writeBytesPhysical",
+        "objectAllocCount",
         "retainCount",
         "releaseCount",
         "retainReleaseDelta"

--- a/Tests/BenchmarkTests/BenchmarkMetricsTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkMetricsTests.swift
@@ -35,6 +35,7 @@ final class BenchmarkMetricsTests: XCTestCase {
         .writeBytesLogical,
         .readBytesPhysical,
         .writeBytesPhysical,
+        .objectAllocCount,
         .retainCount,
         .releaseCount,
         .retainReleaseDelta,

--- a/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
@@ -16,12 +16,12 @@ final class BenchmarkRunnerTests: XCTestCase, BenchmarkRunnerReadWrite {
     private var writeCount: Int = 0
 
     // swiftlint:disable test_case_accessibility
-    internal func write(_: BenchmarkCommandReply) throws {
+    func write(_: BenchmarkCommandReply) throws {
         writeCount += 1
 //        print("write \(reply)")
     }
 
-    internal func read() throws -> BenchmarkCommandRequest {
+    func read() throws -> BenchmarkCommandRequest {
         //      print("read request")
         Benchmark.testSkipBenchmarkRegistrations = true
         let benchmark = Benchmark("Minimal benchmark") { _ in

--- a/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
+++ b/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
@@ -97,7 +97,7 @@ final class OperatingSystemAndMallocTests: XCTestCase {
         XCTAssertTrue(statsProducer.metricSupported(.writeBytesPhysical))
 
         statsProducer.configureMetrics([.readBytesPhysical, .writeBytesPhysical])
-        
+
         let startStats = statsProducer.makeOperatingSystemStats()
 
         let amplificationFactor = 1_000
@@ -112,7 +112,7 @@ final class OperatingSystemAndMallocTests: XCTestCase {
 
         var buffer = (0 ..< stat.st_blksize).map { _ in UInt8.random(in: 0 ... UInt8.max) }
 
-        for _ in (0 ..< amplificationFactor) {
+        for _ in 0 ..< amplificationFactor {
             buffer.withUnsafeBytes { buffer in
                 XCTAssertEqual(write(fildes, buffer.baseAddress, buffer.count), buffer.count, "write() failed: \(errno)")
             }

--- a/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
+++ b/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
@@ -56,14 +56,13 @@ final class OperatingSystemAndMallocTests: XCTestCase {
 
     #if canImport(jemalloc)
         func testMallocProducerLeaks() throws {
-            let mallocStatsProducer = MallocStatsProducer()
-            let startMallocStats = mallocStatsProducer.makeMallocStats()
+            let startMallocStats = MallocStatsProducer.makeMallocStats()
 
             for outerloop in 1 ... 100 {
                 blackHole(malloc(outerloop * 1_024))
             }
 
-            let stopMallocStats = mallocStatsProducer.makeMallocStats()
+            let stopMallocStats = MallocStatsProducer.makeMallocStats()
 
             XCTAssertGreaterThanOrEqual(stopMallocStats.mallocCountTotal - startMallocStats.mallocCountTotal, 100)
             XCTAssertGreaterThanOrEqual(stopMallocStats.allocatedResidentMemory - startMallocStats.allocatedResidentMemory,
@@ -72,12 +71,10 @@ final class OperatingSystemAndMallocTests: XCTestCase {
     #endif
 
     func testARCStatsProducer() throws {
-        let statsProducer = ARCStatsProducer()
-
         let array = [3]
-        statsProducer.hook()
+        ARCStatsProducer.hook()
 
-        let startStats = statsProducer.makeARCStats()
+        let startStats = ARCStatsProducer.makeARCStats()
 
         for outerloop in 1 ... 100 {
             var arrayCopy = array
@@ -86,8 +83,9 @@ final class OperatingSystemAndMallocTests: XCTestCase {
             blackHole(arrayCopy)
         }
 
-        let stopStats = statsProducer.makeARCStats()
+        let stopStats = ARCStatsProducer.makeARCStats()
 
+        XCTAssertGreaterThanOrEqual(stopStats.objectAllocCount - startStats.objectAllocCount, 100)
         XCTAssertGreaterThanOrEqual(stopStats.retainCount - startStats.retainCount, 100)
         XCTAssertGreaterThanOrEqual(stopStats.releaseCount - startStats.releaseCount, 100)
     }

--- a/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
+++ b/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
@@ -96,6 +96,8 @@ final class OperatingSystemAndMallocTests: XCTestCase {
         XCTAssertTrue(statsProducer.metricSupported(.readBytesPhysical))
         XCTAssertTrue(statsProducer.metricSupported(.writeBytesPhysical))
 
+        statsProducer.configureMetrics([.readBytesPhysical, .writeBytesPhysical])
+        
         let startStats = statsProducer.makeOperatingSystemStats()
 
         let amplificationFactor = 1_000


### PR DESCRIPTION
## Description

Delta for retain/release was misleading as initial retain count from alloc wasn't included.
Other refactoring/cleanup.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [ ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
