### PR TITLE
fix: absolute thresholds checks from benchmark setup

### DIFF
--- a/Sources/Benchmark/BenchmarkThresholds.swift
+++ b/Sources/Benchmark/BenchmarkThresholds.swift
@@ -26,6 +26,6 @@ public struct BenchmarkThresholds: Codable {
         self.absolute = absolute
     }
 
-    let relative: RelativeThresholds
-    let absolute: AbsoluteThresholds
+    public let relative: RelativeThresholds
+    public let absolute: AbsoluteThresholds
 }


### PR DESCRIPTION
## Description

Closes https://github.com/ordo-one/package-benchmark/issues/282.

## How Has This Been Tested?

Added 

```swift
    Benchmark(
        "p90Sleep" ,
        configuration: .init(metrics: .all, thresholds: [.wallClock: .init(absolute: [.p90: .milliseconds(100)])])
    ) { _ in
        sleep(1)
    }
```

to `Benchmarks/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift` and ran `swift package benchmark --target P90AbsoluteThresholdsBenchmark baseline check --check-absolute`  (from the Benchmarks directory) to verify the thresholds are correctly respected.

Still, I am not sure this is the right place to introduce this fix. Also, if you run `swift package benchmark --target P90AbsoluteThresholdsBenchmark baseline check --check-absolute` you will see that the `"Retain/release deviation"` Benchmark fails the defined thresholds suddenly. I am not sure if I am doing something wrong or if this is just because of some overhead coming from threshold reporting?

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
