### PR TITLE
fix: migrate SwiftPM plugins from deprecated Path API to URL API

### DIFF
--- a/Plugins/BenchmarkCommandPlugin/ArgumentExtractor+Extensions.swift
+++ b/Plugins/BenchmarkCommandPlugin/ArgumentExtractor+Extensions.swift
@@ -33,8 +33,8 @@ extension ArgumentExtractor {
         var anyMatching = false
 
         try package.targets.forEach { target in
-            let path = target.directory.removingLastComponent()
-            if path.lastComponent == "Benchmarks" {
+            let path = target.directoryURL.deletingLastPathComponent()
+            if path.lastPathComponent == "Benchmarks" {
                 for specifiedTarget in specifiedTargets {
                     let regex = try Regex(specifiedTarget)
 

--- a/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
+++ b/Plugins/BenchmarkCommandPlugin/BenchmarkCommandPlugin.swift
@@ -11,6 +11,7 @@
 // 'Benchmark' plugin that is responsible for gathering command line arguments and then
 // Running the `BenchmarkTool` for each benchmark target.
 
+import Foundation
 import PackagePlugin
 
 #if canImport(Darwin)
@@ -151,12 +152,12 @@ import PackagePlugin
 
         let packageBenchmarkIdentifier = "package-benchmark"
         let benchmarkToolName = "BenchmarkTool"
-        let benchmarkTool: PackagePlugin.Path // = try context.tool(named: benchmarkToolName)
+        let benchmarkTool: URL // = try context.tool(named: benchmarkToolName)
 
         var args: [String] = [
             benchmarkToolName,
             "--command", commandToPerform.rawValue,
-            "--baseline-storage-path", context.package.directory.string,
+            "--baseline-storage-path", context.package.directoryURL.path(),
             "--format", outputFormat.rawValue,
             "--grouping", grouping,
         ]
@@ -396,21 +397,21 @@ import PackagePlugin
         }
 
         let tool = buildResult.builtArtifacts.first(where: {
-            $0.kind == .executable && $0.path.lastComponent == benchmarkToolName
+            $0.kind == .executable && $0.url.lastPathComponent == benchmarkToolName
         })
 
         guard let tool else {
             throw MyError.buildFailed
         }
 
-        benchmarkTool = tool.path
+        benchmarkTool = tool.url
 
         let filteredTargets =
             swiftSourceModuleTargets
             .filter { $0.kind == .executable }
             .filter { benchmark in
-                let path = benchmark.directory.removingLastComponent()
-                return path.lastComponent == "Benchmarks" ? true : false
+                let path = benchmark.directoryURL.deletingLastPathComponent()
+                return path.lastPathComponent == "Benchmarks" ? true : false
             }
             .filter { benchmark in
                 swiftSourceModuleTargets.first(where: { $0.name == benchmark.name }) != nil ? true : false
@@ -459,7 +460,7 @@ import PackagePlugin
                 // Filter out all executable products which are Benchmarks we should run
                 let benchmarks = buildResult.builtArtifacts
                     .filter { benchmark in
-                        filteredTargets.first(where: { $0.name == benchmark.path.lastComponent }) != nil ? true : false
+                        filteredTargets.first(where: { $0.name == benchmark.url.lastPathComponent }) != nil ? true : false
                     }
 
                 if benchmarks.isEmpty {
@@ -467,7 +468,7 @@ import PackagePlugin
                 }
 
                 benchmarks.forEach { benchmark in
-                    args.append(contentsOf: ["--benchmark-executable-paths", benchmark.path.string])
+                    args.append(contentsOf: ["--benchmark-executable-paths", benchmark.url.path()])
                 }
             }
         }
@@ -477,7 +478,7 @@ import PackagePlugin
         try withCStrings(args) { cArgs in
             if debug > 0 {
                 print("To debug, start \(benchmarkToolName) in LLDB using:")
-                print("lldb \(benchmarkTool.string)")
+                print("lldb \(benchmarkTool.path())")
                 print("")
                 print("Then launch \(benchmarkToolName) with:")
                 print("run \(args.dropFirst().joined(separator: " "))")
@@ -486,7 +487,7 @@ import PackagePlugin
             }
 
             var pid: pid_t = 0
-            var status = posix_spawn(&pid, benchmarkTool.string, nil, nil, cArgs, environ)
+            var status = posix_spawn(&pid, benchmarkTool.path(), nil, nil, cArgs, environ)
 
             if status == 0 {
                 if waitpid(pid, &status, 0) != -1 {

--- a/Plugins/BenchmarkPlugin/BenchmarkSupportPlugin.swift
+++ b/Plugins/BenchmarkPlugin/BenchmarkSupportPlugin.swift
@@ -1,3 +1,4 @@
+import Foundation
 import PackagePlugin
 
 @main
@@ -9,23 +10,23 @@ struct PluginFactory: BuildToolPlugin {
     {
         guard let target = target as? SwiftSourceModuleTarget else { return [] }
         guard target.kind == .executable else { return [] }
-        let path = target.directory.removingLastComponent()
-        guard path.lastComponent == "Benchmarks" else { return [] }
+        let path = target.directoryURL.deletingLastPathComponent()
+        guard path.lastPathComponent == "Benchmarks" else { return [] }
 
         let tool = try context.tool(named: "BenchmarkBoilerplateGenerator")
-        let outputDirectory = context.pluginWorkDirectory
-        let swiftFile = outputDirectory.appending("__BenchmarkBoilerplate.swift")
-        let inputFiles = target.sourceFiles.filter { $0.path.extension == "swift" }.map(\.path)
-        let outputFiles: [Path] = [swiftFile]
+        let outputDirectory = context.pluginWorkDirectoryURL
+        let swiftFile = outputDirectory.appending(path: "__BenchmarkBoilerplate.swift")
+        let inputFiles = target.sourceFiles.filter { $0.url.pathExtension == "swift" }.map(\.url)
+        let outputFiles: [URL] = [swiftFile]
 
         let commandArgs: [String] = [
             "--target", target.name,
-            "--output", swiftFile.string,
+            "--output", swiftFile.path(),
         ]
 
         let command: Command = .buildCommand(
             displayName: "Generating plugin support files",
-            executable: tool.path,
+            executable: tool.url,
             arguments: commandArgs,
             inputFiles: inputFiles,
             outputFiles: outputFiles


### PR DESCRIPTION
## Summary
- Migrate all three SwiftPM plugin files from the deprecated `Path`-based APIs to the new `URL`-based equivalents (`directoryURL`, `pluginWorkDirectoryURL`, `url`, `lastPathComponent`, `path()`, etc.)
- Eliminates ~30 deprecation warnings emitted during plugin compilation

## Test plan
- [x] Clean build (`swift build -c release`) passes with zero plugin warnings
- [ ] Run benchmarks to verify plugin behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)