### PR TITLE
chore(patch): [sc-10781] No procinfo on mobile platforms - stub out + disable jemalloc

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -144,7 +144,7 @@ if macOSSPIBuild == false { // jemalloc always disable for macOSSPIBuild
         print("Jemalloc disabled through environment variable.")
     } else {
         package.dependencies += [.package(url: "https://github.com/ordo-one/package-jemalloc", .upToNextMajor(from: "1.0.0"))]
-        dependencies += [.product(name: "jemalloc", package: "package-jemalloc")]
+        dependencies += [.product(name: "jemalloc", package: "package-jemalloc", condition: .when(platforms: [.macOS, .linux]))]
     }
 }
 

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Darwin.swift
@@ -56,7 +56,7 @@
             nsPerSchedulerTick = 1_000_000_000 / schedulerTicksPerSecond
         }
 
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+        #if os(macOS)
             fileprivate
             func getProcInfo() -> proc_taskinfo {
                 var procTaskInfo = proc_taskinfo()
@@ -93,7 +93,7 @@
         #endif
 
         func startSampling(_: Int = 10_000) { // sample rate in microseconds
-            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+            #if os(macOS)
                 let sampleSemaphore = DispatchSemaphore(value: 0)
 
                 DispatchQueue.global(qos: .userInitiated).async {
@@ -155,7 +155,7 @@
         }
 
         func stopSampling() {
-            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+            #if os(macOS)
                 lock.withLock {
                     runState = .shuttingDown
                 }
@@ -168,7 +168,7 @@
         }
 
         func makeOperatingSystemStats() -> OperatingSystemStats { // swiftlint:disable:this function_body_length
-            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+            #if os(macOS)
                 guard let metrics else {
                     return .init()
                 }
@@ -255,8 +255,12 @@
         }
 
         func makePerformanceCounters() -> PerformanceCounters {
+            #if os(macOS)
             let performanceCounters = getRusage()
             return .init(instructions: performanceCounters.ri_instructions)
+            #else
+            return .init()
+            #endif
         }
     }
 


### PR DESCRIPTION
## Description

`proc_taskinfo()` and friends are not available on iOS.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
