### PR TITLE
feat(patch): Add output suppressor when running with --no-progress

### DIFF
--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -75,29 +75,25 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     }
 #elseif swift(>=5.10)
     @_documentation(visibility: internal)
-    nonisolated(unsafe)
-    public static var startupHook: BenchmarkSetupHook? {
+    nonisolated(unsafe) public static var startupHook: BenchmarkSetupHook? {
         get { _startupHook  }
         set { _startupHook = newValue }
     }
 
     @_documentation(visibility: internal)
-    nonisolated(unsafe)
-    public static var shutdownHook: BenchmarkTeardownHook? {
+    nonisolated(unsafe) public static var shutdownHook: BenchmarkTeardownHook? {
         get { _shutdownHook  }
         set { _shutdownHook = newValue }
     }
 
     /// This closure if set, will be run before a targets benchmarks are run, but after they are registered
-    nonisolated(unsafe)
-    public static var setup: BenchmarkSetupHook? {
+    nonisolated(unsafe) public static var setup: BenchmarkSetupHook? {
         get { _setup  }
         set { _setup = newValue }
     }
 
     /// This closure if set, will be run after a targets benchmarks run, but after they are registered
-    nonisolated(unsafe)
-    public static var teardown: BenchmarkTeardownHook? {
+    nonisolated(unsafe) public static var teardown: BenchmarkTeardownHook? {
         get { _teardown  }
         set { _teardown = newValue }
     }

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -55,7 +55,7 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
         get { _startupHook  }
         set { _startupHook = newValue }
     }
-    
+
     @_documentation(visibility: internal)
     public static var shutdownHook: BenchmarkTeardownHook? {
         get { _shutdownHook  }

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -206,7 +206,6 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                         if quiet {
                             try suppressor.restoreOutput()
                         }
-
                     } catch {
                         print("Error: \(error.localizedDescription)")
                         try channel.write(.error("OutputSuppressor failed: \(String(reflecting: error.localizedDescription))"))

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -96,8 +96,9 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
 
     // swiftlint:disable cyclomatic_complexity function_body_length
     public mutating func run() async throws {
-        // Flush stdout so we see any failures clearly
+        // Flush stdout/stderr so we see any failures clearly
         setbuf(stdout, nil)
+        setbuf(stderr, nil)
 
         // We just run everything in debug mode to simplify workflow with debuggers/profilers
         if inputFD == nil, outputFD == nil {
@@ -111,6 +112,8 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
         let benchmarkExecutor = BenchmarkExecutor(quiet: quiet)
         var benchmark: Benchmark?
         var results: [BenchmarkResult] = []
+
+        let suppressor = OutputSuppressor()
 
         while true {
             if debug { // in debug mode we run all benchmarks matching filter/skip specified
@@ -193,7 +196,21 @@ public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
                         return
                     }
 
-                    results = benchmarkExecutor.run(benchmark)
+                    do {
+                        if quiet {
+                            try suppressor.suppressOutput()
+                        }
+
+                        results = benchmarkExecutor.run(benchmark)
+
+                        if quiet {
+                            try suppressor.restoreOutput()
+                        }
+
+                    } catch {
+                        print("Error: \(error.localizedDescription)")
+                        try channel.write(.error("OutputSuppressor failed: \(String(reflecting: error.localizedDescription))"))
+                    }
 
                     do {
                         for hook in [benchmark.teardown, benchmark.configuration.teardown, Benchmark.shutdownHook, Benchmark.teardown] {

--- a/Sources/Benchmark/OutputSuppressor.swift
+++ b/Sources/Benchmark/OutputSuppressor.swift
@@ -4,48 +4,47 @@ final class OutputSuppressor {
     private var originalStdout: Int32?
     private var originalStderr: Int32?
     private var nullFile: Int32?
-    
+
     func suppressOutput() throws {
         // Save original file descriptors
         originalStdout = dup(FileHandle.standardOutput.fileDescriptor)
         originalStderr = dup(FileHandle.standardError.fileDescriptor)
-        
+
         // Open /dev/null
         nullFile = open("/dev/null", O_WRONLY)
         guard nullFile != -1 else {
             throw NSError(domain: "OutputSuppressor", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to open /dev/null"])
         }
-        
+
         // Redirect stdout and stderr to /dev/null
         guard dup2(nullFile!, FileHandle.standardOutput.fileDescriptor) != -1,
               dup2(nullFile!, FileHandle.standardError.fileDescriptor) != -1 else {
             throw NSError(domain: "OutputSuppressor", code: 2, userInfo: [NSLocalizedDescriptionKey: "Failed to redirect output"])
         }
     }
-    
+
     func restoreOutput() throws {
         // Restore original stdout and stderr
         guard let stdout = originalStdout,
               let stderr = originalStderr else {
             throw NSError(domain: "OutputSuppressor", code: 3, userInfo: [NSLocalizedDescriptionKey: "Original file descriptors not found"])
         }
-        
+
         guard dup2(stdout, FileHandle.standardOutput.fileDescriptor) != -1,
               dup2(stderr, FileHandle.standardError.fileDescriptor) != -1 else {
             throw NSError(domain: "OutputSuppressor", code: 4, userInfo: [NSLocalizedDescriptionKey: "Failed to restore output"])
         }
-        
+
         // Close file descriptors
         close(stdout)
         close(stderr)
         if let null = nullFile {
             close(null)
         }
-        
+
         // Reset stored descriptors
         originalStdout = nil
         originalStderr = nil
         nullFile = nil
     }
 }
-

--- a/Sources/Benchmark/OutputSuppressor.swift
+++ b/Sources/Benchmark/OutputSuppressor.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+final class OutputSuppressor {
+    private var originalStdout: Int32?
+    private var originalStderr: Int32?
+    private var nullFile: Int32?
+    
+    func suppressOutput() throws {
+        // Save original file descriptors
+        originalStdout = dup(FileHandle.standardOutput.fileDescriptor)
+        originalStderr = dup(FileHandle.standardError.fileDescriptor)
+        
+        // Open /dev/null
+        nullFile = open("/dev/null", O_WRONLY)
+        guard nullFile != -1 else {
+            throw NSError(domain: "OutputSuppressor", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to open /dev/null"])
+        }
+        
+        // Redirect stdout and stderr to /dev/null
+        guard dup2(nullFile!, FileHandle.standardOutput.fileDescriptor) != -1,
+              dup2(nullFile!, FileHandle.standardError.fileDescriptor) != -1 else {
+            throw NSError(domain: "OutputSuppressor", code: 2, userInfo: [NSLocalizedDescriptionKey: "Failed to redirect output"])
+        }
+    }
+    
+    func restoreOutput() throws {
+        // Restore original stdout and stderr
+        guard let stdout = originalStdout,
+              let stderr = originalStderr else {
+            throw NSError(domain: "OutputSuppressor", code: 3, userInfo: [NSLocalizedDescriptionKey: "Original file descriptors not found"])
+        }
+        
+        guard dup2(stdout, FileHandle.standardOutput.fileDescriptor) != -1,
+              dup2(stderr, FileHandle.standardError.fileDescriptor) != -1 else {
+            throw NSError(domain: "OutputSuppressor", code: 4, userInfo: [NSLocalizedDescriptionKey: "Failed to restore output"])
+        }
+        
+        // Close file descriptors
+        close(stdout)
+        close(stderr)
+        if let null = nullFile {
+            close(null)
+        }
+        
+        // Reset stored descriptors
+        originalStdout = nil
+        originalStderr = nil
+        nullFile = nil
+    }
+}
+


### PR DESCRIPTION
## Description

When running with --no-progress, we reroute stdout/stderr to /dev/null for the benchmark.

Addresses https://github.com/ordo-one/package-benchmark/issues/288

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
