### PR TITLE
feat(minor): Add signposts for explicit starts

### DIFF
--- a/Benchmarks/Benchmarks/Basic/BenchmarkRunner+Basic.swift
+++ b/Benchmarks/Benchmarks/Basic/BenchmarkRunner+Basic.swift
@@ -143,7 +143,7 @@ let benchmarks = {
                         free(something)
                     }
                     if let fileHandle = FileHandle(forWritingAtPath: "/dev/null") {
-                        let data = "Data to discard".data(using: .utf8)!
+                        let data = Data("Data to discard".utf8)
                         fileHandle.write(data)
                         fileHandle.closeFile()
                     }

--- a/Sources/Benchmark/BenchmarkExecutor.swift
+++ b/Sources/Benchmark/BenchmarkExecutor.swift
@@ -171,7 +171,7 @@ struct BenchmarkExecutor { // swiftlint:disable:this type_body_length
 
         // And corresponding hook for then the benchmark has finished and capture finishing metrics here
         // This closure will only be called once for a given run though.
-        benchmark.measurementPostSynchronization = { explicitStartStop in
+        benchmark.measurementPostSynchronization = { _ in
             if performanceCountersRequested {
                 stopPerformanceCounters = operatingSystemStatsProducer.makePerformanceCounters()
             }

--- a/Sources/Benchmark/BenchmarkExecutor.swift
+++ b/Sources/Benchmark/BenchmarkExecutor.swift
@@ -43,6 +43,7 @@ struct BenchmarkExecutor { // swiftlint:disable:this type_body_length
             let signPost = OSSignposter(logHandle: logHandler)
             let signpostID = OSSignpostID(log: logHandler)
             var warmupInterval: OSSignpostIntervalState?
+            var explicitStartStopInterval: OSSignpostIntervalState?
 
             if benchmark.configuration.warmupIterations > 0 {
                 warmupInterval = signPost.beginInterval("Benchmark", id: signpostID, "\(benchmark.name) warmup")
@@ -141,7 +142,13 @@ struct BenchmarkExecutor { // swiftlint:disable:this type_body_length
         // then reset to a new starting state.
         // NB that the order is important, as we will get leaked
         // ARC measurements if initializing it before malloc etc.
-        benchmark.measurementPreSynchronization = {
+        benchmark.measurementPreSynchronization = { explicitStartStop in
+            #if canImport(OSLog)
+            if explicitStartStop {
+                explicitStartStopInterval = signPost.beginInterval("Benchmark", id: signpostID, "\(benchmark.name) startMeasurement()")
+            }
+            #endif
+
             if mallocStatsRequested {
                 startMallocStats = MallocStatsProducer.makeMallocStats()
             }
@@ -164,7 +171,7 @@ struct BenchmarkExecutor { // swiftlint:disable:this type_body_length
 
         // And corresponding hook for then the benchmark has finished and capture finishing metrics here
         // This closure will only be called once for a given run though.
-        benchmark.measurementPostSynchronization = {
+        benchmark.measurementPostSynchronization = { explicitStartStop in
             if performanceCountersRequested {
                 stopPerformanceCounters = operatingSystemStatsProducer.makePerformanceCounters()
             }
@@ -182,6 +189,12 @@ struct BenchmarkExecutor { // swiftlint:disable:this type_body_length
             if mallocStatsRequested {
                 stopMallocStats = MallocStatsProducer.makeMallocStats()
             }
+
+#if canImport(OSLog)
+            if let explicitStartStopInterval {
+                signPost.endInterval("Benchmark", explicitStartStopInterval, "\(benchmark.name) stopMeasurement()")
+            }
+#endif
 
             var delta = 0
             let runningTime: Duration = startTime.duration(to: stopTime)


### PR DESCRIPTION
## Description

Adding support for per-iteration signposts as requested in 
https://github.com/ordo-one/package-benchmark/issues/259

## How Has This Been Tested?

Manually verified.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
