### PR TITLE
fix: avoid re-building when comparing two baseline results

### DIFF
--- a/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
+++ b/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
@@ -324,6 +324,9 @@ import Glibc
                         throw MyError.invalidArgument
                     }
                 }
+                if positionalArguments.count == 2 {
+                    shouldBuildTargets = false
+                }
             case .read, .list, .delete:
                 shouldBuildTargets = false
             }


### PR DESCRIPTION
## Description

Avoid building the products when comparing 2 baselines:
```
swift package -c release --disable-sandbox benchmark baseline check main_1 main_2
swift package -c release --disable-sandbox benchmark baseline compare main_1 main_2
```

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
