### PR TITLE
fix(minor): Make setup/teardown hooks Swift 6 usable

### DIFF
--- a/.github/workflows/swift-macos-previous.yml
+++ b/.github/workflows/swift-macos-previous.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15]
+        os: [macos-14]
         swift: ["5.9", "5.10"]
 
     runs-on: ${{ matrix.os }}
@@ -49,3 +49,6 @@ jobs:
         if [ -d Tests ]; then
           swift test -c release --parallel
         fi
+    - name: Setup tmate session
+      if: failure()
+      uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/swift-macos-previous.yml
+++ b/.github/workflows/swift-macos-previous.yml
@@ -14,14 +14,19 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-14]
-        swift: ["5.9", "5.10"]
+        xcode: ["15.2", "15.3"]
+        #swift: ["5.9", "5.10"]
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: swift-actions/setup-swift@v2
+      if: ${{ false }}
       with:
         swift-version: ${{ matrix.swift }}
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ matrix.xcode }}
 
     - name: Homebrew Mac
       if: ${{ runner.os == 'Macos' }}

--- a/.github/workflows/swift-macos-previous.yml
+++ b/.github/workflows/swift-macos-previous.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14]
+        os: [macos-15]
         swift: ["5.9", "5.10"]
 
     runs-on: ${{ matrix.os }}

--- a/Benchmarks/Benchmarks/Basic/Basic+SetupTeardown.swift
+++ b/Benchmarks/Benchmarks/Basic/Basic+SetupTeardown.swift
@@ -18,9 +18,9 @@ func sharedTeardown() {
 }
 
 func testSetUpTearDown() {
-    //    Benchmark.setup = { print("Global setup hook")}
+//    Benchmark.setup = { print("Global setup hook")}
 //        Benchmark.setup = { 123 }
-    //    Benchmark.teardown = { print("Global teardown hook") }
+//    Benchmark.teardown = { print("Global teardown hook") }
 
     Benchmark("SetupTeardown",
               configuration: .init(setup: sharedSetup, teardown: sharedTeardown)) { _ in

--- a/Benchmarks/Benchmarks/Basic/BenchmarkRunner+Basic.swift
+++ b/Benchmarks/Benchmarks/Basic/BenchmarkRunner+Basic.swift
@@ -21,22 +21,10 @@ import Glibc
 // quiet swiftlint for now
 extension BenchmarkRunner {}
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     var thresholdTolerances: [BenchmarkMetric: BenchmarkThresholds]
 
-    if Benchmark.checkAbsoluteThresholds {
-        let absolute: BenchmarkThresholds.AbsoluteThresholds = [.p0: .microseconds(1),
-                                                                .p25: .microseconds(1),
-                                                                .p50: .microseconds(2_500),
-                                                                .p75: .microseconds(1),
-                                                                .p90: .microseconds(2),
-                                                                .p99: .milliseconds(3),
-                                                                .p100: .milliseconds(1)]
-
-        thresholdTolerances = [.wallClock: .init(absolute: absolute)]
-    } else {
-        thresholdTolerances = [.wallClock: .relaxed]
-    }
+    thresholdTolerances = [.wallClock: .relaxed]
 
     Benchmark.defaultConfiguration = .init(warmupIterations: 0,
                                            maxDuration: .seconds(1),

--- a/Benchmarks/Benchmarks/DateTime/DateTime.swift
+++ b/Benchmarks/Benchmarks/DateTime/DateTime.swift
@@ -10,7 +10,7 @@
 import Benchmark
 import DateTime
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     Benchmark.defaultConfiguration = .init(metrics: [.throughput, .wallClock, .instructions] + .arc,
                                            warmupIterations: 10,
                                            scalingFactor: .kilo,

--- a/Benchmarks/Benchmarks/Histogram/Histogram.swift
+++ b/Benchmarks/Benchmarks/Histogram/Histogram.swift
@@ -10,7 +10,7 @@
 import Benchmark
 import Histogram
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     let metrics: [BenchmarkMetric] = [
         .wallClock,
         .throughput,

--- a/Benchmarks/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
+++ b/Benchmarks/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
@@ -18,7 +18,7 @@ import Foundation
     #error("Unsupported Platform")
 #endif
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     var thresholdTolerances: [BenchmarkMetric: BenchmarkThresholds]
     let relative: BenchmarkThresholds.RelativeThresholds = [.p25: 25.0, .p50: 50.0, .p75: 75.0, .p90: 100.0, .p99: 101.0, .p100: 201.0]
     let absolute: BenchmarkThresholds.AbsoluteThresholds = [.p75: 999, .p90: 1_000, .p99: 1_001, .p100: 2_001]

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 
 import class Foundation.ProcessInfo
 import PackageDescription
@@ -8,7 +8,7 @@ let disableJemalloc = ProcessInfo.processInfo.environment["BENCHMARK_DISABLE_JEM
 
 let package = Package(
     name: "Benchmarks",
-    platforms: [.macOS(.v14), .iOS(.v17)],
+    platforms: [.macOS(.v15), .iOS(.v17)],
     dependencies: [
         .package(path: "../"),
         .package(url: "https://github.com/ordo-one/package-datetime", .upToNextMajor(from: "1.0.1")),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 5.9
 
 import class Foundation.ProcessInfo
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.10
 
 import class Foundation.ProcessInfo
 import PackageDescription

--- a/Plugins/BenchmarkCommandPlugin/Command+Helpers.swift
+++ b/Plugins/BenchmarkCommandPlugin/Command+Helpers.swift
@@ -51,9 +51,7 @@ public enum Grouping: String, CaseIterable {
     case benchmark
 }
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 public enum TimeUnits: String, CaseIterable {
     case nanoseconds
     case microseconds

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ There are [documentation available](https://swiftpackageindex.com/ordo-one/packa
 ```swift
 import Benchmark
 
-let benchmarks = {
+let benchmarks : @Sendable () -> Void = {
     Benchmark("Minimal benchmark") { benchmark in
       // measure something here
     }
@@ -159,6 +159,14 @@ Using [jmh.morethan.io](https://jmh.morethan.io)
 
 <img width="1482" alt="image" src="https://user-images.githubusercontent.com/8501048/225313559-33014755-797f-4ddf-b536-24c1a618f271.png">
 
+## Swift 6 support
+The package supports Swift 6.0 benchmark targets as well as Swift 5.10 targets (for Swift 5.9 support, need to use version 1.28.0 exactly).
+
+For Swift 6 targets, use the following signature for the benchmarks closure:
+```swift
+let benchmarks : @Sendable () -> Void = {
+```
+
 ## Output
 
 The default text output from Benchmark is oriented around [the five-number summary](https://en.wikipedia.org/wiki/Five-number_summary) percentiles, plus the last decile (`p90`) and the last percentile (`p99`) - it's thus a variation of a [seven-figure summary](https://en.wikipedia.org/wiki/Seven-number_summary) with the focus on the 'bad' end of results (as those are what we typically care about addressing).
@@ -167,16 +175,6 @@ Percentiles allows for a consistent way of expressing benchmark results of both 
 This multi-modal nature of the latency measurements leads to the common statistical measures of mean and standard deviation being potentially misleading.
 
 Please see the [documentation for further details on percentiles](https://swiftpackageindex.com/ordo-one/package-benchmark/documentation/benchmark/aboutpercentiles).
-
-## Swift 6 support
-The package will be updated to be fully Swift 6 when 5.x support is dropped (planned to be when Swift 6.2 is released).
-
-Workaround needed for Swift 6 targets, use the following signature for the benchmarks closure:
-```swift
-let benchmarks : @Sendable () -> Void = {
-```
-
-See https://github.com/ordo-one/package-benchmark/issues/258 for more details.
 
 ## API and file format stability
 The API will be deemed stable as of `1.0.0` and follows semantical versioning for future releases. 

--- a/Sources/Benchmark/ARCStats/ARCStats.swift
+++ b/Sources/Benchmark/ARCStats/ARCStats.swift
@@ -9,10 +9,7 @@
 //
 
 /// The ARC stats the ARCStatsProducer can provide
-#if swift(>=5.8)
-    @_documentation(visibility: internal)
-#endif
-
+@_documentation(visibility: internal)
 struct ARCStats {
     var objectAllocCount: Int = 0 /// total number allocations, implicit retain
     var retainCount: Int = 0 /// total number retains

--- a/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
+++ b/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
@@ -6,6 +6,8 @@ public extension Benchmark {
     ///   - configuration: Defines the settings that should be used for this benchmark
     ///   - closure: The actual benchmark closure that will be measured, this one takes one additional parameter
     ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
+    ///   - setup: A closure that will be run once before the benchmark iterations are run
+    ///   - teardown: A closure that will be run once after the benchmark iterations are done
     @discardableResult
     convenience init?<SetupResult>(_ name: String,
                                    configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
@@ -31,6 +33,8 @@ public extension Benchmark {
     ///   - configuration: Defines the settings that should be used for this benchmark
     ///   - closure: The actual `async` benchmark closure that will be measured, this one takes one additional parameter
     ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
+    ///   - setup: A closure that will be run once before the benchmark iterations are run
+    ///   - teardown: A closure that will be run once after the benchmark iterations are done
     @discardableResult
     convenience init?<SetupResult>(_ name: String,
                                    configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
@@ -56,6 +60,8 @@ public extension Benchmark {
     ///   - configuration: Defines the settings that should be used for this benchmark
     ///   - closure: The actual throwing benchmark closure that will be measured, this one takes one additional parameter
     ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
+    ///   - setup: A closure that will be run once before the benchmark iterations are run
+    ///   - teardown: A closure that will be run once after the benchmark iterations are done
     @discardableResult
     convenience init?<SetupResult>(_ name: String,
                                    configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
@@ -83,6 +89,8 @@ public extension Benchmark {
     ///   - configuration: Defines the settings that should be used for this benchmark
     ///   - closure: The actual async throwing benchmark closure that will be measured, this one takes one additional parameter
     ///   apart from the benchmark instance, which is the generic SetupResult type returned from the setup
+    ///   - setup: A closure that will be run once before the benchmark iterations are run
+    ///   - teardown: A closure that will be run once after the benchmark iterations are done
     @discardableResult
     convenience init?<SetupResult>(_ name: String,
                                    configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -49,6 +49,31 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     @ThreadSafeProperty(wrappedValue: nil, lock: setupTeardownLock)
     public static var _teardown: BenchmarkTeardownHook?
 
+#if swift(<5.10)
+    @_documentation(visibility: internal)
+    public static var startupHook: BenchmarkSetupHook? {
+        get { _startupHook  }
+        set { _startupHook = newValue }
+    }
+    
+    @_documentation(visibility: internal)
+    public static var shutdownHook: BenchmarkTeardownHook? {
+        get { _shutdownHook  }
+        set { _shutdownHook = newValue }
+    }
+
+    /// This closure if set, will be run before a targets benchmarks are run, but after they are registered
+    public static var setup: BenchmarkSetupHook? {
+        get { _setup  }
+        set { _setup = newValue }
+    }
+
+    /// This closure if set, will be run after a targets benchmarks run, but after they are registered
+    public static var teardown: BenchmarkTeardownHook? {
+        get { _teardown  }
+        set { _teardown = newValue }
+    }
+#elseif swift(>=5.10)
     @_documentation(visibility: internal)
     nonisolated(unsafe)
     public static var startupHook: BenchmarkSetupHook? {
@@ -76,6 +101,7 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
         get { _teardown  }
         set { _teardown = newValue }
     }
+#endif
 
     /// Set to true if this benchmark results should be compared with an absolute threshold when `--check-absolute` is
     /// specified on the command line. An implementation can then choose to configure thresholds differently for
@@ -160,11 +186,18 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
                                             thresholds: nil), lock: configurationLock)
     private static var _defaultConfiguration: Configuration
 
+#if swift(<5.10)
+    public static var defaultConfiguration: Configuration {
+        get { _defaultConfiguration  }
+        set { _defaultConfiguration = newValue }
+    }
+#elseif swift(>=5.10)
     nonisolated(unsafe)
     public static var defaultConfiguration: Configuration {
         get { _defaultConfiguration  }
         set { _defaultConfiguration = newValue }
     }
+#endif
 
     static var testSkipBenchmarkRegistrations = false // true in test to avoid bench registration fail
     var measurementCompleted = false // Keep track so we skip multiple 'end of measurement'

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -13,7 +13,7 @@ import Foundation
 // swiftlint:disable file_length identifier_name
 
 /// Defines a benchmark
-public final class Benchmark: Codable, Hashable {
+public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type_body_length
     #if swift(>=5.8)
         @_documentation(visibility: internal)
     #endif

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -14,29 +14,17 @@ import Foundation
 
 /// Defines a benchmark
 public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type_body_length
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     public typealias BenchmarkClosure = (_ benchmark: Benchmark) -> Void
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     public typealias BenchmarkAsyncClosure = (_ benchmark: Benchmark) async -> Void
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     public typealias BenchmarkThrowingClosure = (_ benchmark: Benchmark) throws -> Void
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     public typealias BenchmarkAsyncThrowingClosure = (_ benchmark: Benchmark) async throws -> Void
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     public typealias BenchmarkMeasurementSynchronization = (_ explicitStartStop: Bool) -> Void
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     public typealias BenchmarkCustomMetricMeasurement = (BenchmarkMetric, Int) -> Void
 
     /// Alias for closures used to hook into setup / teardown
@@ -45,41 +33,29 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
 
     private static let setupTeardownLock = NSLock()
 
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     @ThreadSafeProperty(wrappedValue: nil, lock: setupTeardownLock)
     public static var _startupHook: BenchmarkSetupHook? // Should be removed when going to 2.0, just kept for API compatiblity
 
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     @ThreadSafeProperty(wrappedValue: nil, lock: setupTeardownLock)
     public static var _shutdownHook: BenchmarkTeardownHook? // Should be removed when going to 2.0, just kept for API compatiblity
 
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     @ThreadSafeProperty(wrappedValue: nil, lock: setupTeardownLock)
     public static var _setup: BenchmarkSetupHook?
 
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     @ThreadSafeProperty(wrappedValue: nil, lock: setupTeardownLock)
     public static var _teardown: BenchmarkTeardownHook?
 
 #if swift(<5.10)
-#if swift(>=5.8)
     @_documentation(visibility: internal)
-#endif
     public static var startupHook: BenchmarkSetupHook? {
         get { _startupHook  }
         set { _startupHook = newValue }
     }
-#if swift(>=5.8)
     @_documentation(visibility: internal)
-#endif
     public static var shutdownHook: BenchmarkTeardownHook? {
         get { _shutdownHook  }
         set { _shutdownHook = newValue }
@@ -99,18 +75,14 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
 #endif
 
 #if swift(>=5.10)
-#if swift(>=5.8)
     @_documentation(visibility: internal)
-#endif
     nonisolated(unsafe)
     public static var startupHook: BenchmarkSetupHook? {
         get { _startupHook  }
         set { _startupHook = newValue }
     }
 
-#if swift(>=5.8)
     @_documentation(visibility: internal)
-#endif
     nonisolated(unsafe)
     public static var shutdownHook: BenchmarkTeardownHook? {
         get { _shutdownHook  }
@@ -138,9 +110,7 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     @available(*, deprecated, message: "The checking of absolute thresholds should now be done using `swift package benchmark thresholds`")
     public static var checkAbsoluteThresholds = false
 
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     public static var benchmarks: [Benchmark] = [] // Bookkeeping of all registered benchmarks
 
     /// The name of the benchmark without any of the tags appended
@@ -176,13 +146,9 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     public var scaledIterations: Range<Int> { 0 ..< configuration.scalingFactor.rawValue }
 
     /// Some internal state for display purposes of the benchmark by the BenchmarkTool
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     public var target: String
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     public var executablePath: String?
     /// closure: The actual benchmark closure that will be measured
     var closure: BenchmarkClosure? // The actual benchmark to run
@@ -196,13 +162,9 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     public var setupState: Any?
 
     // Hooks for benchmark infrastructure to capture metrics of actual measurement() block without preamble:
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     public var measurementPreSynchronization: BenchmarkMeasurementSynchronization?
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     public var measurementPostSynchronization: BenchmarkMeasurementSynchronization?
 
     // Hook for custom metrics capturing
@@ -251,16 +213,12 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
         case failureReason
     }
 
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     public func hash(into hasher: inout Hasher) {
         hasher.combine(name)
     }
 
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     public static func == (lhs: Benchmark, rhs: Benchmark) -> Bool {
         lhs.name == rhs.name
     }
@@ -271,6 +229,8 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     ///   matching when comparing to baselines)
     ///   - configuration: Defines the settings that should be used for this benchmark
     ///   - closure: The actual benchmark closure that will be measured
+    ///   - setup: A closure that will be run once before the benchmark iterations are run
+    ///   - teardown: A closure that will be run once after the benchmark iterations are done
     @discardableResult
     public init?(_ name: String,
                  configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
@@ -296,6 +256,8 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     ///   matching when comparing to baselines)
     ///   - configuration: Defines the settings that should be used for this benchmark
     ///   - closure: The actual `async` benchmark closure that will be measured
+    ///   - setup: A closure that will be run once before the benchmark iterations are run
+    ///   - teardown: A closure that will be run once after the benchmark iterations are done
     @discardableResult
     public init?(_ name: String,
                  configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
@@ -321,6 +283,8 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     ///   matching when comparing to baselines)
     ///   - configuration: Defines the settings that should be used for this benchmark
     ///   - closure: The actual throwing benchmark closure that will be measured
+    ///   - setup: A closure that will be run once before the benchmark iterations are run
+    ///   - teardown: A closure that will be run once after the benchmark iterations are done
     @discardableResult
     public convenience init?(_ name: String,
                              configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
@@ -342,6 +306,8 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     ///   matching when comparing to baselines)
     ///   - configuration: Defines the settings that should be used for this benchmark
     ///   - closure: The actual async throwing benchmark closure that will be measured
+    ///   - setup: A closure that will be run once before the benchmark iterations are run
+    ///   - teardown: A closure that will be run once after the benchmark iterations are done
     @discardableResult
     public convenience init?(_ name: String,
                              configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
@@ -456,9 +422,7 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     }
 
     // Public but should only be used by BenchmarkRunner
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     public func run() {
         if let closure {
             _startMeasurement(false)

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -10,10 +10,10 @@
 
 import Dispatch
 import Foundation
-// swiftlint:disable file_length
+// swiftlint:disable file_length identifier_name
 
 /// Defines a benchmark
-public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type_body_length
+public final class Benchmark: Codable, Hashable {
     #if swift(>=5.8)
         @_documentation(visibility: internal)
     #endif
@@ -43,7 +43,6 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     public typealias BenchmarkSetupHook = () async throws -> Void
     public typealias BenchmarkTeardownHook = () async throws -> Void
 
-
     private static let setupTeardownLock = NSLock()
 
     #if swift(>=5.8)
@@ -69,7 +68,6 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     #endif
     @ThreadSafeProperty(wrappedValue: nil, lock: setupTeardownLock)
     public static var _teardown: BenchmarkTeardownHook?
-
 
 #if swift(<5.10)
 #if swift(>=5.8)
@@ -572,8 +570,6 @@ public extension Benchmark {
     @_optimize(none) // Used after tip here: https://forums.swift.org/t/compiler-swallows-blackhole/64305/10 - see also https://github.com/apple/swift/commit/1fceeab71e79dc96f1b6f560bf745b016d7fcdcf
     static func blackHole(_: some Any) {}
 }
-// swiftlint:enable file_length
-
 
 // Wrapper for static properties for Swift 6 mode compatibility
 @propertyWrapper
@@ -599,3 +595,5 @@ public struct ThreadSafeProperty<T> {
         }
     }
 }
+
+// swiftlint:enable file_length identifier_name

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -49,12 +49,13 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     @ThreadSafeProperty(wrappedValue: nil, lock: setupTeardownLock)
     public static var _teardown: BenchmarkTeardownHook?
 
-#if swift(<5.10)
+//#if swift(<5.10)
     @_documentation(visibility: internal)
     public static var startupHook: BenchmarkSetupHook? {
         get { _startupHook  }
         set { _startupHook = newValue }
     }
+
     @_documentation(visibility: internal)
     public static var shutdownHook: BenchmarkTeardownHook? {
         get { _shutdownHook  }
@@ -72,35 +73,35 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
         get { _teardown  }
         set { _teardown = newValue }
     }
-#elseif swift(>=5.10)
-    @_documentation(visibility: internal)
-    nonisolated(unsafe)
-    public static var startupHook: BenchmarkSetupHook? {
-        get { _startupHook  }
-        set { _startupHook = newValue }
-    }
-
-    @_documentation(visibility: internal)
-    nonisolated(unsafe)
-    public static var shutdownHook: BenchmarkTeardownHook? {
-        get { _shutdownHook  }
-        set { _shutdownHook = newValue }
-    }
-
-    /// This closure if set, will be run before a targets benchmarks are run, but after they are registered
-    nonisolated(unsafe)
-    public static var setup: BenchmarkSetupHook? {
-        get { _setup  }
-        set { _setup = newValue }
-    }
-
-    /// This closure if set, will be run after a targets benchmarks run, but after they are registered
-    nonisolated(unsafe)
-    public static var teardown: BenchmarkTeardownHook? {
-        get { _teardown  }
-        set { _teardown = newValue }
-    }
-#endif
+//#elseif swift(>=5.10)
+//    @_documentation(visibility: internal)
+//    nonisolated(unsafe)
+//    public static var startupHook: BenchmarkSetupHook? {
+//        get { _startupHook  }
+//        set { _startupHook = newValue }
+//    }
+//
+//    @_documentation(visibility: internal)
+//    nonisolated(unsafe)
+//    public static var shutdownHook: BenchmarkTeardownHook? {
+//        get { _shutdownHook  }
+//        set { _shutdownHook = newValue }
+//    }
+//
+//    /// This closure if set, will be run before a targets benchmarks are run, but after they are registered
+//    nonisolated(unsafe)
+//    public static var setup: BenchmarkSetupHook? {
+//        get { _setup  }
+//        set { _setup = newValue }
+//    }
+//
+//    /// This closure if set, will be run after a targets benchmarks run, but after they are registered
+//    nonisolated(unsafe)
+//    public static var teardown: BenchmarkTeardownHook? {
+//        get { _teardown  }
+//        set { _teardown = newValue }
+//    }
+//#endif
 
     /// Set to true if this benchmark results should be compared with an absolute threshold when `--check-absolute` is
     /// specified on the command line. An implementation can then choose to configure thresholds differently for
@@ -185,18 +186,18 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
                                             thresholds: nil), lock: configurationLock)
     private static var _defaultConfiguration: Configuration
 
-#if swift(<5.10)
+// #if swift(<5.10)
     public static var defaultConfiguration: Configuration {
         get { _defaultConfiguration  }
         set { _defaultConfiguration = newValue }
     }
-#elseif swift(>=5.10)
-    nonisolated(unsafe)
-    public static var defaultConfiguration: Configuration {
-        get { _defaultConfiguration  }
-        set { _defaultConfiguration = newValue }
-    }
-#endif
+//#elseif swift(>=5.10)
+//    nonisolated(unsafe)
+//    public static var defaultConfiguration: Configuration {
+//        get { _defaultConfiguration  }
+//        set { _defaultConfiguration = newValue }
+//    }
+//#endif
 
     static var testSkipBenchmarkRegistrations = false // true in test to avoid bench registration fail
     var measurementCompleted = false // Keep track so we skip multiple 'end of measurement'

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -49,13 +49,14 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     @ThreadSafeProperty(wrappedValue: nil, lock: setupTeardownLock)
     public static var _teardown: BenchmarkTeardownHook?
 
-//#if swift(<5.10)
+#if swift(<5.10)
+#warning("Taking 5.9 PATH")
     @_documentation(visibility: internal)
     public static var startupHook: BenchmarkSetupHook? {
         get { _startupHook  }
         set { _startupHook = newValue }
     }
-
+    
     @_documentation(visibility: internal)
     public static var shutdownHook: BenchmarkTeardownHook? {
         get { _shutdownHook  }
@@ -73,35 +74,36 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
         get { _teardown  }
         set { _teardown = newValue }
     }
-//#elseif swift(>=5.10)
-//    @_documentation(visibility: internal)
-//    nonisolated(unsafe)
-//    public static var startupHook: BenchmarkSetupHook? {
-//        get { _startupHook  }
-//        set { _startupHook = newValue }
-//    }
-//
-//    @_documentation(visibility: internal)
-//    nonisolated(unsafe)
-//    public static var shutdownHook: BenchmarkTeardownHook? {
-//        get { _shutdownHook  }
-//        set { _shutdownHook = newValue }
-//    }
-//
-//    /// This closure if set, will be run before a targets benchmarks are run, but after they are registered
-//    nonisolated(unsafe)
-//    public static var setup: BenchmarkSetupHook? {
-//        get { _setup  }
-//        set { _setup = newValue }
-//    }
-//
-//    /// This closure if set, will be run after a targets benchmarks run, but after they are registered
-//    nonisolated(unsafe)
-//    public static var teardown: BenchmarkTeardownHook? {
-//        get { _teardown  }
-//        set { _teardown = newValue }
-//    }
-//#endif
+#elseif swift(>=5.10)
+    #warning("Taking 5.10+ PATH")
+    @_documentation(visibility: internal)
+    nonisolated(unsafe)
+    public static var startupHook: BenchmarkSetupHook? {
+        get { _startupHook  }
+        set { _startupHook = newValue }
+    }
+
+    @_documentation(visibility: internal)
+    nonisolated(unsafe)
+    public static var shutdownHook: BenchmarkTeardownHook? {
+        get { _shutdownHook  }
+        set { _shutdownHook = newValue }
+    }
+
+    /// This closure if set, will be run before a targets benchmarks are run, but after they are registered
+    nonisolated(unsafe)
+    public static var setup: BenchmarkSetupHook? {
+        get { _setup  }
+        set { _setup = newValue }
+    }
+
+    /// This closure if set, will be run after a targets benchmarks run, but after they are registered
+    nonisolated(unsafe)
+    public static var teardown: BenchmarkTeardownHook? {
+        get { _teardown  }
+        set { _teardown = newValue }
+    }
+#endif
 
     /// Set to true if this benchmark results should be compared with an absolute threshold when `--check-absolute` is
     /// specified on the command line. An implementation can then choose to configure thresholds differently for
@@ -186,18 +188,18 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
                                             thresholds: nil), lock: configurationLock)
     private static var _defaultConfiguration: Configuration
 
-// #if swift(<5.10)
+#if swift(<5.10)
     public static var defaultConfiguration: Configuration {
         get { _defaultConfiguration  }
         set { _defaultConfiguration = newValue }
     }
-//#elseif swift(>=5.10)
-//    nonisolated(unsafe)
-//    public static var defaultConfiguration: Configuration {
-//        get { _defaultConfiguration  }
-//        set { _defaultConfiguration = newValue }
-//    }
-//#endif
+#elseif swift(>=5.10)
+    nonisolated(unsafe)
+    public static var defaultConfiguration: Configuration {
+        get { _defaultConfiguration  }
+        set { _defaultConfiguration = newValue }
+    }
+#endif
 
     static var testSkipBenchmarkRegistrations = false // true in test to avoid bench registration fail
     var measurementCompleted = false // Keep track so we skip multiple 'end of measurement'

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -72,11 +72,17 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
 
 
 #if swift(<5.10)
+#if swift(>=5.8)
+    @_documentation(visibility: internal)
+#endif
     public static var startupHook: BenchmarkSetupHook? {
         get { _startupHook  }
         set { _startupHook = newValue }
     }
-    public static var shutdownHook: BenchmarkSetupHook? {
+#if swift(>=5.8)
+    @_documentation(visibility: internal)
+#endif
+    public static var shutdownHook: BenchmarkTeardownHook? {
         get { _shutdownHook  }
         set { _shutdownHook = newValue }
     }
@@ -88,21 +94,27 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     }
 
     /// This closure if set, will be run after a targets benchmarks run, but after they are registered
-    public static var teardown: BenchmarkSetupHook? {
+    public static var teardown: BenchmarkTeardownHook? {
         get { _teardown  }
         set { _teardown = newValue }
     }
 #endif
 
 #if swift(>=5.10)
+#if swift(>=5.8)
+    @_documentation(visibility: internal)
+#endif
     nonisolated(unsafe)
     public static var startupHook: BenchmarkSetupHook? {
         get { _startupHook  }
         set { _startupHook = newValue }
     }
 
+#if swift(>=5.8)
+    @_documentation(visibility: internal)
+#endif
     nonisolated(unsafe)
-    public static var shutdownHook: BenchmarkSetupHook? {
+    public static var shutdownHook: BenchmarkTeardownHook? {
         get { _shutdownHook  }
         set { _shutdownHook = newValue }
     }
@@ -116,7 +128,7 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
 
     /// This closure if set, will be run after a targets benchmarks run, but after they are registered
     nonisolated(unsafe)
-    public static var teardown: BenchmarkSetupHook? {
+    public static var teardown: BenchmarkTeardownHook? {
         get { _teardown  }
         set { _teardown = newValue }
     }

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -72,9 +72,7 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
         get { _teardown  }
         set { _teardown = newValue }
     }
-#endif
-
-#if swift(>=5.10)
+#elseif swift(>=5.10)
     @_documentation(visibility: internal)
     nonisolated(unsafe)
     public static var startupHook: BenchmarkSetupHook? {
@@ -192,9 +190,7 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
         get { _defaultConfiguration  }
         set { _defaultConfiguration = newValue }
     }
-#endif
-
-#if swift(>=5.10)
+#elseif swift(>=5.10)
     nonisolated(unsafe)
     public static var defaultConfiguration: Configuration {
         get { _defaultConfiguration  }

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -49,33 +49,6 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     @ThreadSafeProperty(wrappedValue: nil, lock: setupTeardownLock)
     public static var _teardown: BenchmarkTeardownHook?
 
-#if swift(<5.10)
-#warning("Taking 5.9 PATH")
-    @_documentation(visibility: internal)
-    public static var startupHook: BenchmarkSetupHook? {
-        get { _startupHook  }
-        set { _startupHook = newValue }
-    }
-    
-    @_documentation(visibility: internal)
-    public static var shutdownHook: BenchmarkTeardownHook? {
-        get { _shutdownHook  }
-        set { _shutdownHook = newValue }
-    }
-
-    /// This closure if set, will be run before a targets benchmarks are run, but after they are registered
-    public static var setup: BenchmarkSetupHook? {
-        get { _setup  }
-        set { _setup = newValue }
-    }
-
-    /// This closure if set, will be run after a targets benchmarks run, but after they are registered
-    public static var teardown: BenchmarkTeardownHook? {
-        get { _teardown  }
-        set { _teardown = newValue }
-    }
-#elseif swift(>=5.10)
-    #warning("Taking 5.10+ PATH")
     @_documentation(visibility: internal)
     nonisolated(unsafe)
     public static var startupHook: BenchmarkSetupHook? {
@@ -103,7 +76,6 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
         get { _teardown  }
         set { _teardown = newValue }
     }
-#endif
 
     /// Set to true if this benchmark results should be compared with an absolute threshold when `--check-absolute` is
     /// specified on the command line. An implementation can then choose to configure thresholds differently for
@@ -188,18 +160,11 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
                                             thresholds: nil), lock: configurationLock)
     private static var _defaultConfiguration: Configuration
 
-#if swift(<5.10)
-    public static var defaultConfiguration: Configuration {
-        get { _defaultConfiguration  }
-        set { _defaultConfiguration = newValue }
-    }
-#elseif swift(>=5.10)
     nonisolated(unsafe)
     public static var defaultConfiguration: Configuration {
         get { _defaultConfiguration  }
         set { _defaultConfiguration = newValue }
     }
-#endif
 
     static var testSkipBenchmarkRegistrations = false // true in test to avoid bench registration fail
     var measurementCompleted = false // Keep track so we skip multiple 'end of measurement'

--- a/Sources/Benchmark/BenchmarkClock.swift
+++ b/Sources/Benchmark/BenchmarkClock.swift
@@ -22,9 +22,7 @@ import Glibc
 #error("Unsupported Platform")
 #endif
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 public struct BenchmarkClock {
     /// A continuous point in time used for `BenchmarkClock`.
     public struct Instant: Codable, Sendable {
@@ -38,9 +36,7 @@ public struct BenchmarkClock {
     public init() {}
 }
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 public extension Clock where Self == BenchmarkClock {
     /// A clock that measures time that always increments but does not stop
     /// incrementing while the system is asleep.
@@ -50,9 +46,7 @@ public extension Clock where Self == BenchmarkClock {
     static var internalUTC: BenchmarkClock { BenchmarkClock() }
 }
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 extension BenchmarkClock: Clock {
     /// The current continuous instant.
     public var now: BenchmarkClock.Instant {
@@ -123,9 +117,7 @@ extension BenchmarkClock: Clock {
     }
 }
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 extension BenchmarkClock.Instant: InstantProtocol {
     public static var now: BenchmarkClock.Instant { BenchmarkClock.now }
 
@@ -189,9 +181,7 @@ extension BenchmarkClock.Instant: InstantProtocol {
     }
 }
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 public extension Duration {
     func nanoseconds() -> Int64 {
         (components.seconds * 1_000_000_000) + (components.attoseconds / 1_000_000_000)

--- a/Sources/Benchmark/BenchmarkInternals.swift
+++ b/Sources/Benchmark/BenchmarkInternals.swift
@@ -13,10 +13,7 @@
 
 // Command sent from benchmark runner to the benchmark under measurement
 
-#if swift(>=5.8)
-    @_documentation(visibility: internal)
-#endif
-/// Internal type that will be hidden from documentation when upgrading doc generation to Swift 5.8+
+@_documentation(visibility: internal)
 public enum BenchmarkCommandRequest: Codable {
     case list
     case run(benchmark: Benchmark)
@@ -24,10 +21,7 @@ public enum BenchmarkCommandRequest: Codable {
 }
 
 // Replies from benchmark under measure to benchmark runner
-#if swift(>=5.8)
-    @_documentation(visibility: internal)
-#endif
-/// Internal type that will be hidden from documentation when upgrading doc generation to Swift 5.8+
+@_documentation(visibility: internal)
 public enum BenchmarkCommandReply: Codable {
     case list(benchmark: Benchmark)
     case ready

--- a/Sources/Benchmark/BenchmarkMetric.swift
+++ b/Sources/Benchmark/BenchmarkMetric.swift
@@ -76,20 +76,14 @@ public enum BenchmarkMetric: Hashable, Equatable, Codable, CustomStringConvertib
     case custom(_ name: String, polarity: Polarity = .prefersSmaller, useScalingFactor: Bool = true)
 
     /// Used internally as placeholders for formatting deltas in an easy way, please don't use
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     case delta
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     case deltaPercentage
 }
 
 // We don't want to take polarity and useScalingFactor into consideration as it makes dealing with custom metrics hard
-#if swift(>=5.8)
-    @_documentation(visibility: internal)
-#endif
+@_documentation(visibility: internal)
 public extension BenchmarkMetric {
     func hash(into hasher: inout Hasher) {
         hasher.combine(description)
@@ -225,9 +219,7 @@ public extension BenchmarkMetric {
     }
 
     // Used by the Benchmark Executor for efficient indexing into results
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     var index: Int {
         switch self {
         case .cpuUser:
@@ -291,15 +283,11 @@ public extension BenchmarkMetric {
         }
     }
 
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     static var maxIndex: Int { 28} //
 
     // Used by the Benchmark Executor for efficient indexing into results
-    #if swift(>=5.8)
-        @_documentation(visibility: internal)
-    #endif
+    @_documentation(visibility: internal)
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     func metricFor(index: Int) -> BenchmarkMetric {
         switch index {
@@ -366,9 +354,7 @@ public extension BenchmarkMetric {
     }
 }
 
-#if swift(>=5.8)
-    @_documentation(visibility: internal)
-#endif
+@_documentation(visibility: internal)
 public extension BenchmarkMetric {
     var rawDescription: String { // As we can't have raw values due to custom support, we do this...
         switch self {
@@ -440,9 +426,7 @@ public extension BenchmarkMetric {
 
 // swiftlint:disable cyclomatic_complexity function_body_length
 // As we can't have raw values and associated data we add this...
-#if swift(>=5.8)
-    @_documentation(visibility: internal)
-#endif
+@_documentation(visibility: internal)
 public extension BenchmarkMetric {
     init?(argument: String) {
         switch argument {

--- a/Sources/Benchmark/BenchmarkMetric.swift
+++ b/Sources/Benchmark/BenchmarkMetric.swift
@@ -288,8 +288,7 @@ public extension BenchmarkMetric {
 
     // Used by the Benchmark Executor for efficient indexing into results
     @_documentation(visibility: internal)
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
-    func metricFor(index: Int) -> BenchmarkMetric {
+    func metricFor(index: Int) -> BenchmarkMetric { // swiftlint:disable:this cyclomatic_complexity function_body_length
         switch index {
         case 1:
             return .cpuUser

--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -10,9 +10,7 @@
 
 // swiftlint: disable file_length identifier_name
 
-#if swift(>=5.8)
-    @_documentation(visibility: internal)
-#endif
+@_documentation(visibility: internal)
 public extension BenchmarkResult {
     enum Percentile: Int, Codable {
         case p0 = 0
@@ -223,10 +221,7 @@ public extension BenchmarkScalingFactor {
 
 // swiftlint:disable type_body_length
 
-#if swift(>=5.8)
-    @_documentation(visibility: internal)
-#endif
-/// Internal type that will be hidden from documentation when upgrading doc generation to Swift 5.8+
+@_documentation(visibility: internal)
 public struct BenchmarkResult: Codable, Comparable, Equatable {
     public init(metric: BenchmarkMetric,
                 timeUnits: BenchmarkTimeUnits,

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -23,7 +23,6 @@ import Shared
 extension TimeUnits: ExpressibleByArgument {}
 
 @_documentation(visibility: internal)
-/// Internal type that will be hidden from documentation when upgrading doc generation to Swift 5.8+
 public protocol BenchmarkRunnerHooks {
     static func main() async
     static func registerBenchmarks()
@@ -37,7 +36,6 @@ public extension BenchmarkRunnerHooks {
 }
 
 @_documentation(visibility: internal)
-/// Internal type that will be hidden from documentation when upgrading doc generation to Swift 5.8+
 public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
     static var testReadWrite: BenchmarkRunnerReadWrite?
 

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -19,32 +19,24 @@
 import ArgumentParser
 import Shared
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 extension TimeUnits: ExpressibleByArgument {}
 
-#if swift(>=5.8)
-    @_documentation(visibility: internal)
-#endif
+@_documentation(visibility: internal)
 /// Internal type that will be hidden from documentation when upgrading doc generation to Swift 5.8+
 public protocol BenchmarkRunnerHooks {
     static func main() async
     static func registerBenchmarks()
 }
 
-#if swift(>=5.8)
-    @_documentation(visibility: internal)
-#endif
+@_documentation(visibility: internal)
 public extension BenchmarkRunnerHooks {
     static func main() async {
         await BenchmarkRunner.setupBenchmarkRunner(registerBenchmarks: registerBenchmarks)
     }
 }
 
-#if swift(>=5.8)
-    @_documentation(visibility: internal)
-#endif
+@_documentation(visibility: internal)
 /// Internal type that will be hidden from documentation when upgrading doc generation to Swift 5.8+
 public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
     static var testReadWrite: BenchmarkRunnerReadWrite?

--- a/Sources/Benchmark/Documentation.docc/BenchmarkTimeUnits.md
+++ b/Sources/Benchmark/Documentation.docc/BenchmarkTimeUnits.md
@@ -11,7 +11,7 @@
 - ``BenchmarkTimeUnits/seconds``
 - ``BenchmarkTimeUnits/kiloseconds``
 - ``BenchmarkTimeUnits/megaseconds``
-- ``BenchmarkTimeUnits/init(_:)``
+- ``BenchmarkTimeUnits/init(_:)-3tc3e``
 - ``BenchmarkTimeUnits/init(rawValue:)``
 
 ### Describing Time Units

--- a/Sources/Benchmark/Documentation.docc/BenchmarkUnits.md
+++ b/Sources/Benchmark/Documentation.docc/BenchmarkUnits.md
@@ -1,4 +1,4 @@
-#``Benchmark/BenchmarkUnits``
+# ``Benchmark/BenchmarkUnits``
 
 ## Topics
 

--- a/Sources/Benchmark/Documentation.docc/Benchmark_Configuration.md
+++ b/Sources/Benchmark/Documentation.docc/Benchmark_Configuration.md
@@ -4,7 +4,7 @@
 
 ### Creating Configurations
 
-- ``Benchmark/Configuration-swift.struct/init(metrics:timeUnits:warmupIterations:scalingFactor:maxDuration:maxIterations:skip:thresholds:setup:teardown:)``
+- ``Benchmark/Configuration-swift.struct/init(metrics:tags:timeUnits:units:warmupIterations:scalingFactor:maxDuration:maxIterations:skip:thresholds:setup:teardown:)``
 
 ### Inspecting Configurations
 

--- a/Sources/Benchmark/MallocStats/MallocStats.swift
+++ b/Sources/Benchmark/MallocStats/MallocStats.swift
@@ -9,9 +9,7 @@
 //
 
 /// The memory allocation stats the the MallocStatsProducer can provide
-#if swift(>=5.8)
-    @_documentation(visibility: internal)
-#endif
+@_documentation(visibility: internal)
 struct MallocStats {
     var mallocCountTotal: Int = 0 /// total number of mallocs done
     var mallocCountSmall: Int = 0 /// number of small mallocs (as defined by jemalloc)

--- a/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
+++ b/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
@@ -17,10 +17,7 @@ import Foundation
     // was used during development to figure out most relevant stats,
     // Keeping them around as we may want to expand malloc statistics
     // to become more detailed.
-    // Disable this for now as it gives unexpected error with Swift 5.7.1 toolchain
-//    #if swift(>=5.8)
-//        @_documentation(visibility: internal)
-//    #endif
+    @_documentation(visibility: internal)
     final class MallocStatsProducer {
         // Basically just set up a number of cached MIB structures for
         // more efficient queries later of malloc statistics.

--- a/Sources/Benchmark/Progress/Progress.swift
+++ b/Sources/Benchmark/Progress/Progress.swift
@@ -28,16 +28,12 @@
 
 // MARK: - ProgressBarDisplayer
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 public protocol ProgressBarPrinter {
     mutating func display(_ progressBar: ProgressBar)
 }
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 struct ProgressBarTerminalPrinter: ProgressBarPrinter {
     var lastPrintedTime = 0.0
 
@@ -59,9 +55,7 @@ struct ProgressBarTerminalPrinter: ProgressBarPrinter {
 
 // MARK: - ProgressBar
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 public struct ProgressBar {
     private(set) public var index = 0
     public let startTime = getTimeOfDay()
@@ -104,9 +98,7 @@ public struct ProgressBar {
 
 // MARK: - GeneratorType
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 public struct ProgressGenerator<G: IteratorProtocol>: IteratorProtocol {
     var source: G
     var progressBar: ProgressBar
@@ -125,9 +117,7 @@ public struct ProgressGenerator<G: IteratorProtocol>: IteratorProtocol {
 
 // MARK: - SequenceType
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 public struct Progress<G: Sequence>: Sequence {
     let generator: G
     let configuration: [ProgressElementType]?

--- a/Sources/Benchmark/Progress/ProgressElements.swift
+++ b/Sources/Benchmark/Progress/ProgressElements.swift
@@ -27,18 +27,14 @@
 //
 
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 public protocol ProgressElementType {
     func value(_ progressBar: ProgressBar) -> String
 }
 
 
 /// the progress bar element e.g. "[----------------------        ]"
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 public struct ProgressBarLine: ProgressElementType {
     let barLength: Int
 
@@ -62,9 +58,7 @@ public struct ProgressBarLine: ProgressElementType {
 
 
 /// the index element e.g. "2 of 3"
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 public struct ProgressIndex: ProgressElementType {
     public init() {}
 
@@ -75,9 +69,7 @@ public struct ProgressIndex: ProgressElementType {
 
 
 /// the percentage element e.g. "90.0%"
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 public struct ProgressPercent: ProgressElementType {
     let decimalPlaces: Int
 
@@ -101,9 +93,7 @@ public struct ProgressPercent: ProgressElementType {
 
 
 /// the time estimates e.g. "ETA: 00:00:02 (at 1.00 it/s)"
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 public struct ProgressTimeEstimates: ProgressElementType {
     public init() {}
 
@@ -137,9 +127,7 @@ public struct ProgressTimeEstimates: ProgressElementType {
 
 
 /// an arbitrary string that can be added to the progress bar.
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 public struct ProgressString: ProgressElementType {
     let string: String
 

--- a/Sources/Benchmark/Progress/Utilities.swift
+++ b/Sources/Benchmark/Progress/Utilities.swift
@@ -32,18 +32,14 @@ import Glibc
 import Darwin.C
 #endif
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 func getTimeOfDay() -> Double {
     var tv = timeval()
     gettimeofday(&tv, nil)
     return Double(tv.tv_sec) + Double(tv.tv_usec) / 1000000
 }
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 extension Double {
     func format(_ decimalPartLength: Int, minimumIntegerPartLength: Int = 0) -> String {
         let value = String(self)
@@ -74,9 +70,7 @@ extension Double {
     }
 }
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 extension String {
     func substringWithRange(_ start: Int, end: Int) -> String {
         var end = end

--- a/Sources/Benchmark/Statistics.swift
+++ b/Sources/Benchmark/Statistics.swift
@@ -13,10 +13,7 @@ import Histogram
 import Numerics
 
 // A type that provides distribution / percentile calculations of latency measurements
-#if swift(>=5.8)
-    @_documentation(visibility: internal)
-#endif
-/// Internal type that will be hidden from documentation when upgrading doc generation to Swift 5.8+
+@_documentation(visibility: internal)
 public final class Statistics: Codable {
     public static let defaultMaximumMeasurement = 1_000_000_000 // 1 second in nanoseconds
     public static let defaultPercentilesToCalculate = [0.0, 25.0, 50.0, 75.0, 90.0, 99.0, 100.0]

--- a/Sources/Shared/Command+Helpers.swift
+++ b/Sources/Shared/Command+Helpers.swift
@@ -10,6 +10,7 @@
 
 // Project wide shared types
 
+@_documentation(visibility: internal)
 public enum Command: String, CaseIterable {
     case run
     case list
@@ -46,9 +47,7 @@ public enum Grouping: String, CaseIterable {
     case benchmark
 }
 
-#if swift(>=5.8)
 @_documentation(visibility: internal)
-#endif
 public enum TimeUnits: String, CaseIterable {
     case nanoseconds
     case microseconds
@@ -58,12 +57,14 @@ public enum TimeUnits: String, CaseIterable {
     case megaseconds
 }
 
+@_documentation(visibility: internal)
 public enum ThresholdsOperation: String, CaseIterable {
     case read
     case update
     case check
 }
 
+@_documentation(visibility: internal)
 public enum BaselineOperation: String, CaseIterable {
     case read
     case update


### PR DESCRIPTION
Add property wrapper to reduce boilerplate

Fixes https://github.com/ordo-one/package-benchmark/issues/311

## How Has This Been Tested?

Tested with benchmark samples and included benchmarks.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
