### PR TITLE
fix: Add missing tag in Influx datatype header

### DIFF
--- a/Plugins/BenchmarkTool/BenchmarkTool+Export+InfluxCSVFormatter.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export+InfluxCSVFormatter.swift
@@ -54,7 +54,7 @@ class InfluxCSVFormatter {
         let memory = machine.memory
 
         if header {
-            let dataTypeHeader = "#datatype tag,tag,tag,tag,tag,tag,tag,tag,double,double,long,long,dateTime\n"
+            let dataTypeHeader = "#datatype tag,tag,tag,tag,tag,tag,tag,tag,tag,double,double,long,long,dateTime\n"
             finalFileFormat.append(dataTypeHeader)
             let headers = "measurement,hostName,processoryType,processors,memory,kernelVersion,metric,unit,test,value,test_average,iterations,warmup_iterations,time\n"
             finalFileFormat.append(headers)


### PR DESCRIPTION
The datatype header should have 14 values to match the 14 column headers.

## Description

When working with the .csv file produced by `--format influx` flag, I noticed that a few datatype headers were misaligned with their corresponding columns, and the `time` column was missing a datatype header entirely. The list of datatype headers seems to be missing one instance of `tag`.

Actual behavior
|tag|tag|tag|tag|tag|tag|tag|tag|double|double|long|long|dateTime||
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
|measurement|hostName|processoryType|processors|memory|kernelVersion|metric|unit|test|value|test_average|iterations|warmup_iterations|time|

Expected behavior
|tag|tag|tag|tag|tag|tag|tag|tag|tag|double|double|long|long|dateTime|
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
|measurement|hostName|processoryType|processors|memory|kernelVersion|metric|unit|test|value|test_average|iterations|warmup_iterations|time|

## How Has This Been Tested?

Run `swift package --disable-sandbox --allow-writing-to-package-directory benchmark --format influx`.
Verify datatype header aligns with column headers.

## Minimal checklist:

- [ ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
