### PR TITLE
chore(minor): Fix sampling for virtual/resident memory peaks

### DIFF
--- a/Sources/Benchmark/BenchmarkExecutor.swift
+++ b/Sources/Benchmark/BenchmarkExecutor.swift
@@ -101,7 +101,7 @@ final class BenchmarkExecutor { // swiftlint:disable:this type_body_length
         let initialStartTime = BenchmarkClock.now
 
         // 'Warmup' to remove initial mallocs from stats in p100, also used as base for some metrics
-        let _ = MallocStatsProducer.makeMallocStats() // baselineMallocStats
+        _ = MallocStatsProducer.makeMallocStats() // baselineMallocStats
 
         // Calculate typical sys call check overhead and deduct that to get 'clean' stats for the actual benchmark
         var operatingSystemStatsOverhead = OperatingSystemStats()

--- a/Sources/Benchmark/BenchmarkExecutor.swift
+++ b/Sources/Benchmark/BenchmarkExecutor.swift
@@ -201,8 +201,8 @@ final class BenchmarkExecutor { // swiftlint:disable:this type_body_length
                 delta = stopMallocStats.allocatedResidentMemory - startMallocStats.allocatedResidentMemory
                 statistics[.memoryLeaked]?.add(Int(delta))
 
-                delta = stopMallocStats.allocatedResidentMemory - baselineMallocStats.allocatedResidentMemory // baselineMallocStats!
-                statistics[.allocatedResidentMemory]?.add(Int(delta))
+//                delta = stopMallocStats.allocatedResidentMemory - baselineMallocStats.allocatedResidentMemory // baselineMallocStats!
+                statistics[.allocatedResidentMemory]?.add(Int(stopMallocStats.allocatedResidentMemory))
             }
 
             if operatingSystemStatsRequested {

--- a/Sources/Benchmark/BenchmarkExecutor.swift
+++ b/Sources/Benchmark/BenchmarkExecutor.swift
@@ -100,10 +100,8 @@ final class BenchmarkExecutor { // swiftlint:disable:this type_body_length
         var iterations = 0
         let initialStartTime = BenchmarkClock.now
 
-        // 'Warmup' to remove initial mallocs from stats in p100
-        if mallocStatsRequested {
-            _ = MallocStatsProducer.makeMallocStats()
-        }
+        // 'Warmup' to remove initial mallocs from stats in p100, also used as base for some metrics
+        let baselineMallocStats = MallocStatsProducer.makeMallocStats()
 
         // Calculate typical sys call check overhead and deduct that to get 'clean' stats for the actual benchmark
         var operatingSystemStatsOverhead = OperatingSystemStats()
@@ -200,11 +198,11 @@ final class BenchmarkExecutor { // swiftlint:disable:this type_body_length
                 delta = stopMallocStats.mallocCountLarge - startMallocStats.mallocCountLarge
                 statistics[.mallocCountLarge]?.add(Int(delta))
 
-                delta = stopMallocStats.allocatedResidentMemory -
-                    startMallocStats.allocatedResidentMemory
+                delta = stopMallocStats.allocatedResidentMemory - startMallocStats.allocatedResidentMemory
                 statistics[.memoryLeaked]?.add(Int(delta))
 
-                statistics[.allocatedResidentMemory]?.add(Int(stopMallocStats.allocatedResidentMemory))
+                delta = stopMallocStats.allocatedResidentMemory - baselineMallocStats.allocatedResidentMemory // baselineMallocStats!
+                statistics[.allocatedResidentMemory]?.add(Int(delta))
             }
 
             if operatingSystemStatsRequested {

--- a/Sources/Benchmark/BenchmarkExecutor.swift
+++ b/Sources/Benchmark/BenchmarkExecutor.swift
@@ -101,7 +101,7 @@ final class BenchmarkExecutor { // swiftlint:disable:this type_body_length
         let initialStartTime = BenchmarkClock.now
 
         // 'Warmup' to remove initial mallocs from stats in p100, also used as base for some metrics
-        let baselineMallocStats = MallocStatsProducer.makeMallocStats()
+        let _ = MallocStatsProducer.makeMallocStats() // baselineMallocStats
 
         // Calculate typical sys call check overhead and deduct that to get 'clean' stats for the actual benchmark
         var operatingSystemStatsOverhead = OperatingSystemStats()

--- a/Sources/Benchmark/BenchmarkExecutor.swift
+++ b/Sources/Benchmark/BenchmarkExecutor.swift
@@ -269,7 +269,9 @@ final class BenchmarkExecutor { // swiftlint:disable:this type_body_length
         }
 
         if benchmark.configuration.metrics.contains(.threads) ||
-            benchmark.configuration.metrics.contains(.threadsRunning) {
+            benchmark.configuration.metrics.contains(.threadsRunning) ||
+            benchmark.configuration.metrics.contains(.peakMemoryResident) ||
+            benchmark.configuration.metrics.contains(.peakMemoryVirtual) {
             operatingSystemStatsProducer.startSampling(5_000) // ~5 ms
         }
 

--- a/Sources/Benchmark/BenchmarkMetric.swift
+++ b/Sources/Benchmark/BenchmarkMetric.swift
@@ -172,7 +172,7 @@ public extension BenchmarkMetric {
         case .mallocCountTotal:
             return "Malloc (total)"
         case .allocatedResidentMemory:
-            return "Memory (allocated)"
+            return "Memory (allocated resident)"
         case .memoryLeaked:
             return "Malloc / free Δ"
         case .syscalls:

--- a/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
+++ b/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
@@ -33,7 +33,7 @@ import ExtrasJSON
 //    var largeNMallocMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.nmalloc")
 //    var smallNDallocMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.ndalloc")
 //    var largeNDallocMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.ndalloc")
-//    var smallAlloctedMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.allocated")
+//    var smallAllocatedMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.allocated")
 //    var largeAllocatedMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.allocated")
 //    var smallNFillsMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).small.nfills")
 //    var largeNFillsMIB = setupMIB(name: "stats.arenas.\(MALLCTL_ARENAS_ALL).large.nfills")
@@ -53,8 +53,6 @@ import ExtrasJSON
 
         // Update jemalloc internal statistics, this is the magic incantation to do it
         static func updateEpoch() {
-            var allocated = 0
-            var size = MemoryLayout<Int>.size
             var epoch = 0
             let epochSize = MemoryLayout<Int>.size
             var result: Int32 = 0
@@ -66,11 +64,10 @@ import ExtrasJSON
             }
 
             // Then update epoch
-            result = mallctlbymib(epochMIB, epochMIB.count, &allocated, &size, &epoch, epochSize)
+            result = mallctlbymib(epochMIB, epochMIB.count, nil, nil, &epoch, epochSize)
             if result != 0 {
                 print("mallctlbymib epochMIB returned \(result)")
             }
-//            return epoch
         }
 
         // Read the actual stats using a cached MIB as the key

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
@@ -22,6 +22,8 @@
         let semaphore = DispatchSemaphore(value: 0)
         var peakThreads: Int = 0
         var peakThreadsRunning: Int = 0
+        var peakMemoryResident: Int = 0
+        var peakMemoryVirtual: Int = 0
         var runState: RunState = .running
         var sampleRate: Int = 10_000
         var metrics: Set<BenchmarkMetric>?
@@ -94,6 +96,9 @@
                     let rate = self.sampleRate
                     self.peakThreads = 0
                     self.peakThreadsRunning = 0
+                    self.peakMemoryResident = 0
+                    self.peakMemoryVirtual = 0
+
                     self.runState = .running
                     self.lock.unlock()
 
@@ -107,6 +112,14 @@
 
                         if procTaskInfo.pti_numrunning > self.peakThreadsRunning {
                             self.peakThreadsRunning = Int(procTaskInfo.pti_numrunning)
+                        }
+
+                        if procTaskInfo.pti_resident_size > self.peakMemoryResident {
+                            self.peakMemoryResident = Int(procTaskInfo.pti_resident_size)
+                        }
+
+                        if procTaskInfo.pti_virtual_size > self.peakMemoryVirtual {
+                            self.peakMemoryVirtual = Int(procTaskInfo.pti_virtual_size)
                         }
 
                         if self.runState == .shuttingDown {
@@ -154,13 +167,21 @@
                 let totalTime = userTime + systemTime
                 var threads = 0
                 var threadsRunning = 0
+                var peakResident = 0
+                var peakVirtual = 0
 
-                if metrics.contains(.threads) || metrics.contains(.threadsRunning) {
+                if metrics.contains(.threads) ||
+                    metrics.contains(.threadsRunning) ||
+                    metrics.contains(.peakMemoryResident) ||
+                    metrics.contains(.peakMemoryVirtual) {
                     lock.lock()
                     threads = peakThreads
                     threadsRunning = peakThreadsRunning
+                    peakResident = peakMemoryResident
+                    peakVirtual = peakMemoryVirtual
                     lock.unlock()
                 }
+
                 var ioStats = IOStats()
 
                 if metrics.contains(.writeBytesPhysical) || metrics.contains(.writeBytesPhysical) {
@@ -170,8 +191,8 @@
                 let stats = OperatingSystemStats(cpuUser: userTime,
                                                  cpuSystem: systemTime,
                                                  cpuTotal: totalTime,
-                                                 peakMemoryResident: Int(procTaskInfo.pti_resident_size),
-                                                 peakMemoryVirtual: Int(procTaskInfo.pti_virtual_size),
+                                                 peakMemoryResident: peakResident,
+                                                 peakMemoryVirtual: peakVirtual,
                                                  syscalls: Int(procTaskInfo.pti_syscalls_unix) +
                                                      Int(procTaskInfo.pti_syscalls_mach),
                                                  contextSwitches: Int(procTaskInfo.pti_csw),

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
@@ -156,6 +156,8 @@
         }
 
         func startSampling(_: Int = 10_000) { // sample rate in microseconds
+            let sampleSemaphore = DispatchSemaphore(value: 0)
+
             DispatchQueue.global(qos: .userInitiated).async {
                 self.lock.lock()
 
@@ -193,6 +195,8 @@
 
                     self.lock.unlock()
 
+                    sampleSemaphore.signal()
+
                     if quit == .done {
                         return
                     }
@@ -200,8 +204,8 @@
                     usleep(UInt32.random(in: UInt32(Double(rate) * 0.9) ... UInt32(Double(rate) * 1.1)))
                 }
             }
-            // We'll sleep just a little bit to let the sampler thread get going so we try to avoid 0 samples
-            usleep(1_000)
+            // We'll need to wait for a single sample from the so we don't get 0 samples
+            sampleSemaphore.wait()
         }
 
         func stopSampling() {


### PR DESCRIPTION
## Description

As reported here: https://forums.swift.org/t/compiler-optimisations-for-functional-style-collection-algorithms/68291/12
the peak resident memory counter showed invalid results - this PR enables the missing sampling for these two peak counters  (virtual/resident) so it provides expected results.

Also cleaned up the jemalloc epoch-poking that had some unnecessary boilerplate.

## How Has This Been Tested?

Test suite + manual testing with the test suite from here:
https://github.com/wadetregaskis/Swift-Benchmarks - tested on both macOS and Linux.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
