### PR TITLE
docs: document scalingFactor timer resolution and memory growth pitfalls

### DIFF
--- a/Sources/Benchmark/Documentation.docc/WritingBenchmarks.md
+++ b/Sources/Benchmark/Documentation.docc/WritingBenchmarks.md
@@ -158,14 +158,14 @@ reported values will cluster around quantized steps (e.g. 42, 83, 125 ns) rather
 than reflecting real differences between benchmarks.
 
 Setting a higher `scalingFactor` (e.g. `.kilo`) amortizes this overhead: the
-framework runs 1,000 inner iterations per sample, divides the measured time by
-1,000, and reports the per-operation result. This gives sub-nanosecond effective
+benchmark closure performs 1,000 inner iterations per sample, the framework
+divides the measured time by 1,000, and reports the per-operation result. This gives sub-nanosecond effective
 resolution while keeping the timer overhead negligible.
 
 **Choosing a value:** pick the smallest factor that makes timer overhead
 insignificant relative to the operation under test. `.kilo` is a good default for
-operations in the 1–500 ns range; `.mega` suits sub-nanosecond work like
-`Date()` creation.
+operations in the 1–500 ns range; `.mega` suits even faster operations or
+cases where extreme precision is desired, such as `Date()` creation.
 
 #### Stateful benchmarks and memory growth
 
@@ -176,8 +176,8 @@ benchmark run. For example, `.kilo` with the default `maxIterations` of 10,000
 means 10 million total mutations — enough to exhaust memory if each mutation adds
 data.
 
-To avoid this, either cap `maxIterations` for mutation benchmarks, or periodically
-reset the state inside the closure:
+To avoid this, you can cap `maxIterations` to limit total growth, or (preferably)
+periodically reset the state inside the closure to ensure consistent measurements:
 
 ```swift
 let box = MyMutableBox(initialData)

--- a/Sources/Benchmark/Documentation.docc/WritingBenchmarks.md
+++ b/Sources/Benchmark/Documentation.docc/WritingBenchmarks.md
@@ -148,6 +148,59 @@ Benchmark("Foundation Date()", configuration: .init(scalingFactor: .mega)) { ben
 }
 ```
 
+#### When to use scalingFactor
+
+On Apple Silicon, `clock_gettime_nsec_np(CLOCK_UPTIME_RAW)` has a resolution of
+approximately 41.67 ns (24 MHz). With the default `scalingFactor` of `.one`, each
+sample measures a single execution of the closure. For operations faster than
+roughly 100 ns, the wall-clock measurement is dominated by timer granularity —
+reported values will cluster around quantized steps (e.g. 42, 83, 125 ns) rather
+than reflecting real differences between benchmarks.
+
+Setting a higher `scalingFactor` (e.g. `.kilo`) amortizes this overhead: the
+framework runs 1,000 inner iterations per sample, divides the measured time by
+1,000, and reports the per-operation result. This gives sub-nanosecond effective
+resolution while keeping the timer overhead negligible.
+
+**Choosing a value:** pick the smallest factor that makes timer overhead
+insignificant relative to the operation under test. `.kilo` is a good default for
+operations in the 1–500 ns range; `.mega` suits sub-nanosecond work like
+`Date()` creation.
+
+#### Stateful benchmarks and memory growth
+
+When a benchmark mutates shared state (e.g. inserting into a collection) and uses
+a `scalingFactor` higher than `.one`, each sample performs many mutations. Because
+the state persists across samples, it can grow without bound over the course of a
+benchmark run. For example, `.kilo` with the default `maxIterations` of 10,000
+means 10 million total mutations — enough to exhaust memory if each mutation adds
+data.
+
+To avoid this, either cap `maxIterations` for mutation benchmarks, or periodically
+reset the state inside the closure:
+
+```swift
+let box = MyMutableBox(initialData)
+
+// Option 1: limit the number of samples
+Benchmark("insert",
+          configuration: .init(scalingFactor: .kilo, maxIterations: 200)) { benchmark in
+    for _ in benchmark.scaledIterations {
+        box.collection.insert(element)
+    }
+}
+
+// Option 2: use startMeasurement() to exclude periodic resets
+Benchmark("insert",
+          configuration: .init(scalingFactor: .kilo)) { benchmark in
+    box.collection = initialData  // reset — not measured
+    benchmark.startMeasurement()
+    for _ in benchmark.scaledIterations {
+        box.collection.insert(element)
+    }
+}
+```
+
 ### Metrics
 
 Benchmark supports a wide range of measurements defined by ``BenchmarkMetric``.


### PR DESCRIPTION
## Description

Add guidance under the scalingFactor section for two common issues:

- Timer granularity on Apple Silicon (~41.67 ns at 24 MHz) makes sub-100 ns benchmarks unreliable without an inner loop. Recommend .kilo for 1–500 ns operations and .mega for sub-nanosecond work.

- Stateful mutation benchmarks with high scalingFactor can exhaust memory (e.g. .kilo × 10K iterations = 10M mutations). Show two mitigation patterns: capping maxIterations and using startMeasurement() to exclude periodic resets.

## How Has This Been Tested?

Documentation-only change. Verified DocC renders correctly locally.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
