### PR TITLE
fix(patch): Use `String(reflecting: error)` for printing errors

### DIFF
--- a/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
@@ -223,7 +223,7 @@ extension BenchmarkTool {
                                             print("Removing baseline '\(baselineName)' for \(target)")
                                             try filemanager.removeItem(atPath: file.description)
                                         } catch {
-                                            print("Failed to remove file \(file), error \(error)")
+                                            print("Failed to remove file \(file), error \(String(reflecting: error))")
                                             print("Give benchmark plugin permissions to delete files by running with e.g.:")
                                             print("")
                                             print("swift package --allow-writing-to-package-directory benchmark baseline delete")
@@ -376,7 +376,7 @@ extension BenchmarkTool {
                         baseline = try JSONDecoder().decode(BenchmarkBaseline.self, from: Data(readBytes))
 
                     } catch {
-                        print("Failed to open file for reading \(path) [\(error)]")
+                        print("Failed to open file for reading \(path) [\(String(reflecting: error))]")
                     }
                 }
             } catch {

--- a/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
@@ -73,11 +73,11 @@ extension BenchmarkTool {
                             _ = try fd.write(UnsafeRawBufferPointer($0))
                         }
                     } catch {
-                        print("Failed to write to file \(outputPath) [\(error)]")
+                        print("Failed to write to file \(outputPath) [\(String(reflecting: error))]")
                     }
                 }
             } catch {
-                print("Failed to close fd for \(outputPath) after write [\(error)].")
+                print("Failed to close fd for \(outputPath) after write [\(String(reflecting: error))].")
             }
         } catch {
             if errno == EPERM {
@@ -127,11 +127,11 @@ extension BenchmarkTool {
                             _ = try fd.write(rawBuffer)
                         }
                     } catch {
-                        print("Failed to write to file \(outputPath) [\(error)]")
+                        print("Failed to write to file \(outputPath) [\(String(reflecting: error))]")
                     }
                 }
             } catch {
-                print("Failed to close fd for \(outputPath) after write [\(error)].")
+                print("Failed to close fd for \(outputPath) after write [\(String(reflecting: error))].")
             }
         } catch {
             if errno == EPERM {

--- a/Plugins/BenchmarkTool/BenchmarkTool+ReadP90AbsoluteThresholds.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+ReadP90AbsoluteThresholds.swift
@@ -79,7 +79,7 @@ extension BenchmarkTool {
                             }
                         }
                     } catch {
-                        print("Failed to read file at \(path) [\(error)] \(Errno(rawValue: errno).description)")
+                        print("Failed to read file at \(path) [\(String(reflecting: error))] \(Errno(rawValue: errno).description)")
                     }
                 }
             } catch {

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -385,7 +385,7 @@ struct BenchmarkTool: AsyncParsableCommand {
 
                 try write(.end)
             } catch {
-                print("Process failed: \(error)")
+                print("Process failed: \(String(reflecting: error))")
             }
 
             if status == 0 {

--- a/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
+++ b/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
@@ -67,7 +67,7 @@ public extension Benchmark {
                 let setupResult = benchmark.setupState! as! SetupResult // swiftlint:disable:this force_cast
                 try closure(benchmark, setupResult)
             } catch {
-                benchmark.error("Benchmark \(name) failed with \(error)")
+                benchmark.error("Benchmark \(name) failed with \(String(reflecting: error))")
             }
         }, teardown: teardown)
 
@@ -94,7 +94,7 @@ public extension Benchmark {
                 let setupResult = benchmark.setupState! as! SetupResult // swiftlint:disable:this force_cast
                 try await closure(benchmark, setupResult)
             } catch {
-                benchmark.error("Benchmark \(name) failed with \(error)")
+                benchmark.error("Benchmark \(name) failed with \(String(reflecting: error))")
             }
         }, teardown: teardown)
 

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -240,7 +240,7 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
             do {
                 try closure(benchmark)
             } catch {
-                benchmark.error("Benchmark \(name) failed with \(error)")
+                benchmark.error("Benchmark \(name) failed with \(String(reflecting: error))")
             }
         }, setup: setup, teardown: teardown)
     }
@@ -261,7 +261,7 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
             do {
                 try await closure(benchmark)
             } catch {
-                benchmark.error("Benchmark \(name) failed with \(error)")
+                benchmark.error("Benchmark \(name) failed with \(String(reflecting: error))")
             }
         }, setup: setup, teardown: teardown)
     }

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -196,7 +196,7 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                             try await hook?()
                         }
                     } catch {
-                        try channel.write(.error("Benchmark.teardown or local benchmark teardown failed: \(error)"))
+                        try channel.write(.error("Benchmark.teardown or local benchmark teardown failed: \(String(reflecting: error))"))
                         return
                     }
 


### PR DESCRIPTION
## Description

A few (mostly server side) packages like PostgresNIO have a generic `description` in their errors, while providing the full error info in `debugDescription`.
Using `String(reflecting: error)` we can make sure the `debugDescription` is preferred when transforming the error into an `String`.

Sample error:
```
Benchmark MyBenchmark failed with PostgresDecodingError – Generic description to prevent accidental leakage of sensitive data. For debugging details, use String(reflecting: error).
```

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
