### PR TITLE
fix: threshold-tolerances sometimes are not respected

### DIFF
--- a/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
+++ b/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
@@ -227,9 +227,7 @@ import PackagePlugin
                         print("Must specify exactly zero or one baseline for check against absolute thresholds, got: \(positionalArguments)")
                         throw MyError.invalidArgument
                     }
-                    if positionalArguments.count == validRange.upperBound { // dont check if we just read baselines
-                        shouldBuildTargets = false
-                    }
+                    shouldBuildTargets = true // still need to load benchmarks to load threshold-tolerances
                 } else {
                     let validRange = 1 ... 2
                     guard validRange.contains(positionalArguments.count) else {


### PR DESCRIPTION
## Description

Resolves #275 by loading benchmarks when they should be loaded.

## How Has This Been Tested?

<details>
  <summary> Click to show benchmark code </summary>
  
```swift
let benchmarks = {
    Benchmark.defaultConfiguration = .init(
        metrics: [.cpuTotal],
        timeUnits: .nanoseconds,
        warmupIterations: 1,
        scalingFactor: .one,
        maxDuration: .seconds(1000),
        maxIterations: 1
    )

    func defaultCounter() -> Int { 10 }

    func dummyCounter(_ count: Int) {
        for index in 0 ..< count {
            blackHole(index)
        }
    }

    Benchmark(
        "CountNumbersBenchmark",
        configuration: .init(
            scalingFactor: .kilo,
            thresholds: [
                .cpuTotal: .init(
                    /// Tolerate up to 1% of difference compared to the threshold.
                    relative: [.p90: 1],
                    /// Tolerate up to 80ms of difference compared to the threshold.
                    absolute: [.p90: 80_000_000]
                )
            ]
        )
    ) { _ in
        for _ in 0 ... 1_000_000 {
            dummyCounter(defaultCounter() * 1000)
        }
    }
}
```

</details>

Right now, the following is the result of the benchmark, with fixes applied:


**✅ Pull request has no significant performance differences ✅**

Benchmark check running at [2024-09-18 02:48:03 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?iso=2024-09-18T02%3A48%3A03Z)

Baseline mmbm-no-twice-benchmark-run is EQUAL to the defined absolute baseline thresholds. (--check-absolute)

### Baseline mmbm-no-twice-benchmark-run

```
Host 0d12d771afd8 with 64 aarch64 processors with 125 GB memory, running:
#24~22.04.1-Ubuntu SMP Sat Jul 20 10:48:15 UTC 2024
```
### MyBenchmarks

#### CountNumbersBenchmark

| Metric                  |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |
|:------------------------|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|
| Time (total CPU) (ns) * | 7710000 | 7710000 | 7710000 | 7710000 | 7710000 | 7710000 | 7710000 |       1 |


As you can see, the result shows `7710000` aka `7.71s` of cpu time (now that I look, that `ns` label must be a bug, probably caused by the scaling factor usage. See benchmark code above).
But the threshold file is:

```
{
  "cpuTotal" : 7700000000
}
```

Without this fix, this check would fail since the numbers are not equal.
With this fix, the benchmark completes successfully since it does load the threshold tolerances as declared in the benchmark code:
```swift
            thresholds: [
                .cpuTotal: .init(
                    /// Tolerate up to 1% of difference compared to the threshold.
                    relative: [.p90: 1],
                    /// Tolerate up to 80ms of difference compared to the threshold.
                    absolute: [.p90: 80_000_000]
                )
            ]
```

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
