### PR TITLE
fix: Fix occasionally incorrect unit in some tables [2/4]

### DIFF
--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -493,7 +493,6 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
         _ rhs: Int,
         _ percentile: Self.Percentile,
         _ thresholds: BenchmarkThresholds,
-        _ scalingFactor: Statistics.Units,
         _ thresholdResults: inout ThresholdDeviations,
         _ name: String = "unknown name",
         _ target: String = "unknown target"
@@ -514,7 +513,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
                 difference: Int(Statistics.roundToDecimalplaces(relativeDifference, 1)),
                 differenceThreshold: Int(threshold),
                 relative: true,
-                units: scalingFactor
+                units: Statistics.Units(timeUnits)
             )
             if relativeDifference > threshold {
                 thresholdResults.regressions.append(deviation)
@@ -534,7 +533,7 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
                 difference: normalize(absoluteDifference),
                 differenceThreshold: normalize(threshold),
                 relative: false,
-                units: scalingFactor
+                units: Statistics.Units(timeUnits)
             )
 
             if absoluteDifference > threshold {
@@ -568,7 +567,6 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
                 rhsPercentiles[percentile],
                 Self.Percentile(rawValue: percentile)!,
                 thresholds,
-                lhs.statistics.units(),
                 &thresholdResults,
                 name,
                 target
@@ -594,7 +592,6 @@ public struct BenchmarkResult: Codable, Comparable, Equatable {
             p90Threshold,
             .p90,
             thresholds,
-            statistics.units(),
             &thresholdResults,
             name,
             target


### PR DESCRIPTION
## Description

 Actually resolves #277. EDIT: or actually not sure if this solves the same issue. But solves an issue anyway.

Examples:

Incorrect label, saying "M" aka "Mega" (or I guess "Millions" also reads fine):
<kbd> <img width="832" height="214" alt="Incorrect unit label M denoting Mega" src="https://github.com/user-attachments/assets/f8e7419f-994d-4893-a9c3-72954a4c78ce" /> </kbd>

Correct label, saying "K" aka "Kilo":
<kbd> <img width="822" height="191" alt="Correct unit label K denoting Kilo" src="https://github.com/user-attachments/assets/e1953acc-4489-4b24-a7e1-7a84a97e0bb2" /> </kbd>

To be completely clear, both these images are 100% correct other than the first image mentioning "M" aka 10^6.

Feel free to review on your own schedule.

## How Has This Been Tested?

Manually in my PRs.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
