### PR TITLE
fix(minor): malloc counter regression

### DIFF
--- a/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
+++ b/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 
-#if Jemalloc
+#if canImport(jemalloc)
 import jemalloc
 
 // We currently register a number of MIB:s that aren't in use that

--- a/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
+++ b/Tests/BenchmarkTests/OperatingSystemAndMallocTests.swift
@@ -62,7 +62,7 @@ final class OperatingSystemAndMallocTests: XCTestCase {
         blackHole(operatingSystemStatsProducer.metricSupported(.throughput))
     }
 
-    #if Jemalloc
+    #if canImport(jemalloc)
     func testMallocProducerLeaks() throws {
         let startMallocStats = MallocStatsProducer.makeMallocStats()
 


### PR DESCRIPTION
## Description

With PR #347 we added trait support and we changed the `#canImport(jemalloc)` to `#if Jemalloc`. Since the older toolchains will execute the `Package@5.9` and in there we do not have a way to enable the trait the code guarded with the #if will never compile, the #else block will execute and we will get the stub implementation of the malloc counter which return 0.

Quick fix is to revert back to use `#canImport`.

Related issue: https://github.com/ordo-one/package-benchmark/issues/350

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [ ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
