### PR TITLE
fix(patch): Fix histogram percentiles export to use scaled units

### DIFF
--- a/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
@@ -235,12 +235,12 @@ extension BenchmarkTool {
                 try results.forEach { values in
                     let histogram = values.statistics.histogram
 
-                    outputString += "Percentile\t" + "\(values.metric.description) \(values.unitDescriptionPretty)\n"
+                    outputString += "Percentile\t" + "\(values.metric.description) \(values.scaledUnitDescriptionPretty)\n"
 
                     for percentile in 0...100 {
                         outputString +=
                             "\(percentile)\t"
-                            + "\(values.normalize(Int(histogram.valueAtPercentile(Double(percentile)))))\n"
+                            + "\(values.scale(Int(histogram.valueAtPercentile(Double(percentile)))))\n"
                     }
 
                     let description = values.metric.rawDescription


### PR DESCRIPTION
Use scaledUnitDescriptionPretty and scale() instead of unitDescriptionPretty and normalize() so the TSV output matches the console output (e.g., ms instead of s).