### PR TITLE
fix(patch): Benchmark check pass custom thresholds

### DIFF
--- a/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
@@ -449,7 +449,8 @@ extension BenchmarkBaseline: Equatable {
                             benchmarks,
                             name: lhsBenchmarkIdentifier.name,
                             target: lhsBenchmarkIdentifier.target,
-                            metric: lhsBenchmarkResult.metric
+                            metric: lhsBenchmarkResult.metric,
+                            defaultThresholds: lhsBenchmarkResult.thresholds ?? BenchmarkThresholds.default
                         )
 
                         let deviationResults = lhsBenchmarkResult.deviationsComparedWith(


### PR DESCRIPTION
## Description

The following command currently checks the thresholds against the defaults, not what is configured in the benchmark result:
```
swift package benchmark baseline check main pull_request --format markdown 
```

Compare against the result thresholds instead.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
