### PR TITLE
fix: support github markdown table style

### DIFF
--- a/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
@@ -15,6 +15,15 @@ import TextTable
 private let percentileWidth = 7
 private let maxDescriptionWidth = 100
 
+extension OutputFormat {
+    var tableStyle: TextTableStyle.Type {
+        if case .markdown = self {
+            return Style.pipe
+        }
+        return Style.fancy
+    }
+}
+
 extension BenchmarkTool {
     private func printMarkdown(_ markdown: String, terminator: String = "\n") {
         if format == .markdown {
@@ -128,7 +137,7 @@ extension BenchmarkTool {
         printMarkdown("")
 
         printMarkdown("```")
-        table.print(scaledResults, style: Style.fancy)
+        table.print(scaledResults, style: format.tableStyle)
         printMarkdown("```")
     }
 
@@ -354,7 +363,7 @@ extension BenchmarkTool {
                                                                samples: samples))
 
                             printMarkdown("```")
-                            table.print(scaledResults, style: Style.fancy)
+                            table.print(scaledResults, style: format.tableStyle)
                             printMarkdown("```")
 
                             if format == .markdown {
@@ -415,7 +424,7 @@ extension BenchmarkTool {
                     }
 
                     printMarkdown("```")
-                    absoluteTable.print(absoluteResults, style: Style.fancy)
+                    absoluteTable.print(absoluteResults, style: format.tableStyle)
                     printMarkdown("```")
                 }
 
@@ -430,7 +439,7 @@ extension BenchmarkTool {
                     }
 
                     printMarkdown("```")
-                    relativeTable.print(relativeResults, style: Style.fancy)
+                    relativeTable.print(relativeResults, style: format.tableStyle)
                     printMarkdown("```")
                 }
             }

--- a/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
@@ -136,9 +136,7 @@ extension BenchmarkTool {
         print("\(key)")
         printMarkdown("")
 
-        printMarkdown("```")
         table.print(scaledResults, style: format.tableStyle)
-        printMarkdown("```")
     }
 
     func prettyPrint(_ baseline: BenchmarkBaseline,
@@ -362,9 +360,7 @@ extension BenchmarkTool {
                                                                percentiles: percentageDeltaPercentiles,
                                                                samples: samples))
 
-                            printMarkdown("```")
                             table.print(scaledResults, style: format.tableStyle)
-                            printMarkdown("```")
 
                             if format == .markdown {
                                 if hideResults {
@@ -423,9 +419,7 @@ extension BenchmarkTool {
                          Column(title: "Threshold Δ", value: $0.differenceThreshold, width: percentileWidth, align: .right)]
                     }
 
-                    printMarkdown("```")
                     absoluteTable.print(absoluteResults, style: format.tableStyle)
-                    printMarkdown("```")
                 }
 
                 if relativeResults.isEmpty == false {

--- a/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
@@ -432,9 +432,7 @@ extension BenchmarkTool {
                          Column(title: "Threshold %", value: $0.differenceThreshold, width: percentileWidth, align: .right)]
                     }
 
-                    printMarkdown("```")
                     relativeTable.print(relativeResults, style: format.tableStyle)
-                    printMarkdown("```")
                 }
             }
         }


### PR DESCRIPTION
## Description

https://github.com/ordo-one/package-benchmark/issues/245

A small change to support github markdown style tables.

## How Has This Been Tested?

Tested locally from `package-benchmark-samples`:

```
swift package benchmark --format markdown
```

Output looks correct. Tables are formatted in native GitHub table style:

https://gist.github.com/vanvoorden/466dae6b853e48e1b17f0966c6e29c43

We can test the default table style:

```
swift package benchmark --format text
```

Output looks unchanged:

https://gist.github.com/vanvoorden/234170b07f19e4aa59fb9944fbfdfb31

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
