### PR TITLE
fix(patch): memory unsafe file read on Linux

### DIFF
--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
@@ -55,6 +55,8 @@
                         do {
                             let fileData = try [UInt8](unsafeUninitializedCapacity: 1_024) { buf, count in
                                 count = try fileDescriptor.read(into: UnsafeMutableRawBufferPointer(buf))
+                                // Add nul byte to end of read data.
+                                buf.initializeElement(at: min(count, 1_023), to: 0)
                             }
 
                             fileData.withUnsafeBufferPointer {

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
@@ -47,8 +47,8 @@
         // We should cache the open file(s) and just read from file offset 0 to reduce overhead
         func read(path: FilePath) -> String {
             var string = ""
-            let maxReadBuffer = 8192
-            
+            let maxReadBuffer = 8_192
+
             do {
                 let fileDescriptor = try FileDescriptor.open(path, .readOnly, options: [], permissions: .ownerRead)
                 do {


### PR DESCRIPTION
## Description

When reading from the file descriptor into the temporary buffer, it was only by happenstance that the buffer would contain a terminating nul byte.

The buffer is uninitialized and thus may contain any data.

And the `/proc` files that are read into the buffer are **not** nul terminated.

If the temporary buffer happened to be zero-initialized, then this would accidentally work correctly.

If the temporary buffer happened to have a nul byte somewhere after the read data and in-bounds, then the end of the resulting String would be corrupted with arbitrary crud. This crud would ostensibly be after a terminating newline and thus parsers might have ignored it?

If the temporary buffer happened to not have any nul bytes after the read data, then other Bad Things could happen, including silent success or a crash due to segmentation fault or various checks in String being violated.

The repair is to append a nul byte after the read data (ensuring that the nul byte is not placed after the end of the buffer).

What motivated me to go look for this issue is that I have a benchmark suite in a non-public project that crashes due to this issue. That benchmark suite runs lots of iterations and somehow seems to have a memory access pattern that regularly leads to the conditions where the ill-effects of this bug can manifest.

## How Has This Been Tested?

Regarding testing, I did some one-off testing that pre-filled the temporary buffer with non-zero bytes and then observed those bytes were erroneously present in the resulting `String`.

I have not attempted to craft a unit test that triggers this bug. That would require either directly or indirectly manipulating the system allocator to affect the initial state of this temporary buffer. Too much effort, IMO.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works