### PR TITLE
feat(minor): Disable jemalloc using package traits

### DIFF
--- a/.github/workflows/swift-macos-build.yml
+++ b/.github/workflows/swift-macos-build.yml
@@ -49,10 +49,10 @@ jobs:
     - name: Run tests
       run: |
         if [ -d Tests ]; then
-          swift test --parallel
+          swift test --parallel --disable-default-traits
         fi
     - name: Run tests (release)
       run: |
         if [ -d Tests ]; then
-          swift test -c release --parallel
+          swift test -c release --parallel --disable-default-traits
         fi

--- a/.github/workflows/swift-sanitizer-address.yml
+++ b/.github/workflows/swift-sanitizer-address.yml
@@ -42,10 +42,10 @@ jobs:
       run: swift package clean
 
     - name: Run address sanitizer
-      run: swift test --sanitize=address
-      
+      run: swift test --sanitize=address --disable-default-traits
+
     - name: Clean before release build sanitizier
       run: swift package clean
-      
+
     - name: Run address sanitizer on release build
-      run: swift test --sanitize=address -c release -Xswiftc -enable-testing
+      run: swift test --sanitize=address -c release -Xswiftc -enable-testing --disable-default-traits

--- a/.github/workflows/swift-sanitizer-thread.yml
+++ b/.github/workflows/swift-sanitizer-thread.yml
@@ -43,10 +43,10 @@ jobs:
       run: swift package clean
 
     - name: Run thread sanitizer
-      run: swift test --sanitize=thread
-      
+      run: swift test --sanitize=thread --disable-default-traits
+
     - name: Clean before release build sanitizier
       run: swift package clean
-      
+
     - name: Run thread sanitizer on release build
-      run: swift test --sanitize=thread -c release -Xswiftc -enable-testing
+      run: swift test --sanitize=thread -c release -Xswiftc -enable-testing --disable-default-traits

--- a/.github/workflows/swift-static-musl.yml
+++ b/.github/workflows/swift-static-musl.yml
@@ -54,4 +54,4 @@ jobs:
       env:
         BENCHMARK_DISABLE_JEMALLOC: 1
       run: |
-        swift build --swift-sdks-path /tmp/swiftsdks --swift-sdk x86_64-swift-linux-musl
+        swift build --swift-sdks-path /tmp/swiftsdks --swift-sdk x86_64-swift-linux-musl --disable-default-traits

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
     ],
     traits: [
         .trait(name: "Jemalloc"),
+        .default(enabledTraits: ["Jemalloc"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMajor(from: "1.1.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -2,11 +2,6 @@
 
 import PackageDescription
 
-import class Foundation.ProcessInfo
-
-// If the environment variable BENCHMARK_DISABLE_JEMALLOC is set, we'll build the package without Jemalloc support
-let disableJemalloc = ProcessInfo.processInfo.environment["BENCHMARK_DISABLE_JEMALLOC"]
-
 let package = Package(
     name: "Benchmark",
     platforms: [
@@ -21,14 +16,33 @@ let package = Package(
             targets: ["Benchmark"]
         ),
     ],
+    traits: [
+        .trait(name: "EnableJemalloc"),
+    ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMajor(from: "1.1.0")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", "1.1.0" ..< "1.6.0"),
         .package(url: "https://github.com/ordo-one/TextTable.git", .upToNextMajor(from: "0.0.1")),
         .package(url: "https://github.com/HdrHistogram/hdrhistogram-swift.git", .upToNextMajor(from: "0.1.4")),
         .package(url: "https://github.com/apple/swift-atomics.git", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/ordo-one/package-jemalloc.git", .upToNextMajor(from: "1.0.0")),
     ],
     targets: [
+        .target(
+            name: "Benchmark",
+            dependencies: [
+                .product(name: "Histogram", package: "hdrhistogram-swift"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "SystemPackage", package: "swift-system"),
+                .byNameItem(name: "CDarwinOperatingSystemStats", condition: .when(platforms: [.macOS, .iOS])),
+                .byNameItem(name: "CLinuxOperatingSystemStats", condition: .when(platforms: [.linux])),
+                .product(name: "Atomics", package: "swift-atomics"),
+                "SwiftRuntimeHooks",
+                "BenchmarkShared",
+                .product(name: "jemalloc", package: "package-jemalloc", condition: .when(platforms: [.macOS, .linux], traits: ["EnableJemalloc"])),
+            ],
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        ),
         // Plugins used by users of the package
 
         // The actual 'benchmark' command plugin
@@ -117,46 +131,3 @@ let package = Package(
         ),
     ]
 )
-// Check if this is a SPI build, then we need to disable jemalloc for macOS
-
-let macOSSPIBuild: Bool // Disables jemalloc for macOS SPI builds as the infrastructure doesn't have jemalloc there
-
-#if canImport(Darwin)
-if let spiBuildEnvironment = ProcessInfo.processInfo.environment["SPI_BUILD"], spiBuildEnvironment == "1" {
-    macOSSPIBuild = true
-    print("Building for SPI@macOS, disabling Jemalloc")
-} else {
-    macOSSPIBuild = false
-}
-#else
-macOSSPIBuild = false
-#endif
-
-// Add Benchmark target dynamically
-
-// Shared dependencies
-var dependencies: [PackageDescription.Target.Dependency] = [
-    .product(name: "Histogram", package: "hdrhistogram-swift"),
-    .product(name: "ArgumentParser", package: "swift-argument-parser"),
-    .product(name: "SystemPackage", package: "swift-system"),
-    .byNameItem(name: "CDarwinOperatingSystemStats", condition: .when(platforms: [.macOS, .iOS])),
-    .byNameItem(name: "CLinuxOperatingSystemStats", condition: .when(platforms: [.linux])),
-    .product(name: "Atomics", package: "swift-atomics"),
-    "SwiftRuntimeHooks",
-    "BenchmarkShared",
-]
-
-if macOSSPIBuild == false { // jemalloc always disable for macOSSPIBuild
-    if let disableJemalloc, disableJemalloc != "false", disableJemalloc != "0" {
-        print("Jemalloc disabled through environment variable.")
-    } else {
-        package.dependencies += [
-            .package(url: "https://github.com/ordo-one/package-jemalloc.git", .upToNextMajor(from: "1.0.0"))
-        ]
-        dependencies += [
-            .product(name: "jemalloc", package: "package-jemalloc", condition: .when(platforms: [.macOS, .linux]))
-        ]
-    }
-}
-
-package.targets += [.target(name: "Benchmark", dependencies: dependencies, swiftSettings: [.swiftLanguageMode(.v5)])]

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         ),
     ],
     traits: [
-        .trait(name: "EnableJemalloc"),
+        .trait(name: "Jemalloc"),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMajor(from: "1.1.0")),
@@ -39,7 +39,7 @@ let package = Package(
                 .product(name: "Atomics", package: "swift-atomics"),
                 "SwiftRuntimeHooks",
                 "BenchmarkShared",
-                .product(name: "jemalloc", package: "package-jemalloc", condition: .when(platforms: [.macOS, .linux], traits: ["EnableJemalloc"])),
+                .product(name: "jemalloc", package: "package-jemalloc", condition: .when(platforms: [.macOS, .linux], traits: ["Jemalloc"])),
             ],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.1
 
 import PackageDescription
 
@@ -66,7 +66,8 @@ let package = Package(
                 "Benchmark",
                 "BenchmarkShared",
             ],
-            path: "Plugins/BenchmarkTool"
+            path: "Plugins/BenchmarkTool",
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
 
         // Tool that generates the boilerplate
@@ -111,7 +112,8 @@ let package = Package(
 
         .testTarget(
             name: "BenchmarkTests",
-            dependencies: ["Benchmark"]
+            dependencies: ["Benchmark"],
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
     ]
 )
@@ -157,4 +159,4 @@ if macOSSPIBuild == false { // jemalloc always disable for macOSSPIBuild
     }
 }
 
-package.targets += [.target(name: "Benchmark", dependencies: dependencies)]
+package.targets += [.target(name: "Benchmark", dependencies: dependencies, swiftSettings: [.swiftLanguageMode(.v5)])]

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,0 +1,160 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+import class Foundation.ProcessInfo
+
+// If the environment variable BENCHMARK_DISABLE_JEMALLOC is set, we'll build the package without Jemalloc support
+let disableJemalloc = ProcessInfo.processInfo.environment["BENCHMARK_DISABLE_JEMALLOC"]
+
+let package = Package(
+    name: "Benchmark",
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v16),
+    ],
+    products: [
+        .plugin(name: "BenchmarkCommandPlugin", targets: ["BenchmarkCommandPlugin"]),
+        .plugin(name: "BenchmarkPlugin", targets: ["BenchmarkPlugin"]),
+        .library(
+            name: "Benchmark",
+            targets: ["Benchmark"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-system.git", .upToNextMajor(from: "1.1.0")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "1.1.0")),
+        .package(url: "https://github.com/ordo-one/TextTable.git", .upToNextMajor(from: "0.0.1")),
+        .package(url: "https://github.com/HdrHistogram/hdrhistogram-swift.git", .upToNextMajor(from: "0.1.0")),
+        .package(url: "https://github.com/apple/swift-atomics.git", .upToNextMajor(from: "1.0.0")),
+    ],
+    targets: [
+        // Plugins used by users of the package
+
+        // The actual 'benchmark' command plugin
+        .plugin(
+            name: "BenchmarkCommandPlugin",
+            capability: .command(
+                intent: .custom(
+                    verb: "benchmark",
+                    description: "Run the Benchmark performance test suite."
+                )
+            ),
+            dependencies: [
+                "BenchmarkTool"
+            ],
+            path: "Plugins/BenchmarkCommandPlugin"
+        ),
+
+        // Plugin that generates the boilerplate needed to interface with the Benchmark infrastructure
+        .plugin(
+            name: "BenchmarkPlugin",
+            capability: .buildTool(),
+            dependencies: [
+                "BenchmarkBoilerplateGenerator"
+            ],
+            path: "Plugins/BenchmarkPlugin"
+        ),
+
+        // Tool that the plugin executes to perform the actual work, the real benchmark driver
+        .executableTarget(
+            name: "BenchmarkTool",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "SystemPackage", package: "swift-system"),
+                .product(name: "TextTable", package: "TextTable"),
+                "Benchmark",
+                "BenchmarkShared",
+            ],
+            path: "Plugins/BenchmarkTool"
+        ),
+
+        // Tool that generates the boilerplate
+        .executableTarget(
+            name: "BenchmarkBoilerplateGenerator",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "SystemPackage", package: "swift-system"),
+            ],
+            path: "Plugins/BenchmarkBoilerplateGenerator"
+        ),
+
+        // Tool that simply generates the man page for the BenchmarkPlugin as we can't use SAP in it... :-/
+        .executableTarget(
+            name: "BenchmarkHelpGenerator",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                "BenchmarkShared",
+            ],
+            path: "Plugins/BenchmarkHelpGenerator"
+        ),
+
+        // Getting OS specific information
+        .target(
+            name: "CDarwinOperatingSystemStats",
+            dependencies: [],
+            path: "Platform/CDarwinOperatingSystemStats"
+        ),
+
+        // Getting OS specific information
+        .target(
+            name: "CLinuxOperatingSystemStats",
+            dependencies: [],
+            path: "Platform/CLinuxOperatingSystemStats"
+        ),
+
+        // Hooks for ARC
+        .target(name: "SwiftRuntimeHooks"),
+
+        // Shared definitions
+        .target(name: "BenchmarkShared"),
+
+        .testTarget(
+            name: "BenchmarkTests",
+            dependencies: ["Benchmark"]
+        ),
+    ]
+)
+// Check if this is a SPI build, then we need to disable jemalloc for macOS
+
+let macOSSPIBuild: Bool // Disables jemalloc for macOS SPI builds as the infrastructure doesn't have jemalloc there
+
+#if canImport(Darwin)
+if let spiBuildEnvironment = ProcessInfo.processInfo.environment["SPI_BUILD"], spiBuildEnvironment == "1" {
+    macOSSPIBuild = true
+    print("Building for SPI@macOS, disabling Jemalloc")
+} else {
+    macOSSPIBuild = false
+}
+#else
+macOSSPIBuild = false
+#endif
+
+// Add Benchmark target dynamically
+
+// Shared dependencies
+var dependencies: [PackageDescription.Target.Dependency] = [
+    .product(name: "Histogram", package: "hdrhistogram-swift"),
+    .product(name: "ArgumentParser", package: "swift-argument-parser"),
+    .product(name: "SystemPackage", package: "swift-system"),
+    .byNameItem(name: "CDarwinOperatingSystemStats", condition: .when(platforms: [.macOS, .iOS])),
+    .byNameItem(name: "CLinuxOperatingSystemStats", condition: .when(platforms: [.linux])),
+    .product(name: "Atomics", package: "swift-atomics"),
+    "SwiftRuntimeHooks",
+    "BenchmarkShared",
+]
+
+if macOSSPIBuild == false { // jemalloc always disable for macOSSPIBuild
+    if let disableJemalloc, disableJemalloc != "false", disableJemalloc != "0" {
+        print("Jemalloc disabled through environment variable.")
+    } else {
+        package.dependencies += [
+            .package(url: "https://github.com/ordo-one/package-jemalloc.git", .upToNextMajor(from: "1.0.0"))
+        ]
+        dependencies += [
+            .product(name: "jemalloc", package: "package-jemalloc", condition: .when(platforms: [.macOS, .linux]))
+        ]
+    }
+}
+
+package.targets += [.target(name: "Benchmark", dependencies: dependencies)]

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -23,7 +23,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMajor(from: "1.1.0")),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "1.1.0")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", "1.1.0"..<"1.6.0"),
         .package(url: "https://github.com/ordo-one/TextTable.git", .upToNextMajor(from: "0.0.1")),
         .package(url: "https://github.com/HdrHistogram/hdrhistogram-swift.git", .upToNextMajor(from: "0.1.0")),
         .package(url: "https://github.com/apple/swift-atomics.git", .upToNextMajor(from: "1.0.0")),

--- a/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
+++ b/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
@@ -14,11 +14,11 @@
 import PackagePlugin
 
 #if canImport(Darwin)
-import Darwin
+@preconcurrency import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #else
 #error("Unsupported Platform")
 #endif

--- a/Plugins/BenchmarkHelpGenerator/BenchmarkHelpGenerator.swift
+++ b/Plugins/BenchmarkHelpGenerator/BenchmarkHelpGenerator.swift
@@ -53,7 +53,7 @@ extension TimeUnits: ExpressibleByArgument {}
 
 @main
 struct Benchmark: AsyncParsableCommand {
-    static var configuration = CommandConfiguration(
+    static let configuration = CommandConfiguration(
         abstract: "Run benchmarks or update, compare or check performance baselines",
         usage: """
             swift package benchmark <command>

--- a/Sources/Benchmark/Documentation.docc/GettingStarted.md
+++ b/Sources/Benchmark/Documentation.docc/GettingStarted.md
@@ -16,17 +16,33 @@ After having done those, running your benchmarks are as simple as running `swift
 
 Benchmark requires Swift 5.7 support as it uses Regex and Duration types introduced with the `macOS 13` runtime, most versions of Linux will work as long as Swift 5.7+ is used. 
 
-Benchmark also by default depends on and uses the [jemalloc](https://jemalloc.net) memory allocation library, which is used by the Benchmark infrastructure to capture memory allocation statistics.
+Benchmark also by default depends on and uses the [jemalloc](https://jemalloc.net) memory allocation library, which is used by the Benchmark infrastructure to capture memory allocation statistics. This is controlled via a Swift Package Manager trait named `Jemalloc`, which is **enabled by default**.
 
-For platforms where `jemalloc` isn't available it's possible to build the Benchmark package without a `jemalloc` dependency by setting the environment variable BENCHMARK_DISABLE_JEMALLOC to any value except `false` or `0`.
+The Benchmark package requires you to install jemalloc on any machine used for benchmarking if you want malloc statistics.
 
-E.g. to run the benchmark on the command line without memory allocation stats could look like:
+#### Disabling jemalloc (Swift 6.1+)
+
+For platforms where `jemalloc` isn't available (e.g. musl/static SDK builds, sanitizer builds, or Xcode profiling), disable the `Jemalloc` trait by passing `--disable-default-traits` to the Swift build, test, or package command:
+
+```bash
+swift build --disable-default-traits
+swift test --disable-default-traits
+swift package --disable-default-traits benchmark
+```
+
+If you depend on `package-benchmark` in your own package and want to disable jemalloc, you can opt out of the trait in your `Package.swift`:
+
+```swift
+.package(url: "https://github.com/ordo-one/package-benchmark.git", from: "...", traits: [])
+```
+
+#### Disabling jemalloc (Swift 5.x legacy)
+
+When using Swift 5.x toolchains (which use the `Package@swift-5.9.swift` manifest), jemalloc can still be disabled via the `BENCHMARK_DISABLE_JEMALLOC` environment variable:
 
 ```bash
 BENCHMARK_DISABLE_JEMALLOC=true swift package benchmark
 ```
-
-The Benchmark package requires you to install jemalloc on any machine used for benchmarking if you want malloc statistics. 
 
 If you want to avoid adding the `jemalloc` dependency to your main project while still getting malloc statistics when benchmarking, the recommended approach is to embed a separate Swift project in a subdirectory that uses your project, then the dependency on `jemalloc` is contained to that subproject only.
 

--- a/Sources/Benchmark/Documentation.docc/RunningBenchmarks.md
+++ b/Sources/Benchmark/Documentation.docc/RunningBenchmarks.md
@@ -117,11 +117,19 @@ This implicitly sets --check-absolute to true as well.
 
 ## Running benchmarks in Xcode and using Instruments for profiling benchmarks
 
-Profiling benchmarks or building the benchmarks in release mode in Xcode with jemalloc is currently not supported (as Xcode currently doesn't support interposition of the malloc library) and requires disabling jemalloc. 
+Profiling benchmarks or building the benchmarks in release mode in Xcode with jemalloc is currently not supported (as Xcode currently doesn't support interposition of the malloc library) and requires disabling jemalloc.
 
-Make sure Xcode is closed and then open it from the CLI with the `BENCHMARK_DISABLE_JEMALLOC` environment variable set e.g.:
+The `Jemalloc` support is controlled via a Swift Package Manager trait. To open Xcode with jemalloc disabled, make sure Xcode is closed and then open it from the CLI passing the `BENCHMARK_DISABLE_JEMALLOC` environment variable (supported by the Swift 5.x `Package@swift-5.9.swift` manifest):
+
 ```bash
 open --env BENCHMARK_DISABLE_JEMALLOC=true Package.swift
+```
+
+For Swift 6.1+ toolchains, use `--disable-default-traits` when building or testing from the command line instead:
+
+```bash
+swift build --disable-default-traits
+swift test --disable-default-traits
 ```
 
 This will disable the jemalloc dependency and you can simply build in Xcode for profiling and use Instruments as normal - including signpost information for the benchmark run.

--- a/Sources/Benchmark/Documentation.docc/WritingBenchmarks.md
+++ b/Sources/Benchmark/Documentation.docc/WritingBenchmarks.md
@@ -425,4 +425,4 @@ The Benchmark SwiftPM plugins executes the `BenchmarkTool` executable which is t
 
 The `BenchmarkTool` in turns runs each executable target that is defined and uses JSON to communicate with the target process over pipes.
 
-The executable benchmark targets just implements the actual benchmark tests, as much boilerplate code as possible has been hidden. The executable benchmark must depend on the `Benchmark` library target which also will pull in `jemalloc` for malloc stats.
+The executable benchmark targets just implements the actual benchmark tests, as much boilerplate code as possible has been hidden. The executable benchmark must depend on the `Benchmark` library target which also will pull in `jemalloc` for malloc stats when the `Jemalloc` package trait is enabled (it is enabled by default). See <doc:GettingStarted> for how to disable it if needed.

--- a/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
+++ b/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 
-#if canImport(jemalloc)
+#if EnableJemalloc
 import jemalloc
 
 // We currently register a number of MIB:s that aren't in use that

--- a/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
+++ b/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 
-#if EnableJemalloc
+#if Jemalloc
 import jemalloc
 
 // We currently register a number of MIB:s that aren't in use that

--- a/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
+++ b/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
@@ -62,7 +62,7 @@ final class OperatingSystemAndMallocTests: XCTestCase {
         blackHole(operatingSystemStatsProducer.metricSupported(.throughput))
     }
 
-    #if canImport(jemalloc)
+    #if EnableJemalloc
     func testMallocProducerLeaks() throws {
         let startMallocStats = MallocStatsProducer.makeMallocStats()
 

--- a/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
+++ b/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
@@ -62,7 +62,7 @@ final class OperatingSystemAndMallocTests: XCTestCase {
         blackHole(operatingSystemStatsProducer.metricSupported(.throughput))
     }
 
-    #if EnableJemalloc
+    #if Jemalloc
     func testMallocProducerLeaks() throws {
         let startMallocStats = MallocStatsProducer.makeMallocStats()
 


### PR DESCRIPTION
## Description

This is a first attempt at enabling/disable jemalloc using package traits #316 
This shows off what a trait based implementation could look like. But I'm not exactly sure what the expected behaviour would be on unsupported platforms. So that probably needs some more discussion.

## How Has This Been Tested?

I performed a build and ran the tests with and without the trait enabled.
The build succeeds on Mac but running tests (with the trait enabled) fails with a segmentation error. 
I'm not entirely sure where this is coming from but seems to fail once we add `package-jemalloc` to the package dependencies. Regardless of if it is actually used by package-benchmark this seems to crash running `swift test --traits EnableJemalloc`
This user experience should be improved ofcourse. Which I'm hoping to discuss in the PR.

## Minimal checklist:

- [ ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
