### PR TITLE
docs(patch): Add example on how parameterization is done

### DIFF
--- a/Benchmarks/Benchmarks/Basic/BenchmarkRunner+Basic.swift
+++ b/Benchmarks/Benchmarks/Basic/BenchmarkRunner+Basic.swift
@@ -102,4 +102,14 @@ let benchmarks = {
             blackHole(stats.percentiles())
         }
     }
+
+    let paramterization = (0...5).map { 1 << $0 } // 1, 2, 4, ...
+
+    paramterization.forEach { count in
+        Benchmark("ParameterizedWith\(count)") { benchmark in
+            for _ in 0 ..< count {
+                blackHole(Int.random(in: benchmark.scaledIterations))
+            }
+        }
+    }
 }

--- a/Benchmarks/Benchmarks/Basic/BenchmarkRunner+Basic.swift
+++ b/Benchmarks/Benchmarks/Basic/BenchmarkRunner+Basic.swift
@@ -103,9 +103,9 @@ let benchmarks = {
         }
     }
 
-    let paramterization = (0...5).map { 1 << $0 } // 1, 2, 4, ...
+    let parameterization = (0...5).map { 1 << $0 } // 1, 2, 4, ...
 
-    paramterization.forEach { count in
+    parameterization.forEach { count in
         Benchmark("ParameterizedWith\(count)") { benchmark in
             for _ in 0 ..< count {
                 blackHole(Int.random(in: benchmark.scaledIterations))

--- a/Sources/Benchmark/Documentation.docc/WritingBenchmarks.md
+++ b/Sources/Benchmark/Documentation.docc/WritingBenchmarks.md
@@ -198,9 +198,9 @@ Benchmark.defaultConfiguration = .init(...)
  
 ```swift
 let benchmarks = {
-  let paramterization = (0...5).map { 1 << $0 } // 1, 2, 4, ...
+  let parameterization = (0...5).map { 1 << $0 } // 1, 2, 4, ...
 
-  paramterization.forEach { count in
+  parameterization.forEach { count in
     Benchmark("ParameterizedWith\(count)") { benchmark in
       for _ in 0 ..< count {
         blackHole(Int.random(in: benchmark.scaledIterations))

--- a/Sources/Benchmark/Documentation.docc/WritingBenchmarks.md
+++ b/Sources/Benchmark/Documentation.docc/WritingBenchmarks.md
@@ -194,6 +194,22 @@ Similar defaults can be set for all benchmark settings using the class variable 
 Benchmark.defaultConfiguration = .init(...)
 ```
 
+### Running mutliple similar Benchmarks with Parameterizations
+ 
+```swift
+let benchmarks = {
+  let paramterization = (0...5).map { 1 << $0 } // 1, 2, 4, ...
+
+  paramterization.forEach { count in
+    Benchmark("ParameterizedWith\(count)") { benchmark in
+      for _ in 0 ..< count {
+        blackHole(Int.random(in: benchmark.scaledIterations))
+      }
+    }
+  }
+}
+```
+
 ### Custom thresholds
 
 ```swift

--- a/Tests/BenchmarkTests/BenchmarkResultTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkResultTests.swift
@@ -298,8 +298,6 @@ final class BenchmarkResultTests: XCTestCase {
                                                                    .p90: 1_500,
                                                                    .p99: 1_500]
 
-        let absoluteThresholdsTwo = BenchmarkThresholds(absolute: absoluteTwo)
-
         let absoluteP90: BenchmarkThresholds.AbsoluteThresholds = [.p90: 3]
 
         let absoluteThresholdsP90 = BenchmarkThresholds(absolute: absoluteP90)
@@ -324,13 +322,6 @@ final class BenchmarkResultTests: XCTestCase {
                                           warmupIterations: 0,
                                           thresholds: .default,
                                           statistics: thirdStatistics)
-
-        let fourthResult = BenchmarkResult(metric: .cpuUser,
-                                           timeUnits: .nanoseconds,
-                                           scalingFactor: .one,
-                                           warmupIterations: 0,
-                                           thresholds: .default,
-                                           statistics: fourthStatistics)
 
         var deviations = secondResult.deviationsComparedWith(firstResult,
                                                              thresholds: absoluteThresholds)


### PR DESCRIPTION
## Description

Added another sample for how to run parametrised benchmarks

Fixes https://github.com/ordo-one/package-benchmark/issues/224

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
