### PR TITLE
chore: Replace platform requirement with `@available` markup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let disableJemalloc = ProcessInfo.processInfo.environment["BENCHMARK_DISABLE_JEM
 let package = Package(
     name: "Benchmark",
     platforms: [
-        .macOS(.v13),
-        .iOS(.v16)
+        .macOS(.v10_15),
+        .iOS(.v13),
     ],
     products: [
         .plugin(name: "BenchmarkCommandPlugin", targets: ["BenchmarkCommandPlugin"]),

--- a/Plugins/BenchmarkBoilerplateGenerator/BenchmarkBoilerplateGenerator.swift
+++ b/Plugins/BenchmarkBoilerplateGenerator/BenchmarkBoilerplateGenerator.swift
@@ -25,6 +25,7 @@ struct Benchmark: AsyncParsableCommand {
         import Benchmark
 
         @main
+        @available(macOS 13, iOS 16, tvOS 16, *)
         struct BenchmarkRunner: BenchmarkRunnerHooks {
           static func registerBenchmarks() {
             _ = benchmarks()

--- a/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
@@ -63,6 +63,7 @@ struct BenchmarkIdentifier: Codable, Hashable {
     }
 }
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension Benchmark {
     var benchmarkIdentifier: BenchmarkIdentifier {
         .init(target: self.target, name: self.name)
@@ -177,6 +178,7 @@ struct BenchmarkBaseline: Codable {
 
 let baselinesDirectory: String = ".benchmarkBaselines"
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkTool {
     func printAllBaselines() {
         var storagePath = FilePath(baselineStoragePath)
@@ -391,6 +393,7 @@ extension BenchmarkTool {
     }
 }
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkBaseline {
     func thresholdsForBenchmarks(
         _ benchmarks: [Benchmark],
@@ -417,6 +420,7 @@ extension BenchmarkBaseline {
     }
 }
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkBaseline: Equatable {
     public func deviationsComparedToBaseline(_ rhs: BenchmarkBaseline,
                                              benchmarks: [Benchmark]) -> BenchmarkResult.ThresholdDeviations {

--- a/Plugins/BenchmarkTool/BenchmarkTool+CreateBenchmark.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+CreateBenchmark.swift
@@ -18,6 +18,7 @@ import SystemPackage
     #error("Unsupported Platform")
 #endif
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkTool {
     var benchmarksDirectory: String { "Benchmarks" }
 

--- a/Plugins/BenchmarkTool/BenchmarkTool+Export+InfluxCSVFormatter.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export+InfluxCSVFormatter.swift
@@ -105,6 +105,7 @@ class InfluxCSVFormatter {
     }
 }
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkTool {
     func convertToInflux(_ baseline: BenchmarkBaseline) throws -> String {
         var outputString = ""

--- a/Plugins/BenchmarkTool/BenchmarkTool+Export+JMHFormatter.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export+JMHFormatter.swift
@@ -57,6 +57,7 @@ extension JMHPrimaryMetric {
     }
 }
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkTool {
     func convertToJMH(_ baseline: BenchmarkBaseline) throws -> String {
         var resultString = ""

--- a/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
@@ -20,6 +20,7 @@ import SystemPackage
     #error("Unsupported Platform")
 #endif
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkTool {
     func write(exportData: String,
                hostIdentifier: String? = nil,

--- a/Plugins/BenchmarkTool/BenchmarkTool+JSON.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+JSON.swift
@@ -14,6 +14,7 @@ import Benchmark
 import Foundation
 import SystemPackage
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkTool {
     func write(_ reply: BenchmarkCommandRequest) throws {
         let bytesArray = try JSONEncoder().encode(reply)

--- a/Plugins/BenchmarkTool/BenchmarkTool+Machine.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Machine.swift
@@ -20,6 +20,7 @@ import Benchmark
     #error("Unsupported Platform")
 #endif
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkTool {
     func benchmarkMachine() -> BenchmarkMachine {
         let processors = sysconf(Int32(_SC_NPROCESSORS_ONLN))

--- a/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
@@ -22,6 +22,7 @@ import Foundation
 import SystemPackage
 import TextTable
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkTool {
     mutating func queryBenchmarks(_ benchmarkPath: String) throws {
         try write(.list)

--- a/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+PrettyPrinting.swift
@@ -25,6 +25,7 @@ extension OutputFormat {
     }
 }
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkTool {
     private func printMarkdown(_ markdown: String, terminator: String = "\n") {
         if format == .markdown {

--- a/Plugins/BenchmarkTool/BenchmarkTool+ReadP90AbsoluteThresholds.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+ReadP90AbsoluteThresholds.swift
@@ -20,6 +20,7 @@ import SystemPackage
     #error("Unsupported Platform")
 #endif
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkTool {
     /// `makeBenchmarkThresholds` is a convenience function for reading p90 static thresholds that previously have been exported with `metricP90AbsoluteThresholds`
     ///

--- a/Plugins/BenchmarkTool/BenchmarkTool+Thresholds.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Thresholds.swift
@@ -22,6 +22,7 @@ fileprivate struct ThresholdsTableEntry {
     var relative: Double
 }
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkTool {
     func printThresholds(_ staticThresholdsPerBenchmark: [BenchmarkIdentifier : [BenchmarkMetric: BenchmarkThresholds.AbsoluteThreshold]]) {
 

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -43,6 +43,7 @@ typealias BenchmarkResults = [BenchmarkIdentifier: [BenchmarkResult]]
 fileprivate var failedBenchmarkRuns = 0
 
 @main
+@available(macOS 13, iOS 16, tvOS 16, *)
 struct BenchmarkTool: AsyncParsableCommand {
     @Option(name: .long, help: "The paths to the benchmarks to run")
     var benchmarkExecutablePaths: [String] = []

--- a/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
+++ b/Sources/Benchmark/Benchmark+ConvenienceInitializers.swift
@@ -1,3 +1,4 @@
+@available(macOS 13, iOS 16, tvOS 16, *)
 public extension Benchmark {
     /// Definition of a Benchmark
     /// - Parameters:

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -13,6 +13,7 @@ import Foundation
 // swiftlint:disable file_length identifier_name
 
 /// Defines a benchmark
+@available(macOS 13, iOS 16, tvOS 16, *)
 public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type_body_length
     @_documentation(visibility: internal)
     public typealias BenchmarkClosure = (_ benchmark: Benchmark) -> Void
@@ -427,6 +428,7 @@ public final class Benchmark: Codable, Hashable { // swiftlint:disable:this type
     }
 }
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 public extension Benchmark {
     /// The configuration settings for running a benchmark.
     struct Configuration: Codable {
@@ -505,6 +507,7 @@ public extension Benchmark {
 // This is an additional convenience duplicating the free standing function blackHole() for those cases where
 // another module happens to define it, as we have a type clash between module name and type name and otherwise
 // the user would need to do `import func Benchmark.blackHole` which isn't that obvious - thus this duplication.
+@available(macOS 13, iOS 16, tvOS 16, *)
 public extension Benchmark {
     /// A function to foil compiler optimizations that would otherwise optimize out code you want to benchmark.
     ///

--- a/Sources/Benchmark/BenchmarkClock.swift
+++ b/Sources/Benchmark/BenchmarkClock.swift
@@ -23,6 +23,7 @@ import Glibc
 #endif
 
 @_documentation(visibility: internal)
+@available(macOS 13, iOS 16, tvOS 16, *)
 public struct BenchmarkClock {
     /// A continuous point in time used for `BenchmarkClock`.
     public struct Instant: Codable, Sendable {
@@ -37,6 +38,7 @@ public struct BenchmarkClock {
 }
 
 @_documentation(visibility: internal)
+@available(macOS 13, iOS 16, tvOS 16, *)
 public extension Clock where Self == BenchmarkClock {
     /// A clock that measures time that always increments but does not stop
     /// incrementing while the system is asleep.
@@ -47,6 +49,7 @@ public extension Clock where Self == BenchmarkClock {
 }
 
 @_documentation(visibility: internal)
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkClock: Clock {
     /// The current continuous instant.
     public var now: BenchmarkClock.Instant {
@@ -118,6 +121,7 @@ extension BenchmarkClock: Clock {
 }
 
 @_documentation(visibility: internal)
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkClock.Instant: InstantProtocol {
     public static var now: BenchmarkClock.Instant { BenchmarkClock.now }
 
@@ -182,6 +186,7 @@ extension BenchmarkClock.Instant: InstantProtocol {
 }
 
 @_documentation(visibility: internal)
+@available(macOS 13, iOS 16, tvOS 16, *)
 public extension Duration {
     func nanoseconds() -> Int64 {
         (components.seconds * 1_000_000_000) + (components.attoseconds / 1_000_000_000)

--- a/Sources/Benchmark/BenchmarkExecutor+Extensions.swift
+++ b/Sources/Benchmark/BenchmarkExecutor+Extensions.swift
@@ -9,6 +9,7 @@
 //
 // swiftlint:disable cyclomatic_complexity
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkExecutor {
     func performanceCountersNeeded(_ metric: BenchmarkMetric) -> Bool {
         switch metric {
@@ -20,6 +21,7 @@ extension BenchmarkExecutor {
     }
 }
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkExecutor {
     func mallocStatsProducerNeeded(_ metric: BenchmarkMetric) -> Bool {
         switch metric {
@@ -39,6 +41,7 @@ extension BenchmarkExecutor {
     }
 }
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkExecutor {
     func operatingSystemsStatsProducerNeeded(_ metric: BenchmarkMetric) -> Bool {
         switch metric {
@@ -82,6 +85,7 @@ extension BenchmarkExecutor {
     }
 }
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkExecutor {
     func arcStatsProducerNeeded(_ metric: BenchmarkMetric) -> Bool {
         switch metric {

--- a/Sources/Benchmark/BenchmarkExecutor.swift
+++ b/Sources/Benchmark/BenchmarkExecutor.swift
@@ -14,6 +14,7 @@
 
 // swiftlint:disable file_length
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 struct BenchmarkExecutor { // swiftlint:disable:this type_body_length
     init(quiet: Bool = false) {
         self.quiet = quiet

--- a/Sources/Benchmark/BenchmarkInternals.swift
+++ b/Sources/Benchmark/BenchmarkInternals.swift
@@ -13,6 +13,7 @@
 
 // Command sent from benchmark runner to the benchmark under measurement
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 @_documentation(visibility: internal)
 public enum BenchmarkCommandRequest: Codable {
     case list
@@ -21,6 +22,7 @@ public enum BenchmarkCommandRequest: Codable {
 }
 
 // Replies from benchmark under measure to benchmark runner
+@available(macOS 13, iOS 16, tvOS 16, *)
 @_documentation(visibility: internal)
 public enum BenchmarkCommandReply: Codable {
     case list(benchmark: Benchmark)

--- a/Sources/Benchmark/BenchmarkRunner+ReadWrite.swift
+++ b/Sources/Benchmark/BenchmarkRunner+ReadWrite.swift
@@ -14,11 +14,13 @@ import Foundation
 import SystemPackage
 
 // For test dependency injection
+@available(macOS 13, iOS 16, tvOS 16, *)
 protocol BenchmarkRunnerReadWrite {
     func write(_ reply: BenchmarkCommandReply) throws
     func read() throws -> BenchmarkCommandRequest
 }
 
+@available(macOS 13, iOS 16, tvOS 16, *)
 extension BenchmarkRunner {
     func write(_ reply: BenchmarkCommandReply) throws {
         guard outputFD != nil else {

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -29,6 +29,7 @@ public protocol BenchmarkRunnerHooks {
 }
 
 @_documentation(visibility: internal)
+@available(macOS 13, iOS 16, tvOS 16, *)
 public extension BenchmarkRunnerHooks {
     static func main() async {
         await BenchmarkRunner.setupBenchmarkRunner(registerBenchmarks: registerBenchmarks)
@@ -36,6 +37,7 @@ public extension BenchmarkRunnerHooks {
 }
 
 @_documentation(visibility: internal)
+@available(macOS 13, iOS 16, tvOS 16, *)
 public struct BenchmarkRunner: AsyncParsableCommand, BenchmarkRunnerReadWrite {
     static var testReadWrite: BenchmarkRunnerReadWrite?
 


### PR DESCRIPTION
## Description

Replaced platform requirement in Package.swift with `@available` checks. This allows package-benchmark to be included in other packages without them requiring the additional platform requirements of package-benchmark.

Unfortunately we still need a 10.15 requirement as HdrHistogram requires it.

## How Has This Been Tested?

I included package-benchmark in another package not requiring macOS 13 and verified everything compiled fine.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
