### PR TITLE
feat: add percentile column to influx format

### DIFF
--- a/Plugins/BenchmarkTool/BenchmarkTool+Export+InfluxCSVFormatter.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export+InfluxCSVFormatter.swift
@@ -54,9 +54,9 @@ class InfluxCSVFormatter {
         let memory = machine.memory
 
         if header {
-            let dataTypeHeader = "#datatype tag,tag,tag,tag,tag,tag,tag,tag,tag,double,double,long,long,dateTime\n"
+            let dataTypeHeader = "#datatype tag,tag,tag,tag,tag,tag,tag,tag,tag,double,double,double,long,long,dateTime\n"
             finalFileFormat.append(dataTypeHeader)
-            let headers = "measurement,hostName,processoryType,processors,memory,kernelVersion,metric,unit,test,value,test_average,iterations,warmup_iterations,time\n"
+            let headers = "measurement,hostName,processoryType,processors,memory,kernelVersion,metric,unit,test,percentile,value,test_average,iterations,warmup_iterations,time\n"
             finalFileFormat.append(headers)
         }
 
@@ -64,16 +64,15 @@ class InfluxCSVFormatter {
             let testName = testData.test
             let iterations = testData.iterations
             let warmup_iterations = testData.warmupIterations
-
+            let percentiles = Statistics.defaultPercentilesToCalculate
             for granularData in testData.data {
                 let metric = granularData.metric
                     .replacingOccurrences(of: " ", with: "")
                 let units = granularData.units
                 let average = granularData.average
-
-                for dataTableValue in granularData.metricsdata {
+                for (percentile, dataTableValue) in zip(percentiles, granularData.metricsdata) {
                     let time = ISO8601DateFormatter().string(from: Date())
-                    let dataLine = "\(exportableBenchmark.target),\(hostName),\(processorType),\(processors),\(memory),\(kernelVersion),\(metric),\(units),\(testName),\(dataTableValue),\(average),\(iterations),\(warmup_iterations),\(time)\n"
+                    let dataLine = "\(exportableBenchmark.target),\(hostName),\(processorType),\(processors),\(memory),\(kernelVersion),\(metric),\(units),\(testName),\(percentile),\(dataTableValue),\(average),\(iterations),\(warmup_iterations),\(time)\n"
                     finalFileFormat.append(dataLine)
                 }
             }


### PR DESCRIPTION
## Description

This PR adds a percentile column for the influx export format using the default percentile values. This would close #227. 

## How Has This Been Tested?
Example output of `swift package --allow-writing-to-package-directory benchmark --format influx`
```
#datatype tag,tag,tag,tag,tag,tag,tag,tag,tag,double,double,double,long,long,dateTime
measurement,hostName,processoryType,processors,memory,kernelVersion,metric,unit,test,percentile,value,test_average,iterations,warmup_iterations,time
LanguageCoverage,ckumar,arm64,14,36,Darwin-Kernel-Version-23.6.0:-Fri-Nov-15-15:12:52-PST-2024;-root:xnu-10063.141.1.702.7~1/RELEASE_ARM64_T6031,ratio,K,eight operations looped,0.0,47950,61914.57142857143,17,1,2025-03-14T12:02:23Z
LanguageCoverage,ckumar,arm64,14,36,Darwin-Kernel-Version-23.6.0:-Fri-Nov-15-15:12:52-PST-2024;-root:xnu-10063.141.1.702.7~1/RELEASE_ARM64_T6031,ratio,K,eight operations looped,25.0,53151,61914.57142857143,17,1,2025-03-14T12:02:23Z
LanguageCoverage,ckumar,arm64,14,36,Darwin-Kernel-Version-23.6.0:-Fri-Nov-15-15:12:52-PST-2024;-root:xnu-10063.141.1.702.7~1/RELEASE_ARM64_T6031,ratio,K,eight operations looped,50.0,57855,61914.57142857143,17,1,2025-03-14T12:02:23Z
LanguageCoverage,ckumar,arm64,14,36,Darwin-Kernel-Version-23.6.0:-Fri-Nov-15-15:12:52-PST-2024;-root:xnu-10063.141.1.702.7~1/RELEASE_ARM64_T6031,ratio,K,eight operations looped,75.0,61791,61914.57142857143,17,1,2025-03-14T12:02:23Z
LanguageCoverage,ckumar,arm64,14,36,Darwin-Kernel-Version-23.6.0:-Fri-Nov-15-15:12:52-PST-2024;-root:xnu-10063.141.1.702.7~1/RELEASE_ARM64_T6031,ratio,K,eight operations looped,90.0,70207,61914.57142857143,17,1,2025-03-14T12:02:23Z
LanguageCoverage,ckumar,arm64,14,36,Darwin-Kernel-Version-23.6.0:-Fri-Nov-15-15:12:52-PST-2024;-root:xnu-10063.141.1.702.7~1/RELEASE_ARM64_T6031,ratio,K,eight operations looped,99.0,71224,61914.57142857143,17,1,2025-03-14T12:02:23Z
LanguageCoverage,ckumar,arm64,14,36,Darwin-Kernel-Version-23.6.0:-Fri-Nov-15-15:12:52-PST-2024;-root:xnu-10063.141.1.702.7~1/RELEASE_ARM64_T6031,ratio,K,eight operations looped,100.0,71224,61914.57142857143,17,1,2025-03-14T12:02:23Z
```


## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [X] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
