### PR TITLE
fix(patch): add Musl support

### DIFF
--- a/Benchmarks/Benchmarks/Basic/BenchmarkRunner+Basic.swift
+++ b/Benchmarks/Benchmarks/Basic/BenchmarkRunner+Basic.swift
@@ -14,6 +14,8 @@ import Foundation
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Unsupported Platform")
 #endif

--- a/Benchmarks/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
+++ b/Benchmarks/Benchmarks/P90AbsoluteThresholds/P90AbsoluteThresholds.swift
@@ -14,6 +14,8 @@ import Foundation
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Unsupported Platform")
 #endif

--- a/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
+++ b/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
@@ -17,6 +17,8 @@ import PackagePlugin
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Unsupported Platform")
 #endif

--- a/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Baselines.swift
@@ -18,6 +18,8 @@ import SystemPackage
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Unsupported Platform")
 #endif

--- a/Plugins/BenchmarkTool/BenchmarkTool+CreateBenchmark.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+CreateBenchmark.swift
@@ -14,6 +14,8 @@ import SystemPackage
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Unsupported Platform")
 #endif

--- a/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Export.swift
@@ -16,6 +16,8 @@ import SystemPackage
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Unsupported Platform")
 #endif

--- a/Plugins/BenchmarkTool/BenchmarkTool+Machine.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Machine.swift
@@ -16,6 +16,8 @@ import Benchmark
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Unsupported Platform")
 #endif

--- a/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+Operations.swift
@@ -18,6 +18,8 @@ import TextTable
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Unsupported Platform")
 #endif

--- a/Plugins/BenchmarkTool/BenchmarkTool+ReadP90AbsoluteThresholds.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool+ReadP90AbsoluteThresholds.swift
@@ -16,6 +16,8 @@ import SystemPackage
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Unsupported Platform")
 #endif

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -19,6 +19,8 @@ import SystemPackage
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Unsupported Platform")
 #endif

--- a/Plugins/BenchmarkTool/FilePath+Additions.swift
+++ b/Plugins/BenchmarkTool/FilePath+Additions.swift
@@ -14,6 +14,8 @@ import SystemPackage
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Unsupported Platform")
 #endif

--- a/Plugins/BenchmarkTool/FilePath+DirectoryView.swift
+++ b/Plugins/BenchmarkTool/FilePath+DirectoryView.swift
@@ -16,6 +16,9 @@ typealias DirectoryStreamPointer = UnsafeMutablePointer<DIR>?
 #elseif canImport(Glibc)
 import Glibc
 typealias DirectoryStreamPointer = OpaquePointer?
+#elseif canImport(Musl)
+import Musl
+typealias DirectoryStreamPointer = OpaquePointer?
 #else
 #error("Unsupported Platform")
 #endif

--- a/Sources/Benchmark/BenchmarkClock.swift
+++ b/Sources/Benchmark/BenchmarkClock.swift
@@ -18,6 +18,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Unsupported Platform")
 #endif

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -15,6 +15,8 @@ import BenchmarkShared
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Unsupported Platform")
 #endif

--- a/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
+++ b/Sources/Benchmark/OperatingSystemStats/OperatingSystemStatsProducer+Linux.swift
@@ -12,7 +12,11 @@
 
 import CLinuxOperatingSystemStats
 import Dispatch
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 import SystemPackage
 
 final class OperatingSystemStatsProducer {

--- a/Sources/Benchmark/Progress/Utilities.swift
+++ b/Sources/Benchmark/Progress/Utilities.swift
@@ -27,7 +27,11 @@
 //
 
 #if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 #else
 import Darwin.C
 #endif

--- a/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
+++ b/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
@@ -16,6 +16,8 @@ import XCTest
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Unsupported Platform")
 #endif


### PR DESCRIPTION
## Description

This is a follow-up to https://github.com/HdrHistogram/hdrhistogram-swift/pull/29, since I am encountering compilation failures because package-benchmark itself needs to support importing Musl where it currently attempts to import Glibc (or fallback to "unsupported platform").

## How Has This Been Tested?

I conducted a `swift build` using the [Static Linux SDK](https://www.swift.org/documentation/articles/static-linux-getting-started.html).

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
