### PR TITLE
chore: Fix test compilation on Ubuntu Noble

### DIFF
--- a/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
+++ b/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
@@ -106,7 +106,10 @@ final class OperatingSystemAndMallocTests: XCTestCase {
         let amplificationFactor = 1_000
 
         let tempFile = tmpfile()
-        XCTAssertNotNil(tempFile, "tmpfile() failed: \(errno)")
+        guard let tempFile else {
+            XCTFail("tmpfile() failed: \(errno)")
+            return
+        }
 
         let fildes = fileno(tempFile)
 


### PR DESCRIPTION
## Description

Fix test build failure

```
Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift:111:29: error: value of optional type 'UnsafeMutablePointer<FILE>?' (aka 'Optional<UnsafeMutablePointer<_IO_FILE>>') must be unwrapped to a value of type 'UnsafeMutablePointer<FILE>' (aka 'UnsafeMutablePointer<_IO_FILE>')
109 |         XCTAssertNotNil(tempFile, "tmpfile() failed: \(errno)")
110 | 
111 |         let fildes = fileno(tempFile)
    |                             |- error: value of optional type 'UnsafeMutablePointer<FILE>?' (aka 'Optional<UnsafeMutablePointer<_IO_FILE>>') must be unwrapped to a value of type 'UnsafeMutablePointer<FILE>' (aka 'UnsafeMutablePointer<_IO_FILE>')
    |                             |- note: coalesce using '??' to provide a default when the optional value contains 'nil'
    |                             `- note: force-unwrap using '!' to abort execution if the optional value contains 'nil'
112 | 
113 |         var stat = stat()
```
