### PR TITLE
fix(minor): file descriptor leaks

### DIFF
--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -397,9 +397,9 @@ struct BenchmarkTool: AsyncParsableCommand {
         try withCStrings(args) { cArgs in
             var status = posix_spawn(&pid, path.string, nil, nil, cArgs, environ)
 
-            // Close child ends of the pipes
-            try toChild.readEnd.close()
-            try fromChild.writeEnd.close()
+            // Close child ends of the pipes (independently, so a failure closing one still closes the other)
+            try? toChild.readEnd.close()
+            try? fromChild.writeEnd.close()
 
             do {
                 switch benchmarkCommand {

--- a/Plugins/BenchmarkTool/BenchmarkTool.swift
+++ b/Plugins/BenchmarkTool/BenchmarkTool.swift
@@ -375,6 +375,15 @@ struct BenchmarkTool: AsyncParsableCommand {
         var benchmarkResults: BenchmarkResults = [:]
         let fromChild = try FileDescriptor.pipe()
         let toChild = try FileDescriptor.pipe()
+
+        // Close the parent-side ends of the pipes whenever we return, regardless of how we exit, so we don't
+        // leak two file descriptors for every benchmark we run. (The child-side ends are closed separately,
+        // right after spawning, so the parent's reads see EOF when the child exits.)
+        defer {
+            try? toChild.writeEnd.close()
+            try? fromChild.readEnd.close()
+        }
+
         let path = FilePath(benchmarkPath)
         var args: [String] = [
             path.lastComponent!.description,


### PR DESCRIPTION
## Description

That parent process was leaking two file descriptors for every benchmark subprocess it spawned, and in some cases the child processes weren't closing one of their file descriptors either (if `toChild.writeEnd.close()` failed with an exception, it'd derail execution before `fromChild.readEnd.close()` was called).

## How Has This Been Tested?

Ran a benchmark suite with ~20k benchmarks.  Previously this would die about 15% of the way through (because of the default 2,560 file descriptor soft limit under Terminal.app).  Now it completes successfully.

## Minimal checklist:

- ✅ I have performed a self-review of my own code 
- N/A ~I have added `DocC` code-level documentation for any public interfaces exported by the package~
- ❌ I have added unit and/or integration tests that prove my fix is effective or that my feature works

I'm not sure how best to unit test this - I welcome suggestions.
