### PR TITLE
fix(patch): Log less when `--no-progress` in `thresholds` subcommand

### DIFF
--- a/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
@@ -144,8 +144,10 @@ extension BenchmarkTool {
 
                 var p90Thresholds: [BenchmarkIdentifier : [BenchmarkMetric: BenchmarkThresholds.AbsoluteThreshold]] = [:]
 
-                print("")
-                print("Reading thresholds from \"\(thresholdsPath)\"")
+                if quiet == false {
+                    print("")
+                    print("Reading thresholds from \"\(thresholdsPath)\"")
+                }
 
                 benchmarks.forEach { benchmark in
                     if let thresholds = BenchmarkTool.makeBenchmarkThresholds(
@@ -164,9 +166,11 @@ extension BenchmarkTool {
                                   exitCode: .thresholdRegression)
                 }
 
-                print("")
-                print("Checking \(benchmarks.map { $0.target + ":" + $0.name })")
-                print("")
+                if quiet == false {
+                    print("")
+                    print("Checking \(benchmarks.map { $0.target + ":" + $0.name })")
+                    print("")
+                }
 
                 let deviationResults = currentBaseline.failsAbsoluteThresholdChecks(benchmarks: benchmarks,
                                                                                     p90Thresholds: p90Thresholds)


### PR DESCRIPTION
## Description

Suppress some logs in `thresholds` subcommand when using `--no-progress`:

<kbd> <img width="934" alt="Screenshot 2024-10-04 at 10 52 55 PM" src="https://github.com/user-attachments/assets/4254fb63-77d0-4b0b-a0ce-29c8198c4e0d"> </kbd>


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
