### PR TITLE
fix(patch): Log less when `--no-progress` (again)

### DIFF
--- a/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
@@ -144,8 +144,10 @@ extension BenchmarkTool {
 
                 var p90Thresholds: [BenchmarkIdentifier : [BenchmarkMetric: BenchmarkThresholds.AbsoluteThreshold]] = [:]
 
-                print("")
-                print("Reading thresholds from \"\(thresholdsPath)\"")
+                if noProgress == false {
+                    print("")
+                    print("Reading thresholds from \"\(thresholdsPath)\"")
+                }
 
                 benchmarks.forEach { benchmark in
                     if let thresholds = BenchmarkTool.makeBenchmarkThresholds(
@@ -164,9 +166,11 @@ extension BenchmarkTool {
                                   exitCode: .thresholdRegression)
                 }
 
-                print("")
-                print("Checking \(benchmarks.map { $0.target + ":" + $0.name })")
-                print("")
+                if noProgress == false {
+                    print("")
+                    print("Checking \(benchmarks.map { $0.target + ":" + $0.name })")
+                    print("")
+                }
 
                 let deviationResults = currentBaseline.failsAbsoluteThresholdChecks(benchmarks: benchmarks,
                                                                                     p90Thresholds: p90Thresholds)


### PR DESCRIPTION
## Description

The last PR made it so it requires the `--quiet` flag to silence those logs.
This wasn't my intention, I wanted `--no-progress` to do that.
Using `--quiet` will make the benchmark comparison not report what regressed if anything has regressed, so I don't want to use that flag.

<This time actually tested the PR against our repo>

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
