### PR TITLE
feat(minor): Make CI fail with regression for crashes or other run failures

### DIFF
--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -125,7 +125,7 @@ struct BenchmarkTool: AsyncParsableCommand {
         // check what failed and react accordingly
         switch exitCode {
         case .benchmarkJobFailed:
-            if self.baselineOperation == .check { // We need to fail with exit code for the baseline checks such that CI fails properly
+            if baselineOperation == .check { // We need to fail with exit code for the baseline checks such that CI fails properly
                 exitBenchmark(exitCode: .thresholdRegression)
             }
             if let failedBenchmark {
@@ -146,10 +146,10 @@ struct BenchmarkTool: AsyncParsableCommand {
 
     func printChildRunError(error: Int32, benchmarkExecutablePath: String) {
         print("Failed to run '\(command)' for \(benchmarkExecutablePath), error code [\(error)]")
-        print("Likely your benchmark crahed, try running the tool in the debugger, e.g.")
+        print("Likely your benchmark crashed, try running the tool in the debugger, e.g.")
         print("lldb \(benchmarkExecutablePath)")
         print("Or check Console.app for a backtrace if on macOS.")
-        if self.baselineOperation == .check { // We need to fail with exit code for the baseline checks such that CI fails properly
+        if baselineOperation == .check { // We need to fail with exit code for the baseline checks such that CI fails properly
             exitBenchmark(exitCode: .thresholdRegression)
         }
     }

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -125,6 +125,9 @@ struct BenchmarkTool: AsyncParsableCommand {
         // check what failed and react accordingly
         switch exitCode {
         case .benchmarkJobFailed:
+            if self.baselineOperation == .check { // We need to fail with exit code for the baseline checks such that CI fails properly
+                exitBenchmark(exitCode: .thresholdRegression)
+            }
             if let failedBenchmark {
                 failedBenchmarkList.append(failedBenchmark)
             }
@@ -146,6 +149,9 @@ struct BenchmarkTool: AsyncParsableCommand {
         print("Likely your benchmark crahed, try running the tool in the debugger, e.g.")
         print("lldb \(benchmarkExecutablePath)")
         print("Or check Console.app for a backtrace if on macOS.")
+        if self.baselineOperation == .check { // We need to fail with exit code for the baseline checks such that CI fails properly
+            exitBenchmark(exitCode: .thresholdRegression)
+        }
     }
 
     func shouldIncludeBenchmark(_ name: String) throws -> Bool {


### PR DESCRIPTION
## Description

After the changes in https://github.com/ordo-one/package-benchmark/pull/166 we no longer fail the run of the rest of the benchmarks if a single one fails, which is reasonable during normal iterative work. This is not ok for CI baseline checks though, so this PR restores failures when `baseline check` is performed.

## How Has This Been Tested?

Manually tested.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
