### PR TITLE
fix: quote test names with comma

### DIFF
--- a/Plugins/BenchmarkTool/BenchmarkTool+Export+InfluxCSVFormatter.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export+InfluxCSVFormatter.swift
@@ -144,11 +144,18 @@ extension BenchmarkTool {
                 var benchmarkResultData: [TestMetricData] = []
                 var iterations = 0
                 var warmupIterations = 0
+                var cleanedTestName = test.name
+                
+                // adds quotes around test names that contain a comma.
+                // This helps avoid parsing issues on the exported CSV file
+                if cleanedTestName.contains(",") {
+                    cleanedTestName = "\"\(cleanedTestName)\""
+                }
                 allResults.forEach { results in
 
                     benchmarkResultData.append(
                         processBenchmarkResult(test: results,
-                                               testName: test.name)
+                                               testName: cleanedTestName)
                     )
 
                     iterations = results.statistics.measurementCount
@@ -156,7 +163,7 @@ extension BenchmarkTool {
                 }
 
                 testList.append(
-                    TestData(test: test.name,
+                    TestData(test: cleanedTestName,
                              iterations: iterations,
                              warmupIterations: warmupIterations,
                              data: benchmarkResultData)


### PR DESCRIPTION
This is to help prevent parsing errors in output CSV

## Description

Due to the way CSV files are parsed, any test name with a comma in it will cause errors when trying to parse.
This change looks for and wraps test names with commas with double quotes.

## How Has This Been Tested?

Locally ran and checked output of CSV file

## Minimal checklist:

- [ ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
